### PR TITLE
:sparkles: Move to an options based way of configuring glaze parameter layer

### DIFF
--- a/cmd/glaze/cmds/docs.go
+++ b/cmd/glaze/cmds/docs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/adrg/frontmatter"
 	"github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -42,33 +43,28 @@ var DocsCmd = &cobra.Command{
 func init() {
 	DocsCmd.Flags().SortFlags = false
 	// This is an example of selective use of glazed parameter layers.
-	// If we extracted out the docts command into a cmds.Command, which we should
+	// If we extracted out the docs command into a cmds.Command, which we should
 	// in order to expose it as a REST API, all of this would not even be necessary,
 	// I think.
-	gpl, err := cli.NewGlazedParameterLayers()
-	if err != nil {
-		panic(err)
-	}
-
-	// TODO(2023-02-12, manuel) Overload settings could be loaded from YAML too
-	//
-	// See https://github.com/go-go-golems/glazed/issues/133
-	defaults := &cli.FieldsFilterFlagsDefaults{
-		Fields: []string{
-			"path",
-			"Title",
-			"SectionType",
-			"Slug",
-			"Commands",
-			"Flags",
-			"Topics",
-			"IsTopLevel",
-			"ShowPerDefault",
-		},
-		Filter:      []string{},
-		SortColumns: false,
-	}
-	err = gpl.FieldsFiltersParameterLayer.InitializeParameterDefaultsFromStruct(defaults)
+	gpl, err := cli.NewGlazedParameterLayers(
+		cli.WithFieldsFiltersParameterLayerOptions(
+			layers.WithDefaults(
+				&cli.FieldsFilterFlagsDefaults{
+					Fields: []string{
+						"path",
+						"Title",
+						"SectionType",
+						"Slug",
+						"Commands",
+						"Flags",
+						"Topics",
+						"IsTopLevel",
+						"ShowPerDefault",
+					},
+				},
+			),
+		),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cli/glazed_layer.go
+++ b/pkg/cli/glazed_layer.go
@@ -172,39 +172,122 @@ func (g *GlazedParameterLayers) InitializeParameterDefaultsFromStruct(s interfac
 	return nil
 }
 
-func NewGlazedParameterLayers(options ...layers.ParameterLayerOptions) (*GlazedParameterLayers, error) {
-	fieldsFiltersParameterLayer, err := NewFieldsFiltersParameterLayer(options...)
+type GlazeParameterLayerOption func(*GlazedParameterLayers) error
+
+func WithOutputParameterLayerOptions(options ...layers.ParameterLayerOptions) GlazeParameterLayerOption {
+	return func(g *GlazedParameterLayers) error {
+		for _, option := range options {
+			err := option(g.OutputParameterLayer.ParameterLayerImpl)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func WithSelectParameterLayerOptions(options ...layers.ParameterLayerOptions) GlazeParameterLayerOption {
+	return func(g *GlazedParameterLayers) error {
+		for _, option := range options {
+			err := option(g.SelectParameterLayer.ParameterLayerImpl)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func WithTemplateParameterLayerOptions(options ...layers.ParameterLayerOptions) GlazeParameterLayerOption {
+	return func(g *GlazedParameterLayers) error {
+		for _, option := range options {
+			err := option(g.TemplateParameterLayer.ParameterLayerImpl)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func WithRenameParameterLayerOptions(options ...layers.ParameterLayerOptions) GlazeParameterLayerOption {
+	return func(g *GlazedParameterLayers) error {
+		for _, option := range options {
+			err := option(g.RenameParameterLayer.ParameterLayerImpl)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func WithReplaceParameterLayerOptions(options ...layers.ParameterLayerOptions) GlazeParameterLayerOption {
+	return func(g *GlazedParameterLayers) error {
+		for _, option := range options {
+			err := option(g.ReplaceParameterLayer.ParameterLayerImpl)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func WithFieldsFiltersParameterLayerOptions(options ...layers.ParameterLayerOptions) GlazeParameterLayerOption {
+	return func(g *GlazedParameterLayers) error {
+		for _, option := range options {
+			err := option(g.FieldsFiltersParameterLayer.ParameterLayerImpl)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func NewGlazedParameterLayers(options ...GlazeParameterLayerOption) (*GlazedParameterLayers, error) {
+	fieldsFiltersParameterLayer, err := NewFieldsFiltersParameterLayer()
 	if err != nil {
 		return nil, err
 	}
-	outputParameterLayer, err := NewOutputParameterLayer(options...)
+	outputParameterLayer, err := NewOutputParameterLayer()
 	if err != nil {
 		return nil, err
 	}
-	renameParameterLayer, err := NewRenameParameterLayer(options...)
+	renameParameterLayer, err := NewRenameParameterLayer()
 	if err != nil {
 		return nil, err
 	}
-	replaceParameterLayer, err := NewReplaceParameterLayer(options...)
+	replaceParameterLayer, err := NewReplaceParameterLayer()
 	if err != nil {
 		return nil, err
 	}
-	selectParameterLayer, err := NewSelectParameterLayer(options...)
+	selectParameterLayer, err := NewSelectParameterLayer()
 	if err != nil {
 		return nil, err
 	}
-	templateParameterLayer, err := NewTemplateParameterLayer(options...)
+	templateParameterLayer, err := NewTemplateParameterLayer()
 	if err != nil {
 		return nil, err
 	}
-	return &GlazedParameterLayers{
+	ret := &GlazedParameterLayers{
 		FieldsFiltersParameterLayer: fieldsFiltersParameterLayer,
 		OutputParameterLayer:        outputParameterLayer,
 		RenameParameterLayer:        renameParameterLayer,
 		ReplaceParameterLayer:       replaceParameterLayer,
 		SelectParameterLayer:        selectParameterLayer,
 		TemplateParameterLayer:      templateParameterLayer,
-	}, nil
+	}
+
+	for _, option := range options {
+		err := option(ret)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ret, nil
 }
 
 func SetupProcessor(ps map[string]interface{}) (

--- a/pkg/cli/settings_fields-filters.go
+++ b/pkg/cli/settings_fields-filters.go
@@ -13,11 +13,6 @@ import (
 //go:embed "flags/fields-filters.yaml"
 var fieldsFiltersFlagsYaml []byte
 
-// TODO(manuel, 2022-11-20) Make it easy for the developer to configure which flag they want
-// and which they don't
-//
-// See https://github.com/go-go-golems/glazed/issues/130
-
 type FieldsFilterFlagsDefaults struct {
 	Fields      []string `glazed.parameter:"fields"`
 	Filter      []string `glazed.parameter:"filter"`
@@ -25,7 +20,7 @@ type FieldsFilterFlagsDefaults struct {
 }
 
 type FieldsFiltersParameterLayer struct {
-	layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl
 }
 
 type FieldsFilterSettings struct {
@@ -41,7 +36,7 @@ func NewFieldsFiltersParameterLayer(options ...layers.ParameterLayerOptions) (*F
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create fields and filters parameter layer")
 	}
-	ret.ParameterLayerImpl = *layer
+	ret.ParameterLayerImpl = layer
 
 	return ret, nil
 }

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -44,7 +44,7 @@ type OutputFlagsDefaults struct {
 var outputFlagsYaml []byte
 
 type OutputParameterLayer struct {
-	layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl
 }
 
 func NewOutputParameterLayer(options ...layers.ParameterLayerOptions) (*OutputParameterLayer, error) {
@@ -53,7 +53,7 @@ func NewOutputParameterLayer(options ...layers.ParameterLayerOptions) (*OutputPa
 	if err != nil {
 		return nil, err
 	}
-	ret.ParameterLayerImpl = *layer
+	ret.ParameterLayerImpl = layer
 
 	return ret, nil
 }

--- a/pkg/cli/settings_rename.go
+++ b/pkg/cli/settings_rename.go
@@ -52,7 +52,7 @@ type RenameFlagsDefaults struct {
 var renameFlagsYaml []byte
 
 type RenameParameterLayer struct {
-	layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl
 }
 
 func NewRenameParameterLayer(options ...layers.ParameterLayerOptions) (*RenameParameterLayer, error) {
@@ -61,7 +61,7 @@ func NewRenameParameterLayer(options ...layers.ParameterLayerOptions) (*RenamePa
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create rename parameter layer")
 	}
-	ret.ParameterLayerImpl = *layer
+	ret.ParameterLayerImpl = layer
 	return ret, nil
 }
 

--- a/pkg/cli/settings_replace.go
+++ b/pkg/cli/settings_replace.go
@@ -38,7 +38,7 @@ type ReplaceFlagsDefaults struct {
 }
 
 type ReplaceParameterLayer struct {
-	layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl
 }
 
 //go:embed "flags/replace.yaml"
@@ -50,7 +50,7 @@ func NewReplaceParameterLayer(options ...layers.ParameterLayerOptions) (*Replace
 	if err != nil {
 		return nil, err
 	}
-	ret.ParameterLayerImpl = *layer
+	ret.ParameterLayerImpl = layer
 
 	return ret, nil
 }

--- a/pkg/cli/settings_select.go
+++ b/pkg/cli/settings_select.go
@@ -55,7 +55,7 @@ type SelectFlagsDefaults struct {
 }
 
 type SelectParameterLayer struct {
-	layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl
 }
 
 func NewSelectParameterLayer(options ...layers.ParameterLayerOptions) (*SelectParameterLayer, error) {
@@ -64,7 +64,7 @@ func NewSelectParameterLayer(options ...layers.ParameterLayerOptions) (*SelectPa
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create select parameter layer")
 	}
-	ret.ParameterLayerImpl = *layer
+	ret.ParameterLayerImpl = layer
 
 	return ret, nil
 }

--- a/pkg/cli/settings_template.go
+++ b/pkg/cli/settings_template.go
@@ -43,7 +43,7 @@ func NewTemplateFlagsDefaults() *TemplateFlagsDefaults {
 }
 
 type TemplateParameterLayer struct {
-	layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl
 }
 
 func NewTemplateParameterLayer(options ...layers.ParameterLayerOptions) (*TemplateParameterLayer, error) {
@@ -52,7 +52,7 @@ func NewTemplateParameterLayer(options ...layers.ParameterLayerOptions) (*Templa
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create template parameter layer")
 	}
-	ret.ParameterLayerImpl = *layer
+	ret.ParameterLayerImpl = layer
 
 	return ret, nil
 }

--- a/pkg/cmds/layers/groups.go
+++ b/pkg/cmds/layers/groups.go
@@ -205,7 +205,7 @@ func (p *ParameterLayerImpl) InitializeParameterDefaultsFromStruct(defaults inte
 	return err
 }
 
-func (p *ParameterLayerImpl) InitializeParameterDefinitionsFromParameters(
+func (p *ParameterLayerImpl) InitializeParameterDefaultsFromParameters(
 	ps map[string]interface{},
 ) error {
 	pds := p.GetParameterDefinitions()


### PR DESCRIPTION
Closes #183

This makes things a little bit nicer wrt configuring individual glazed layers, instead
of having to call InitializeParameterDefaultsFromStruct by hand.
