### PR TITLE
Split Command into GlazeCommand and Command

### DIFF
--- a/cmd/glaze/cmds/docs.go
+++ b/cmd/glaze/cmds/docs.go
@@ -43,7 +43,7 @@ var DocsCmd = &cobra.Command{
 func init() {
 	DocsCmd.Flags().SortFlags = false
 	// This is an example of selective use of glazed parameter layers.
-	// If we extracted out the docs command into a cmds.Command, which we should
+	// If we extracted out the docs command into a cmds.GlazeCommand, which we should
 	// in order to expose it as a REST API, all of this would not even be necessary,
 	// I think.
 	gpl, err := cli.NewGlazedParameterLayers(

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -244,7 +244,10 @@ func BuildCobraCommand(s cmds.GlazeCommand) (*cobra.Command, error) {
 }
 
 func BuildCobraCommandAlias(alias *cmds.CommandAlias) (*cobra.Command, error) {
-	s := alias.AliasedCommand
+	s, ok := alias.AliasedCommand.(cmds.GlazeCommand)
+	if !ok {
+		return nil, fmt.Errorf("command %s is not a GlazeCommand", alias.AliasFor)
+	}
 
 	cmd, err := BuildCobraCommand(s)
 	if err != nil {

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -50,7 +50,7 @@ func GatherParametersFromCobraCommand(
 	return ps, nil
 }
 
-func BuildCobraCommand(s cmds.Command) (*cobra.Command, error) {
+func BuildCobraCommand(s cmds.GlazeCommand) (*cobra.Command, error) {
 	description := s.Description()
 	cmd := &cobra.Command{
 		Use:   description.Name,
@@ -291,8 +291,8 @@ func findOrCreateParentCommand(rootCmd *cobra.Command, parents []string) *cobra.
 	return parentCmd
 }
 
-func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []cmds.Command, aliases []*cmds.CommandAlias) error {
-	commandsByName := map[string]cmds.Command{}
+func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []cmds.GlazeCommand, aliases []*cmds.CommandAlias) error {
+	commandsByName := map[string]cmds.GlazeCommand{}
 
 	for _, command := range commands {
 		// find the proper subcommand, or create if it doesn't exist
@@ -313,7 +313,7 @@ func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []cmds.Command, a
 		path := strings.Join(alias.Parents, " ")
 		aliasedCommand, ok := commandsByName[path]
 		if !ok {
-			return errors.Errorf("Command %s not found for alias %s", path, alias.Name)
+			return errors.Errorf("GlazeCommand %s not found for alias %s", path, alias.Name)
 		}
 		alias.AliasedCommand = aliasedCommand
 
@@ -331,11 +331,11 @@ func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []cmds.Command, a
 // CreateGlazedProcessorFromCobra is a helper for cobra centric apps that quickly want to add
 // the glazed processing layer.
 //
-// If you are more serious about using glazed, consider using the `cmds.Command` and `parameters.ParameterDefinition`
+// If you are more serious about using glazed, consider using the `cmds.GlazeCommand` and `parameters.ParameterDefinition`
 // abstraction to define your CLI applications, which allows you to use layers and other nice features
 // of the glazed ecosystem.
 //
-// If so, use SetupProcessor instead, and create a proper glazed.Command for your command.
+// If so, use SetupProcessor instead, and create a proper glazed.GlazeCommand for your command.
 func CreateGlazedProcessorFromCobra(cmd *cobra.Command) (
 	*cmds.GlazeProcessor,
 	formatters.OutputFormatter,

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -313,7 +313,7 @@ func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []cmds.GlazeComma
 		path := strings.Join(alias.Parents, " ")
 		aliasedCommand, ok := commandsByName[path]
 		if !ok {
-			return errors.Errorf("GlazeCommand %s not found for alias %s", path, alias.Name)
+			return errors.Errorf("Command %s not found for alias %s", path, alias.Name)
 		}
 		alias.AliasedCommand = aliasedCommand
 

--- a/pkg/cmds/alias.go
+++ b/pkg/cmds/alias.go
@@ -17,9 +17,9 @@ type CommandAlias struct {
 	Flags     map[string]string `yaml:"flags,omitempty"`
 	Arguments []string          `yaml:"arguments,omitempty"`
 
-	AliasedCommand Command  `yaml:",omitempty"`
-	Parents        []string `yaml:",omitempty"`
-	Source         string   `yaml:",omitempty"`
+	AliasedCommand GlazeCommand `yaml:",omitempty"`
+	Parents        []string     `yaml:",omitempty"`
+	Source         string       `yaml:",omitempty"`
 }
 
 func (a *CommandAlias) String() string {

--- a/pkg/cmds/alias.go
+++ b/pkg/cmds/alias.go
@@ -17,9 +17,9 @@ type CommandAlias struct {
 	Flags     map[string]string `yaml:"flags,omitempty"`
 	Arguments []string          `yaml:"arguments,omitempty"`
 
-	AliasedCommand GlazeCommand `yaml:",omitempty"`
-	Parents        []string     `yaml:",omitempty"`
-	Source         string       `yaml:",omitempty"`
+	AliasedCommand Command  `yaml:",omitempty"`
+	Parents        []string `yaml:",omitempty"`
+	Source         string   `yaml:",omitempty"`
 }
 
 func (a *CommandAlias) String() string {
@@ -36,7 +36,11 @@ func (a *CommandAlias) Run(
 	if a.AliasedCommand == nil {
 		return errors.New("no aliased command")
 	}
-	return a.AliasedCommand.Run(ctx, parsedLayers, ps, gp)
+	glazeCommand, ok := a.AliasedCommand.(GlazeCommand)
+	if !ok {
+		return errors.New("aliased command is not a GlazeCommand")
+	}
+	return glazeCommand.Run(ctx, parsedLayers, ps, gp)
 }
 
 func (a *CommandAlias) IsValid() bool {

--- a/pkg/help/cobra.go
+++ b/pkg/help/cobra.go
@@ -100,7 +100,7 @@ func renderCommandHelpPage(c *cobra.Command, options *RenderOptions, hs *HelpSys
 		}
 	}
 
-	data["Command"] = c
+	data["GlazeCommand"] = c
 	data["FlagGroupUsage"] = flagGroupUsage
 	data["FlagUsageMaxLength"] = maxLength
 	data["HelpCommand"] = options.HelpCommand

--- a/pkg/help/cobra.go
+++ b/pkg/help/cobra.go
@@ -100,7 +100,7 @@ func renderCommandHelpPage(c *cobra.Command, options *RenderOptions, hs *HelpSys
 		}
 	}
 
-	data["GlazeCommand"] = c
+	data["Command"] = c
 	data["FlagGroupUsage"] = flagGroupUsage
 	data["FlagUsageMaxLength"] = maxLength
 	data["HelpCommand"] = options.HelpCommand


### PR DESCRIPTION
This splits the Command interface into two interfaces:

- Command handles only the Description() part and allows us to wrap commands into CLI apps
- GlazeCommand is focused on the Run() method and running things into a GlazeProcessor

- :art: Split Command into GlazeCommand and Command
- :sparkles: Make loaders only deal with Command, GlazeCommand can come later
