### PR TITLE
Properly handle prefix of embedded yaml commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ tag-patch:
 	git tag $(shell svu patch)
 
 release:
-	git push origin $(shell svu current)
+	git push --tags
 	GOPROXY=proxy.golang.org go list -m github.com/go-go-golems/glazed@$(shell svu current)
 
 exhaustive:

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 
 all: gifs
 
-VERSION=v0.2.27
-
 TAPES=$(shell ls doc/vhs/*tape)
 gifs: $(TAPES)
 	for i in $(TAPES); do vhs < $$i; done
@@ -24,12 +22,18 @@ build:
 goreleaser:
 	goreleaser release --snapshot --rm-dist
 
-tag-release:
-	git tag ${VERSION}
+tag-major:
+	git tag $(shell svu major)
+
+tag-minor:
+	git tag $(shell svu minor)
+
+tag-patch:
+	git tag $(shell svu patch)
 
 release:
-	git push origin ${VERSION}
-	GOPROXY=proxy.golang.org go list -m github.com/go-go-golems/glazed@${VERSION}
+	git push origin $(shell svu current)
+	GOPROXY=proxy.golang.org go list -m github.com/go-go-golems/glazed@$(shell svu current)
 
 exhaustive:
 	golangci-lint run -v --enable=exhaustive

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -352,7 +352,11 @@ func (l *YAMLFSCommandLoader) LoadCommandsFromFS(
 					}()
 
 					log.Debug().Str("file", fileName).Msg("Loading command from file")
-					commands, err := l.loader.LoadCommandFromYAML(file, options...)
+					options_ := append([]CommandDescriptionOption{
+						WithSource(l.sourceName + ":" + fileName),
+						WithParents(GetParentsFromDir(dir, l.rootDirectory)...),
+					}, options...)
+					commands, err := l.loader.LoadCommandFromYAML(file, options_...)
 					if err != nil {
 						return nil, err
 					}
@@ -360,9 +364,6 @@ func (l *YAMLFSCommandLoader) LoadCommandsFromFS(
 						return nil, errors.New("Expected exactly one command")
 					}
 					command := commands[0]
-
-					command.Description().Parents = GetParentsFromDir(dir, l.rootDirectory)
-					command.Description().Source = l.sourceName + ":" + fileName
 
 					return command, err
 				}()


### PR DESCRIPTION
- :art: Try using svu
- :art: Push --tags instead of more restricted push
- :ambulance: Properly handle source/parents of yaml commands
