### PR TITLE
Add simple concurrency tools

### DIFF
--- a/pkg/helpers/concurrency.go
+++ b/pkg/helpers/concurrency.go
@@ -1,0 +1,24 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+)
+
+func CancelOnSignal(ctx context.Context, signal_ os.Signal, cancel func()) error {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, signal_)
+	defer signal.Stop(sigCh)
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-sigCh:
+		fmt.Println("Received Ctrl+C, canceling context")
+		cancel()
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds a few concurrency tools useful for CLI applications.

One of them is to cancel a context on CTRL-C (or other signals).

One is to merge multiple channels into a single one.
