### PR TITLE
Refactor embed/dir FS handling to be a single function

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     main: ./cmd/glaze
-    binary: program
+    binary: glaze
     goos:
       - linux
 # I am not able to test windows at the time

--- a/cmd/glaze/main.go
+++ b/cmd/glaze/main.go
@@ -21,7 +21,7 @@ var docFS embed.FS
 
 func init() {
 	helpSystem := help.NewHelpSystem()
-	err := helpSystem.LoadSectionsFromEmbedFS(docFS, ".")
+	err := helpSystem.LoadSectionsFromFS(docFS, ".")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cmds/alias.go
+++ b/pkg/cmds/alias.go
@@ -54,15 +54,19 @@ func (a *CommandAlias) Description() *CommandDescription {
 	for _, argument := range s.Arguments {
 		newArgument := argument.Copy()
 
-		// TODO(2022-12-22, manuel) this needs to be handled, overriding arguments and figuring out which order
-		// is a bitch
-		//
 		// NOTE(2023-02-07, manuel) I don't fully understand what this is referring to anymore,
 		// but I remember struggling with this in the context of setting and overriding default values.
 		// Say, if an alias defines --fields id,name and then the user passes in --fields foo,bla
 		// on top, I remember there being some kind of conflict.
 		//
+		// See also the note in cobra.go about checking the argument count. This might all
+		// refer to overloading arguments, and not just flags. This seems to make sense given the
+		// talk about argument counts.
+		//
 		// ---
+		//
+		// TODO(2022-12-22, manuel) this needs to be handled, overriding arguments and figuring out which order
+		// is a bitch
 		//
 		// so iN command.go in cobra, prerun is run before the arg validation is done
 		// so that we could potentially override the args here

--- a/pkg/cmds/alias.go
+++ b/pkg/cmds/alias.go
@@ -5,6 +5,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// CommandAlias defines a struct that should be able to define generic aliases
+// for any kind of command line applications, by providing overrides for certain
+// flags (prepopulating them with certain flags and arguments, basically)
 type CommandAlias struct {
 	Name      string            `yaml:"name"`
 	AliasFor  string            `yaml:"aliasFor"`
@@ -27,44 +30,11 @@ func (a *CommandAlias) IsValid() bool {
 	return a.Name != "" && a.AliasFor != ""
 }
 
-// TODO(2022-12-22, manuel) this is actually not enough, because we want aliases to also deal with
-// any kind of default value. So this is a good first approach, but not sufficient...
-//
-// So what we want to do is to load all the flags and arguments from the alias file
-// and then merge them with the flags and arguments that the user passes on the command line?
-//
-// I'm going to take a look at the implementation of ParseFlags() in cobra. One reason
-// that we need a bit more is because we don't want to use the default value from the aliased commands
-// in case our flags provide something. Maybe cobra allows us to set the flag values?
-//
-// So there is a Set(name,value string) method on the FlagSet. We could use that to set the values
-// as a string, but since we already have them parsed out, that's a bit crude maybe (?)
-//
-// While readin the code I came across the Flag struct which has the following members, maybe there is
-// something useful i can think of while looking through it (plus, remember we wanted to tackle
-// proper flag groups).
-//
-// The flag has something called a Value which is of type Value as well.
-// The DefValue is just a string, used for the usage message.
-// The Changed value specifies if the user overrode the value (this could maybe be useful for
-//     us too because that's what we want to output in the alias file)
-// Deprecated is cool
-// I'm not sure what NoOptDefVal is for, it's the default value if the flag is specified without any option on the command line
-//   so maybe that's a way to give something you can toggle a different default value
-// Annotations is something used by the autocomplete code, which I haven't looked into yet at all
-//
-// Value is an interface that you can Set from a string, that returns its type, and that you can also
-// serialize to a string.
-//
-// If I look at how this is no concretely implement, for example by looking at the GetString() method,
-// we can see that we first  get the flag type with `getFlagType`, which interestingly returns an interface
-// and takes a conversion function. This first looks up the flag in the flag set, checks that its type
-// matches, then gets its string value, and calls the conversion function.
-// So maybe it's the best for us to also transform everything into a string and just call Set on the flag if
-// it has not been set yet?
-//
-// Let's first start by outputting all the set flags when create-alias is passed.
-
+// Description returns the CommandDescription of an alias.
+// It computes it at runtime by loading the aliased command's Description() and
+// making copies of its flags and arguments.
+// This is necessary because they get mutated at runtime with various defaults,
+// depending on where they come from.
 func (a *CommandAlias) Description() *CommandDescription {
 	s := a.AliasedCommand.Description()
 	ret := &CommandDescription{
@@ -77,14 +47,22 @@ func (a *CommandAlias) Description() *CommandDescription {
 
 	for _, flag := range s.Flags {
 		newFlag := flag.Copy()
-		//newFlag.Required = false
+		// newFlag.Required = false
 		ret.Flags = append(ret.Flags, newFlag)
 	}
 
 	for _, argument := range s.Arguments {
 		newArgument := argument.Copy()
+
 		// TODO(2022-12-22, manuel) this needs to be handled, overriding arguments and figuring out which order
 		// is a bitch
+		//
+		// NOTE(2023-02-07, manuel) I don't fully understand what this is referring to anymore,
+		// but I remember struggling with this in the context of setting and overriding default values.
+		// Say, if an alias defines --fields id,name and then the user passes in --fields foo,bla
+		// on top, I remember there being some kind of conflict.
+		//
+		// ---
 		//
 		// so iN command.go in cobra, prerun is run before the arg validation is done
 		// so that we could potentially override the args here
@@ -101,10 +79,10 @@ func (a *CommandAlias) Description() *CommandDescription {
 		// by doing our own little scanning, which is probably useful anyway if done in glazed
 		// so that we can handle different types of arg parsing.
 		//
-		//if defaultValue, ok := a.ArgumentDefaults[argument.Name]; ok {
+		// if defaultValue, ok := a.ArgumentDefaults[argument.Name]; ok {
 		//	newArgument.Default = defaultValue
-		//}
-		//newArgument.Required = false
+		// }
+		// newArgument.Required = false
 		ret.Arguments = append(ret.Arguments, newArgument)
 	}
 

--- a/pkg/cmds/cobra.go
+++ b/pkg/cmds/cobra.go
@@ -13,6 +13,10 @@ import (
 	"time"
 )
 
+// CobraCommand is a subset of Command than can be registered as a
+// cobra.Command by using BuildCobraCommand, and can then be executed
+// when cobra runs it through RunFromCobra, passing in the full cobra object
+// in case the user wants to overload anything.
 type CobraCommand interface {
 	Command
 	RunFromCobra(cmd *cobra.Command, args []string) error
@@ -436,8 +440,6 @@ func findOrCreateParentCommand(rootCmd *cobra.Command, parents []string) *cobra.
 	for _, parent := range parents {
 		subCmd, _, _ := parentCmd.Find([]string{parent})
 		if subCmd == nil || subCmd == parentCmd {
-			// TODO(2022-12-19) Load documentation for subcommands from a readme file
-			// See https://github.com/wesen/sqleton/issues/34
 			newParentCmd := &cobra.Command{
 				Use:   parent,
 				Short: fmt.Sprintf("All commands for %s", parent),
@@ -451,7 +453,6 @@ func findOrCreateParentCommand(rootCmd *cobra.Command, parents []string) *cobra.
 	return parentCmd
 }
 
-// XXX(manuel, 2023-01-25) Figure out how to refactor parents/aliases
 func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []CobraCommand, aliases []*CommandAlias) error {
 	commandsByName := map[string]Command{}
 
@@ -496,8 +497,12 @@ func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []CobraCommand, a
 					cobra.CheckErr(err)
 				}
 			}
+
 			// TODO(2022-12-22, manuel) This is not right because the args count is checked earlier, but when,
 			// and how can i override it
+			//
+			// NOTE(2023-02-07, manuel) I think the above refers to the fact that an alias
+			// should be able to override arguments.
 			if len(args) == 0 {
 				args = alias2.Arguments
 			}

--- a/pkg/cmds/doc.go
+++ b/pkg/cmds/doc.go
@@ -1,0 +1,25 @@
+package cmds
+
+// The commands part of glazed contains multiple things:
+//
+// # Describe command line applications declaratively
+//
+// - structs to describe flags and arguments for commands
+// - helper functions to register these structs as commands with cobra
+//
+// Because these applications are domain specific, they usually need to be overloaded
+// and this is where the current messy situation is starting.
+//
+// Currently, sqleton, escuse-me and pinocchio benefit from loading applications
+// declaratively. In addition to flags and arguments, they need to load:
+//
+// - a SQL query template, in sqleton's case
+// - a ElasticSearch query template, in escuse-me's case
+// - a complex array of steps and factory settings, in pinocchio's case
+//
+// Currently, all 3 applications use a single YAML file to store commands.
+//
+// # Create aliases for command line applications
+//
+// - a generic CommandAlias struct that should be possible to use by
+//   any kind of command line application.

--- a/pkg/cmds/doc.go
+++ b/pkg/cmds/doc.go
@@ -23,3 +23,13 @@ package cmds
 //
 // - a generic CommandAlias struct that should be possible to use by
 //   any kind of command line application.
+//
+// # Load commands and aliases from disk and register with cobra
+//
+// If an application implements CommandLoader, glazed provides helper
+// functions to load all commands and applications from a directory
+// containing YAML files, by giving the application control over how
+// these YAML files are parsed.
+//
+// This part probably will be refactored soon
+// See https://github.com/go-go-golems/glazed/issues/117


### PR DESCRIPTION
We used to have an embedFS and a separate Dir implementation,
mostly out of ignorance. 

They are now unified for both HelpSections and Commands loading.

Breaks existing APIs.

```
 _______  _______    _______  _______    _______  _______ 
|       ||       |  |       ||       |  |       ||       |
|    ___||   _   |  |    ___||   _   |  |    ___||   _   |
|   | __ |  | |  |  |   | __ |  | |  |  |   | __ |  | |  |
|   ||  ||  |_|  |  |   ||  ||  |_|  |  |   ||  ||  |_|  |
|   |_| ||       |  |   |_| ||       |  |   |_| ||       |
|_______||_______|  |_______||_______|  |_______||_______|
 _______  _______  __   __  __   __  _______  __    _  ______   _______ 
|       ||       ||  |_|  ||  |_|  ||   _   ||  |  | ||      | |       |
|       ||   _   ||       ||       ||  |_|  ||   |_| ||  _    ||  _____|
|       ||  | |  ||       ||       ||       ||       || | |   || |_____ 
|      _||  |_|  ||       ||       ||       ||  _    || |_|   ||_____  |
|     |_ |       || ||_|| || ||_|| ||   _   || | |   ||       | _____| |
|_______||_______||_|   |_||_|   |_||__| |__||_|  |__||______| |_______|

```

- :art: Use proper name for binary when building with goreleaser
- :recycle: Remove the need for special embed.FS method for loading help pages
- :recycle: Refactor to load commands from FS using a single function
- :memo: Add some docs about the commands part of glazed
- :memo: Add some more notes about the state of commands loading in glazed
