### PR TITLE
:ambulance: Fix aliases

### DIFF
--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -41,20 +41,20 @@ func NewOutputFlagsDefaults() *OutputFlagsDefaults {
 }
 
 func AddOutputFlags(cmd *cobra.Command, defaults *OutputFlagsDefaults) {
-	cmd.Flags().StringP("output", "o", defaults.Output, "Output format (table, csv, tsv, json, yaml, sqlite, template)")
-	cmd.Flags().StringP("output-file", "f", defaults.OutputFile, "Output file")
-	cmd.Flags().String("template-file", defaults.TemplateFile, "Template file for template output")
-	cmd.Flags().StringSlice("template-data", []string{}, "Additional data for template output")
+	cmd.PersistentFlags().StringP("output", "o", defaults.Output, "Output format (table, csv, tsv, json, yaml, sqlite, template)")
+	cmd.PersistentFlags().StringP("output-file", "f", defaults.OutputFile, "Output file")
+	cmd.PersistentFlags().String("template-file", defaults.TemplateFile, "Template file for template output")
+	cmd.PersistentFlags().StringSlice("template-data", []string{}, "Additional data for template output")
 
-	cmd.Flags().String("table-format", defaults.TableFormat, "Table format (ascii, markdown, html, csv, tsv)")
-	cmd.Flags().Bool("with-headers", defaults.WithHeaders, "Include headers in output (CSV, TSV)")
-	cmd.Flags().String("csv-separator", defaults.CsvSeparator, "CSV separator")
+	cmd.PersistentFlags().String("table-format", defaults.TableFormat, "Table format (ascii, markdown, html, csv, tsv)")
+	cmd.PersistentFlags().Bool("with-headers", defaults.WithHeaders, "Include headers in output (CSV, TSV)")
+	cmd.PersistentFlags().String("csv-separator", defaults.CsvSeparator, "CSV separator")
 
 	// json output flags
-	cmd.Flags().Bool("output-as-objects", defaults.OutputAsObjects, "Output as individual objects instead of JSON array")
+	cmd.PersistentFlags().Bool("output-as-objects", defaults.OutputAsObjects, "Output as individual objects instead of JSON array")
 
 	// output processing
-	cmd.Flags().Bool("flatten", defaults.Flatten, "Flatten nested fields (after templating)")
+	cmd.PersistentFlags().Bool("flatten", defaults.Flatten, "Flatten nested fields (after templating)")
 }
 
 func ParseOutputFlags(cmd *cobra.Command) (*OutputFormatterSettings, error) {
@@ -117,8 +117,8 @@ func NewSelectFlagsDefaults() *SelectFlagsDefaults {
 }
 
 func AddSelectFlags(cmd *cobra.Command, defaults *SelectFlagsDefaults) {
-	cmd.Flags().String("select", defaults.Select, "Select a single field and output as a single line")
-	cmd.Flags().String("select-template", defaults.SelectTemplate, "Output a single templated value for each row, on a single line")
+	cmd.PersistentFlags().String("select", defaults.Select, "Select a single field and output as a single line")
+	cmd.PersistentFlags().String("select-template", defaults.SelectTemplate, "Output a single templated value for each row, on a single line")
 }
 
 func ParseSelectFlags(cmd *cobra.Command) (*SelectSettings, error) {
@@ -143,7 +143,7 @@ func NewReplaceFlagsDefaults() *ReplaceFlagsDefaults {
 }
 
 func AddReplaceFlags(cmd *cobra.Command, defaults *ReplaceFlagsDefaults) {
-	cmd.Flags().String("replace-file", defaults.ReplaceFile, "File with replacements")
+	cmd.PersistentFlags().String("replace-file", defaults.ReplaceFile, "File with replacements")
 }
 
 func ParseReplaceFlags(cmd *cobra.Command) (*ReplaceSettings, error) {
@@ -169,9 +169,9 @@ func NewRenameFlagsDefaults() *RenameFlagsDefaults {
 }
 
 func AddRenameFlags(cmd *cobra.Command, defaults *RenameFlagsDefaults) {
-	cmd.Flags().StringSlice("rename", defaults.Rename, "Rename fields (list of oldName:newName)")
-	cmd.Flags().StringSlice("rename-regexp", defaults.RenameRegexp, "Rename fields using regular expressions (list of regex:newName)")
-	cmd.Flags().String("rename-yaml", defaults.RenameYaml, "Rename fields using a yaml file")
+	cmd.PersistentFlags().StringSlice("rename", defaults.Rename, "Rename fields (list of oldName:newName)")
+	cmd.PersistentFlags().StringSlice("rename-regexp", defaults.RenameRegexp, "Rename fields using regular expressions (list of regex:newName)")
+	cmd.PersistentFlags().String("rename-yaml", defaults.RenameYaml, "Rename fields using a yaml file")
 }
 
 func ParseRenameFlags(cmd *cobra.Command) (*RenameSettings, error) {
@@ -224,9 +224,9 @@ func NewTemplateFlagsDefaults() *TemplateFlagsDefaults {
 }
 
 func AddTemplateFlags(cmd *cobra.Command, defaults *TemplateFlagsDefaults) {
-	cmd.Flags().String("template", defaults.Template, "Go Template to use for single string")
-	cmd.Flags().StringSlice("template-field", defaults.TemplateField, "For table output, fieldName:template to create new fields, or @fileName to read field templates from a yaml dictionary")
-	cmd.Flags().Bool("use-row-templates", defaults.UseRowTemplates, "Use row templates instead of column templates")
+	cmd.PersistentFlags().String("template", defaults.Template, "Go Template to use for single string")
+	cmd.PersistentFlags().StringSlice("template-field", defaults.TemplateField, "For table output, fieldName:template to create new fields, or @fileName to read field templates from a yaml dictionary")
+	cmd.PersistentFlags().Bool("use-row-templates", defaults.UseRowTemplates, "Use row templates instead of column templates")
 }
 
 func ParseTemplateFlags(cmd *cobra.Command) (*TemplateSettings, error) {
@@ -287,9 +287,9 @@ func AddFieldsFilterFlags(cmd *cobra.Command, defaults *FieldsFilterFlagsDefault
 	if defaultFieldHelp == "" {
 		defaultFieldHelp = "all"
 	}
-	cmd.Flags().String("fields", defaults.Fields, "Fields to include in the output, default: "+defaultFieldHelp)
-	cmd.Flags().String("filter", defaults.Filter, "Fields to remove from output")
-	cmd.Flags().Bool("sort-columns", defaults.SortColumns, "Sort columns alphabetically")
+	cmd.PersistentFlags().String("fields", defaults.Fields, "Fields to include in the output, default: "+defaultFieldHelp)
+	cmd.PersistentFlags().String("filter", defaults.Filter, "Fields to remove from output")
+	cmd.PersistentFlags().Bool("sort-columns", defaults.SortColumns, "Sort columns alphabetically")
 }
 
 func ParseFieldsFilterFlags(cmd *cobra.Command) (*FieldsFilterSettings, error) {

--- a/pkg/cmds/alias.go
+++ b/pkg/cmds/alias.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,11 @@ type CommandAlias struct {
 	AliasedCommand Command  `yaml:",omitempty"`
 	Parents        []string `yaml:",omitempty"`
 	Source         string   `yaml:",omitempty"`
+}
+
+func (a *CommandAlias) String() string {
+	return fmt.Sprintf("CommandAlias{Name: %s, AliasFor: %s, Parents: %v, Source: %s}",
+		a.Name, a.AliasFor, a.Parents, a.Source)
 }
 
 func (a *CommandAlias) Run(parameters map[string]interface{}) error {

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -445,7 +445,7 @@ func (l *YAMLFSCommandLoader) LoadCommandsFromFS(f fs.FS, dir string) ([]Command
 					log.Debug().Str("file", fileName).Msg("Loading command from file")
 					commands, err := l.loader.LoadCommandFromYAML(file)
 					if err != nil {
-						return nil, errors.Wrapf(err, "Could not load command from file %s", fileName)
+						return nil, err
 					}
 					if len(commands) != 1 {
 						return nil, errors.New("Expected exactly one command")


### PR DESCRIPTION
The refactor moving commands and aliases into glazed broke aliases for two reasons:

- the yaml parse error that was the signal for parsing a yaml file as an alias was broken because of wrapping the parse error
- glazed flags that were previously set for every alias in sqleton were now missing the glazed flatgs

The glazed helper flags are now set as PersistentFlags(), but considering the refactor of the entire
declarative flags sections, it will make more sense to add the glazed flags to the declarative flags
of the commands themselves, and thus register them properly. 

This might happen in a second step of the declarative flag refactor, however.

See also: https://github.com/go-go-golems/glazed/issues/136

- :art: Fix broken aliases
- :art: Register glazed commands as persistentflags so that aliases benefit from it
