### PR TITLE
Add GetTable to OutputFormatter, make help usage prettier, fix Parents setting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/adrg/frontmatter v0.2.0
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
+	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54
 	github.com/mattn/go-isatty v0.0.16
@@ -19,7 +20,6 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tj/go-naturaldate v1.3.0
-	github.com/wesen/filepathx v1.0.1-0.20230227021146-d1c2e34eff6e
 	github.com/yuin/goldmark v1.5.4
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/aymanbagabas/go-osc52 v1.0.3 h1:DTwqENW7X9arYimJrPeGZcV0ln14sGMt3pHZs
 github.com/aymanbagabas/go-osc52 v1.0.3/go.mod h1:zT8H+Rk4VSabYN90pWyugflM3ZhpTZNC7cASDfUCdT4=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/charmbracelet/glamour v0.6.0 h1:wi8fse3Y7nfcabbbDuwolqTqMQPMnVPeZhDM273bISc=
 github.com/charmbracelet/glamour v0.6.0/go.mod h1:taqWV4swIMMbWALc0m7AfE9JkPSU8om2538k9ITBxOc=
@@ -252,8 +254,6 @@ github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160 h1:NSWpaDaurcAJY7PkL8Xt0
 github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-naturaldate v1.3.0 h1:OgJIPkR/Jk4bFMBLbxZ8w+QUxwjqSvzd9x+yXocY4RI=
 github.com/tj/go-naturaldate v1.3.0/go.mod h1:rpUbjivDKiS1BlfMGc2qUKNZ/yxgthOfmytQs8d8hKk=
-github.com/wesen/filepathx v1.0.1-0.20230227021146-d1c2e34eff6e h1:t/X5D51cT1uIcA7K1wa9fjNxxMez6S0aJNrV7UlpO8Q=
-github.com/wesen/filepathx v1.0.1-0.20230227021146-d1c2e34eff6e/go.mod h1:8kvfGVCYNfq0wC/QpgMOsCWtNQC5JysLRyKMVkq3mSg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/cli/flags/fields-filters.yaml
+++ b/pkg/cli/flags/fields-filters.yaml
@@ -13,6 +13,7 @@ flags:
   - name: filter
     type: stringList
     help: Fields to remove from output
+    default: []
 
   - name: sort-columns
     type: bool

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -178,9 +178,33 @@ func WithParents(p ...string) CommandDescriptionOption {
 	}
 }
 
+func WithPrependParents(p ...string) CommandDescriptionOption {
+	return func(c *CommandDescription) {
+		c.Parents = append(p, c.Parents...)
+	}
+}
+
+func WithStripParentsPrefix(prefixes []string) CommandDescriptionOption {
+	return func(c *CommandDescription) {
+		toRemove := 0
+		for i, p := range c.Parents {
+			if i < len(prefixes) && p == prefixes[i] {
+				toRemove = i + 1
+			}
+		}
+		c.Parents = c.Parents[toRemove:]
+	}
+}
+
 func WithSource(s string) CommandDescriptionOption {
 	return func(c *CommandDescription) {
 		c.Source = s
+	}
+}
+
+func WithPrependSource(s string) CommandDescriptionOption {
+	return func(c *CommandDescription) {
+		c.Source = s + c.Source
 	}
 }
 
@@ -261,9 +285,11 @@ func LoadCommandAliasFromYAML(s io.Reader) ([]*CommandAlias, error) {
 // See https://github.com/go-go-golems/glazed/issues/117
 
 type YAMLFSCommandLoader struct {
-	loader     YAMLCommandLoader
+	loader YAMLCommandLoader
+	// sourceName is a prefix prepended to give information about where each command comes from
 	sourceName string
-	cmdRoot    string
+	// rootDirectory is the root directory these commands will be loaded from
+	rootDirectory string
 }
 
 func NewYAMLFSCommandLoader(
@@ -272,9 +298,9 @@ func NewYAMLFSCommandLoader(
 	cmdRoot string,
 ) *YAMLFSCommandLoader {
 	return &YAMLFSCommandLoader{
-		loader:     loader,
-		sourceName: sourceName,
-		cmdRoot:    cmdRoot,
+		loader:        loader,
+		sourceName:    sourceName,
+		rootDirectory: cmdRoot,
 	}
 }
 
@@ -335,7 +361,7 @@ func (l *YAMLFSCommandLoader) LoadCommandsFromFS(
 					}
 					command := commands[0]
 
-					command.Description().Parents = getParentsFromDir(dir, l.cmdRoot)
+					command.Description().Parents = GetParentsFromDir(dir, l.rootDirectory)
 					command.Description().Source = l.sourceName + ":" + fileName
 
 					return command, err
@@ -366,7 +392,7 @@ func (l *YAMLFSCommandLoader) LoadCommandsFromFS(
 							alias := aliases[0]
 							alias.Source = l.sourceName + ":" + fileName
 
-							alias.Parents = getParentsFromDir(dir, l.cmdRoot)
+							alias.Parents = GetParentsFromDir(dir, l.rootDirectory)
 
 							return alias, err
 						}()
@@ -388,11 +414,11 @@ func (l *YAMLFSCommandLoader) LoadCommandsFromFS(
 	return commands, aliases, nil
 }
 
-// getParentsFromDir is a helper function to simply return a list of parent verbs
+// GetParentsFromDir is a helper function to simply return a list of parent verbs
 // for applications loaded from declarative yaml files.
 // The directory structure mirrors the verb structure in cobra.
-func getParentsFromDir(dir string, cmdRoot string) []string {
-	// make sure both dir and cmdRoot have a trailing slash
+func GetParentsFromDir(dir string, cmdRoot string) []string {
+	// make sure both dir and rootDirectory have a trailing slash
 	if !strings.HasSuffix(dir, "/") {
 		dir += "/"
 	}

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -223,7 +223,7 @@ func (e *ExitWithoutGlazeError) Error() string {
 // library to loader commands from YAML files.
 type YAMLCommandLoader interface {
 	LoadCommandFromYAML(s io.Reader, options ...CommandDescriptionOption) ([]Command, error)
-	LoadCommandAliasFromYAML(s io.Reader, options ...CommandDescriptionOption) ([]*CommandAlias, error)
+	LoadCommandAliasFromYAML(s io.Reader) ([]*CommandAlias, error)
 }
 
 // TODO(2023-02-09, manuel) We can probably implement the directory walking part in a couple of lines
@@ -240,7 +240,7 @@ type FSCommandLoader interface {
 	LoadCommandsFromFS(f fs.FS, dir string, options ...CommandDescriptionOption) ([]Command, []*CommandAlias, error)
 }
 
-func LoadCommandAliasFromYAML(s io.Reader, options ...CommandDescriptionOption) ([]*CommandAlias, error) {
+func LoadCommandAliasFromYAML(s io.Reader) ([]*CommandAlias, error) {
 	var alias CommandAlias
 	err := yaml.NewDecoder(s).Decode(&alias)
 	if err != nil {
@@ -249,10 +249,6 @@ func LoadCommandAliasFromYAML(s io.Reader, options ...CommandDescriptionOption) 
 
 	if !alias.IsValid() {
 		return nil, errors.New("Invalid command alias")
-	}
-
-	for _, o := range options {
-		o(alias.Description())
 	}
 
 	return []*CommandAlias{&alias}, nil
@@ -360,7 +356,7 @@ func (l *YAMLFSCommandLoader) LoadCommandsFromFS(
 							}()
 
 							log.Debug().Str("file", fileName).Msg("Loading alias from file")
-							aliases, err := l.loader.LoadCommandAliasFromYAML(file, options...)
+							aliases, err := l.loader.LoadCommandAliasFromYAML(file)
 							if err != nil {
 								return nil, err
 							}

--- a/pkg/formatters/csv.go
+++ b/pkg/formatters/csv.go
@@ -33,6 +33,10 @@ func NewTSVOutputFormatter() *CSVOutputFormatter {
 	}
 }
 
+func (f *CSVOutputFormatter) GetTable() (*types.Table, error) {
+	return f.Table, nil
+}
+
 func (f *CSVOutputFormatter) AddTableMiddleware(m middlewares2.TableMiddleware) {
 	f.middlewares = append(f.middlewares, m)
 }

--- a/pkg/formatters/json.go
+++ b/pkg/formatters/json.go
@@ -13,6 +13,10 @@ type JSONOutputFormatter struct {
 	middlewares          []middlewares.TableMiddleware
 }
 
+func (J *JSONOutputFormatter) GetTable() (*types.Table, error) {
+	return J.Table, nil
+}
+
 func (J *JSONOutputFormatter) AddRow(row types.Row) {
 	J.Table.Rows = append(J.Table.Rows, row)
 }

--- a/pkg/formatters/table.go
+++ b/pkg/formatters/table.go
@@ -43,6 +43,8 @@ type OutputFormatter interface {
 	AddTableMiddlewareInFront(m middlewares.TableMiddleware)
 	AddTableMiddlewareAtIndex(i int, m middlewares.TableMiddleware)
 
+	GetTable() (*types.Table, error)
+
 	Output() (string, error)
 }
 
@@ -60,6 +62,10 @@ func NewTableOutputFormatter(tableFormat string) *TableOutputFormatter {
 		middlewares: []middlewares.TableMiddleware{},
 		TableFormat: tableFormat,
 	}
+}
+
+func (tof *TableOutputFormatter) GetTable() (*types.Table, error) {
+	return tof.Table, nil
 }
 
 func (tof *TableOutputFormatter) Output() (string, error) {

--- a/pkg/formatters/template.go
+++ b/pkg/formatters/template.go
@@ -15,6 +15,10 @@ type TemplateFormatter struct {
 	AdditionalData   interface{}
 }
 
+func (t *TemplateFormatter) GetTable() (*types.Table, error) {
+	return t.Table, nil
+}
+
 func (t *TemplateFormatter) AddRow(row types.Row) {
 	t.Table.Rows = append(t.Table.Rows, row)
 }

--- a/pkg/formatters/yaml.go
+++ b/pkg/formatters/yaml.go
@@ -11,6 +11,10 @@ type YAMLOutputFormatter struct {
 	middlewares []middlewares.TableMiddleware
 }
 
+func (Y *YAMLOutputFormatter) GetTable() (*types.Table, error) {
+	return Y.Table, nil
+}
+
 func (Y *YAMLOutputFormatter) AddRow(row types.Row) {
 	Y.Table.Rows = append(Y.Table.Rows, row)
 }

--- a/pkg/help/cobra.go
+++ b/pkg/help/cobra.go
@@ -26,6 +26,7 @@ func GetCobraHelpUsageFuncs(hs *HelpSystem) (HelpFunc, UsageFunc) {
 			HelpCommand:     c.Root().CommandPath() + " help",
 		}
 
+		c.NamePadding()
 		cobra.CheckErr(renderCommandHelpPage(c, options, hs))
 	}
 
@@ -104,6 +105,15 @@ func renderCommandHelpPage(c *cobra.Command, options *RenderOptions, hs *HelpSys
 	data["FlagUsageMaxLength"] = maxLength
 	data["HelpCommand"] = options.HelpCommand
 	data["Slug"] = c.Name()
+
+	maxCommandNameLen := 0
+	for _, c := range c.Commands() {
+		if len(c.Name()) > maxCommandNameLen {
+			maxCommandNameLen = len(c.Name())
+		}
+	}
+
+	data["MaxCommandNameLen"] = maxCommandNameLen
 
 	s, err := RenderToMarkdown(t, data)
 	if err != nil {

--- a/pkg/help/templates/cobra-usage.tmpl
+++ b/pkg/help/templates/cobra-usage.tmpl
@@ -10,7 +10,7 @@
 {{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
 
 ## Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  - {{rpad (quote .Name) .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+  - {{rpad (bold .Name) (add .NamePadding 4) }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
 
 ## {{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
   - {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}

--- a/pkg/helpers/templating.go
+++ b/pkg/helpers/templating.go
@@ -410,7 +410,12 @@ func stripNewlines(s string) string {
 }
 
 // rpad adds padding to the right of a string.
-func rpad(s string, padding int) string {
+func rpad(s string, padding_ interface{}) string {
+	padding, ok := CastInterfaceToInt[int](padding_)
+	if !ok {
+		panic("padding must be an int")
+	}
+
 	t := fmt.Sprintf("%%-%ds", padding)
 	return fmt.Sprintf(t, s)
 }

--- a/pkg/helpers/templating.go
+++ b/pkg/helpers/templating.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/Masterminds/sprig"
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/pkg/errors"
-	"github.com/wesen/filepathx"
 	"gopkg.in/yaml.v3"
 	html "html/template"
 	"io"
@@ -507,12 +507,11 @@ func CreateHTMLTemplate(name string) *html.Template {
 
 // ParseFS will recursively glob for all the files matching the given patterns,
 // and load them into one big template (with sub-templates).
-// The globs use filepathx/glob, and support ** notation for recursive globbing.
+// The globs use bmatcuk/doublestar and support ** notation for recursive globbing.
 func ParseFS(t *template.Template, f fs.FS, patterns ...string) error {
 	listMap := make(map[string]struct{})
 	for _, p := range patterns {
-
-		list, err := filepathx.GlobFS(f, p)
+		list, err := doublestar.FilepathGlob(p, doublestar.WithFilesOnly())
 		if err != nil {
 			return err
 		}
@@ -544,9 +543,14 @@ func ParseFS(t *template.Template, f fs.FS, patterns ...string) error {
 // and load them into one big template (with sub-templates).
 // It is the html.Template equivalent of ParseFS.
 //
-// The globs use filepathx/glob, and support ** notation for recursive globbing.
+// The globs use bmatcuk/doublestar and support ** notation for recursive globbing.
 func ParseHTMLFS(t *html.Template, f fs.FS, pattern string, baseDir string) error {
-	list, err := filepathx.GlobFS(f, pattern)
+	list := []string{}
+
+	err := doublestar.GlobWalk(f, pattern, func(path string, d fs.DirEntry) error {
+		list = append(list, path)
+		return nil
+	}, doublestar.WithFilesOnly())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- :art: Add GetTable() API to OutputFormatter
- :ambulance: Use bmatcuk/doublestar and not filepathx
- :ambulance: Don't try to pass options to aliases
- :art: :lipstick: Prettify output of help commands list
- :tractor: :sparkles: Properly handle commands parents when loading from YAML
