### PR TITLE
Add simple jq support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/charmbracelet/glamour v0.6.0
+	github.com/itchyny/gojq v0.12.12
 	github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54
 	github.com/mattn/go-isatty v0.0.17
 	github.com/nishanths/exhaustive v0.9.5
@@ -44,7 +45,6 @@ require (
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
-	github.com/itchyny/gojq v0.12.12 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/kopoli/go-terminal-size v0.0.0-20170219200355-5c97524c8b54
-	github.com/mattn/go-isatty v0.0.16
+	github.com/mattn/go-isatty v0.0.17
 	github.com/nishanths/exhaustive v0.9.5
 	github.com/piprate/json-gold v0.5.0
 	github.com/pkg/errors v0.9.1
@@ -44,6 +44,8 @@ require (
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/itchyny/gojq v0.12.12 // indirect
+	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
@@ -59,7 +61,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -67,7 +69,7 @@ require (
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/net v0.5.0 // indirect
-	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/tools v0.4.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,10 @@ github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/itchyny/gojq v0.12.12 h1:x+xGI9BXqKoJQZkr95ibpe3cdrTbY8D9lonrK433rcA=
+github.com/itchyny/gojq v0.12.12/go.mod h1:j+3sVkjxwd7A7Z5jrbKibgOLn0ZfLWkV+Awxr/pyzJE=
+github.com/itchyny/timefmt-go v0.1.5 h1:G0INE2la8S6ru/ZI5JecgyzbbJNs5lG1RcBqa7Jm6GE=
+github.com/itchyny/timefmt-go v0.1.5/go.mod h1:nEP7L+2YmAbT2kZ2HfSs1d8Xtw9LY8D2stDBckWakZ8=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -179,6 +183,7 @@ github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
@@ -217,6 +222,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
+github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
@@ -420,6 +427,7 @@ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3v
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
-github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
@@ -220,7 +220,6 @@ github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 h1:J9b7z+QKAm
 github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -425,8 +424,7 @@ golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/cli/flags/fields-filters.yaml
+++ b/pkg/cli/flags/fields-filters.yaml
@@ -1,6 +1,6 @@
 slug: glazed-fields-filters
 name: Glazed fields and filters flags
-Description: |
+description: |
   These are the flags used to configure the fields and filters of the structured data processed 
   through glazed. They allow the user to select which columns they want to see and in which order.
 flags:

--- a/pkg/cli/flags/jq.yaml
+++ b/pkg/cli/flags/jq.yaml
@@ -1,0 +1,24 @@
+slug: glazed-jq
+name: Glazed jq flags
+description: |
+  Glazed uses the https://github.com/itchyny/gojq library to provide functionality
+  to transform the incoming data using the jq query language.
+  
+  For more reference, see:
+  - the jq reference manual: https://stedolan.github.io/jq/manual/
+  - the jq cheatsheet: https://lzone.de/cheat-sheet/jq
+  
+  Examples of how to use jq, as well as tutorials, can be found at: 
+  - https://stedolan.github.io/jq/tutorial/
+  - https://www.baeldung.com/linux/jq-command-json
+  - https://schoeffm.github.io/posts/jq-by-example/
+flags:
+  - name: jq
+    type: string
+    help: jq query to apply to the data
+  - name: field-jq
+    type: keyValue
+    help: apply a jq query to a specific field
+  - name: jq-file
+    type: stringFromFile
+    help: jq query to apply to the data, read from a file

--- a/pkg/cli/flags/output.yaml
+++ b/pkg/cli/flags/output.yaml
@@ -1,6 +1,6 @@
 slug: glazed-output
 name: Glazed output format flags
-Description: |
+description: |
   These are the flags used to configure the output format of the structured data processed 
   through glazed. It can be a structured file format like json or yaml, a database in sqlite,
   a CSV file or a templated markdown or generic template file.

--- a/pkg/cli/flags/rename.yaml
+++ b/pkg/cli/flags/rename.yaml
@@ -1,6 +1,6 @@
 slug: glazed-rename
 name: Glazed rename flags
-Description: |
+description: |
   These are the flags used to rename fields in the structured data processed.
 flags:
   - name: rename

--- a/pkg/cli/flags/replace.yaml
+++ b/pkg/cli/flags/replace.yaml
@@ -1,6 +1,6 @@
 slug: glazed-replace
 name: Glazed replace flags
-Description: |
+description: |
   These are the flags used to replace fields in the structured data processed.
 flags:
   - name: replace-file

--- a/pkg/cli/flags/select.yaml
+++ b/pkg/cli/flags/select.yaml
@@ -1,6 +1,6 @@
 slug: glazed-select
 name: Glazed select flags
-Description: |
+description: |
   These are the flags used to select fields in the structured data processed.
 flags:
   - name: select

--- a/pkg/cli/flags/template.yaml
+++ b/pkg/cli/flags/template.yaml
@@ -1,6 +1,6 @@
 slug: glazed-template
 name: Glazed template flags
-Description: |
+description: |
   These are the flags used to configure the template used to format the output of glazed.
 flags:
   - name: template

--- a/pkg/cli/settings_jq.go
+++ b/pkg/cli/settings_jq.go
@@ -11,7 +11,7 @@ import (
 type JqSettings struct {
 	JqExpression       string            `glazed.parameter:"jq"`
 	JqFile             string            `glazed.parameter:"jq-file"`
-	JqFieldExpressions map[string]string `glazed.parameter:"jq-field"`
+	JqFieldExpressions map[string]string `glazed.parameter:"field-jq"`
 }
 
 //go:embed "flags/jq.yaml"

--- a/pkg/cli/settings_jq.go
+++ b/pkg/cli/settings_jq.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	_ "embed"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/pkg/errors"
+)
+
+type JqSettings struct {
+	JqExpression       string            `glazed-parameter:"jq"`
+	JqFile             string            `glazed-parameter:"jq-file"`
+	JqFieldExpressions map[string]string `glazed-parameter:"jq-field"`
+}
+
+//go:embed "flags/jq.yaml"
+var jqFlagsYaml []byte
+
+type JqParameterLayer struct {
+	*layers.ParameterLayerImpl
+}
+
+func NewJqParameterLayer(options ...layers.ParameterLayerOptions) (*JqParameterLayer, error) {
+	ret := &JqParameterLayer{}
+	layer, err := layers.NewParameterLayerFromYAML(jqFlagsYaml, options...)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create jq parameter layer")
+	}
+	ret.ParameterLayerImpl = layer
+
+	return ret, nil
+}
+
+func NewJqSettingsFromParameters(ps map[string]interface{}) (*JqSettings, error) {
+	s := &JqSettings{}
+	err := parameters.InitializeStructFromParameters(s, ps)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to initialize jq settings from parameters")
+	}
+
+	return s, nil
+}
+
+func NewJqMiddlewaresFromSettings(settings *JqSettings) (*middlewares.JqObjectMiddleware, *middlewares.JqTableMiddleware, error) {
+	var jqObjectMiddleware *middlewares.JqObjectMiddleware
+	var jqTableMiddleware *middlewares.JqTableMiddleware
+	var err error
+
+	jqExpression := settings.JqExpression
+	if jqExpression == "" {
+		jqExpression = settings.JqFile
+	}
+
+	if jqExpression != "" {
+		jqObjectMiddleware, err = middlewares.NewJqObjectMiddleware(settings.JqExpression)
+
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	if len(settings.JqFieldExpressions) > 0 {
+		jqTableMiddleware, err = middlewares.NewJqTableMiddleware(settings.JqFieldExpressions)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return jqObjectMiddleware, jqTableMiddleware, nil
+}

--- a/pkg/cli/settings_jq.go
+++ b/pkg/cli/settings_jq.go
@@ -9,9 +9,9 @@ import (
 )
 
 type JqSettings struct {
-	JqExpression       string            `glazed-parameter:"jq"`
-	JqFile             string            `glazed-parameter:"jq-file"`
-	JqFieldExpressions map[string]string `glazed-parameter:"jq-field"`
+	JqExpression       string            `glazed.parameter:"jq"`
+	JqFile             string            `glazed.parameter:"jq-file"`
+	JqFieldExpressions map[string]string `glazed.parameter:"jq-field"`
 }
 
 //go:embed "flags/jq.yaml"

--- a/pkg/middlewares/jq.go
+++ b/pkg/middlewares/jq.go
@@ -1,0 +1,121 @@
+package middlewares
+
+import (
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/itchyny/gojq"
+	"github.com/pkg/errors"
+)
+
+type JqObjectMiddleware struct {
+	expression string
+	query      *gojq.Query
+}
+
+func NewJqObjectMiddleware(
+	expression string,
+) (*JqObjectMiddleware, error) {
+	ret := &JqObjectMiddleware{
+		expression: expression,
+	}
+
+	if expression != "" {
+		query, err := gojq.Parse(expression)
+		if err != nil {
+			return nil, err
+		}
+
+		ret.query = query
+	}
+
+	return ret, nil
+}
+
+func (jqm *JqObjectMiddleware) Process(object map[string]interface{}) (map[string]interface{}, error) {
+	if jqm.query != nil {
+		iter := jqm.query.Run(object)
+		// See https://github.com/go-go-golems/glazed/issues/202
+		// A middleware should be able to produce multiple outputs rows
+		v, ok := iter.Next()
+		if !ok {
+			return nil, errors.New("no result")
+		}
+
+		if err, ok := v.(error); ok {
+			return nil, err
+		}
+
+		object = v.(map[string]interface{})
+	}
+
+	return object, nil
+}
+
+type JqTableMiddleware struct {
+	fieldExpressions map[types.FieldName]string
+	fieldQueries     map[types.FieldName]*gojq.Query
+}
+
+func NewJqTableMiddleware(
+	fieldExpressions map[types.FieldName]string,
+) (*JqTableMiddleware, error) {
+	ret := &JqTableMiddleware{
+		fieldExpressions: fieldExpressions,
+		fieldQueries:     map[types.FieldName]*gojq.Query{},
+	}
+
+	for columnName, fieldExpression := range fieldExpressions {
+		query, err := gojq.Parse(fieldExpression)
+		if err != nil {
+			return nil, err
+		}
+		ret.fieldQueries[columnName] = query
+	}
+
+	return ret, nil
+}
+
+func (jqm *JqTableMiddleware) Process(table *types.Table) (*types.Table, error) {
+	ret := &types.Table{
+		Columns: []types.FieldName{},
+		Rows:    []types.Row{},
+	}
+
+	ret.Columns = append(ret.Columns, table.Columns...)
+
+	for _, row := range table.Rows {
+		values := row.GetValues()
+		newRow := types.SimpleRow{
+			Hash: map[types.FieldName]types.GenericCellValue{},
+		}
+
+		for rowField, value := range values {
+			query, ok := jqm.fieldQueries[rowField]
+			if !ok {
+				newRow.Hash[rowField] = value
+				continue
+			}
+
+			// TODO(manuel, 2023-03-06) Support generating multiple rows out of jq field queries
+			//
+			// See https://github.com/go-go-golems/glazed/issues/203
+			//
+			// currently, we only support single value returning queries.
+			// in the future, we could image individual rows being "flattened"
+			// out into multiple rows, but that will come later
+
+			iter := query.Run(value)
+			v, ok := iter.Next()
+			if ok {
+				if err, ok := v.(error); ok {
+					return nil, err
+				}
+
+				newRow.Hash[rowField] = v
+			}
+		}
+
+		ret.Rows = append(ret.Rows, &newRow)
+	}
+
+	return ret, nil
+}

--- a/pkg/middlewares/jq_test.go
+++ b/pkg/middlewares/jq_test.go
@@ -1,0 +1,131 @@
+package middlewares
+
+import (
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func createJqObjectMiddleware(t *testing.T, e string) *JqObjectMiddleware {
+	ret, err := NewJqObjectMiddleware(e)
+	require.NoError(t, err)
+
+	return ret
+}
+
+func createJqTableMiddleware(t *testing.T, m map[types.FieldName]string) *JqTableMiddleware {
+	ret, err := NewJqTableMiddleware(m)
+	require.NoError(t, err)
+
+	return ret
+}
+
+func createJqTestTable() *types.Table {
+	return &types.Table{
+		Columns: []types.FieldName{},
+		Rows: []types.Row{
+			&types.SimpleRow{
+				Hash: map[string]interface{}{
+					"a": 1,
+					"b": 2,
+					"c": map[string]interface{}{
+						"d": 3,
+					},
+					"e": "hello",
+					"f": []interface{}{1, 2, 3},
+				},
+			},
+			&types.SimpleRow{
+				Hash: map[string]interface{}{
+					"a": 11,
+					"c": map[string]interface{}{
+						"d": 13,
+						"e": 12,
+					},
+					"e": "foobar",
+					"f": []interface{}{1, 4, 2, 3},
+				},
+			},
+		},
+	}
+}
+
+func TestEmptyObjectMiddleware(t *testing.T) {
+	m := createJqObjectMiddleware(t, "")
+	require.Nil(t, m.query)
+
+	o := map[string]interface{}{"a": 1}
+	o2, err := m.Process(o)
+	assert.NoError(t, err)
+	assert.Equal(t, o, o2)
+}
+
+func TestSimpleJqConstant(t *testing.T) {
+	m := createJqObjectMiddleware(t, "{a: 2}")
+	require.NotNil(t, m.query)
+
+	o := map[string]interface{}{"a": 1}
+	o2, err := m.Process(o)
+	assert.NoError(t, err)
+	expected := map[string]interface{}{"a": 2}
+	assert.Equal(t, expected, o2)
+}
+
+func TestSimpleJqConstantArray(t *testing.T) {
+	m := createJqObjectMiddleware(t, "{a: [2]}")
+	require.NotNil(t, m.query)
+
+	o := map[string]interface{}{"a": 1}
+	o2, err := m.Process(o)
+	assert.NoError(t, err)
+	expected := map[string]interface{}{"a": []interface{}{2}}
+	assert.Equal(t, expected, o2)
+}
+
+func TestSimpleJqExtractNestedArray(t *testing.T) {
+	m := createJqObjectMiddleware(t, ".a[0]")
+	require.NotNil(t, m.query)
+
+	o := map[string]interface{}{"a": []interface{}{map[string]interface{}{"b": 2}}}
+	o2, err := m.Process(o)
+	assert.NoError(t, err)
+	expected := map[string]interface{}{"b": 2}
+	assert.Equal(t, expected, o2)
+}
+
+func TestSimpleJqTableConstant(t *testing.T) {
+	m := createJqTableMiddleware(t, map[types.FieldName]string{"a": "2"})
+	require.NotNil(t, m)
+	require.NotEmpty(t, m.fieldQueries)
+
+	table := createJqTestTable()
+	t2, err := m.Process(table)
+	assert.NoError(t, err)
+
+	row := t2.Rows[0].GetValues()
+	assert.Equal(t, 2, row["a"])
+	assert.Equal(t, 2, row["b"])
+	assert.Equal(t, map[string]interface{}{"d": 3}, row["c"])
+
+	assert.Equal(t, "hello", row["e"])
+	assert.Equal(t, []interface{}{1, 2, 3}, row["f"])
+}
+
+func TestSimpleJqTableTwoFields(t *testing.T) {
+	m := createJqTableMiddleware(t, map[types.FieldName]string{"a": "2", "c": ".d"})
+	require.NotNil(t, m)
+	require.NotEmpty(t, m.fieldQueries)
+
+	table := createJqTestTable()
+	t2, err := m.Process(table)
+	assert.NoError(t, err)
+
+	row := t2.Rows[0].GetValues()
+	assert.Equal(t, 2, row["a"])
+	assert.Equal(t, 2, row["b"])
+	assert.Equal(t, 3, row["c"])
+
+	assert.Equal(t, "hello", row["e"])
+	assert.Equal(t, []interface{}{1, 2, 3}, row["f"])
+}

--- a/pkg/middlewares/mod.go
+++ b/pkg/middlewares/mod.go
@@ -15,6 +15,8 @@ type ObjectMiddleware interface {
 	// TODO(manuel, 2022-11-20) Make the Process monadic, to return one or more new objects
 	// this way we can build filtering interfaces
 	//
+	// See https://github.com/go-go-golems/glazed/issues/202
+	//
 	// Although maybe this should just be the interface for a single object,
 	// which in our standard case would be all the rows at once.
 	// A single object JSON manipulation would be just a single "row"


### PR DESCRIPTION
This adds very simple jq support, both at the object level and at the table 
level. 

The biggest limitation is that it is currently not possible to return multiple objects from an 
object level middleware, but only a single row. This should however be fixed soon.

The semantics of returning multiple values from a field based jq expression are less clear.

Closes #85 

- :sparkles: Add jq middlware
- :sparkles: Properly parse and add jq to the CLI tool
- :ambulance: Fix --field-jq as well
