### PR TITLE
Add CSV support to objectFromFile,objectListFromFile,keyValue,stringListFromFile

### DIFF
--- a/pkg/cmds/parameters/parameters.go
+++ b/pkg/cmds/parameters/parameters.go
@@ -1,20 +1,12 @@
 package parameters
 
 import (
-	"bufio"
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"github.com/araddon/dateparse"
 	"github.com/go-go-golems/glazed/pkg/helpers/cast"
 	reflect2 "github.com/go-go-golems/glazed/pkg/helpers/reflect"
 	"github.com/pkg/errors"
-	"github.com/tj/go-naturaldate"
 	"gopkg.in/yaml.v3"
-	"io"
-	"os"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -681,9 +673,9 @@ func (p *ParameterDefinition) CheckParameterDefaultValueValidity() error {
 			}
 
 			// convert to string list
-			fixedDefault, err := convertToStringList(defaultValue)
-			if err != nil {
-				return errors.Wrapf(err, "Could not convert default value for parameter %s to string list: %v", p.Name, p.Default)
+			fixedDefault, ok := cast.CastList[string, interface{}](defaultValue)
+			if !ok {
+				return errors.Errorf("Default value for parameter %s is not a string list: %v", p.Name, p.Default)
 			}
 			p.Default = fixedDefault
 		}
@@ -736,265 +728,6 @@ func (p *ParameterDefinition) CheckParameterDefaultValueValidity() error {
 	}
 
 	return nil
-}
-
-func (p *ParameterDefinition) ParseParameter(v []string) (interface{}, error) {
-	if len(v) == 0 {
-		if p.Required {
-			return nil, errors.Errorf("Argument %s not found", p.Name)
-		} else {
-			return p.Default, nil
-		}
-	}
-
-	switch p.Type {
-	case ParameterTypeString:
-		return v[0], nil
-	case ParameterTypeInteger:
-		i, err := strconv.Atoi(v[0])
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse argument %s as integer", p.Name)
-		}
-		return i, nil
-	case ParameterTypeFloat:
-		f, err := strconv.ParseFloat(v[0], 32)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse argument %s as float", p.Name)
-		}
-		return float32(f), nil
-	case ParameterTypeStringList:
-		return v, nil
-	case ParameterTypeIntegerList:
-		ints := make([]int, 0)
-		for _, arg := range v {
-			i, err := strconv.Atoi(arg)
-			if err != nil {
-				return nil, errors.Wrapf(err, "Could not parse argument %s as integer", p.Name)
-			}
-			ints = append(ints, i)
-		}
-		return ints, nil
-
-	case ParameterTypeBool:
-		b, err := strconv.ParseBool(v[0])
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse argument %s as bool", p.Name)
-		}
-		return b, nil
-
-	case ParameterTypeChoice:
-		choice := v[0]
-		found := false
-		for _, c := range p.Choices {
-			if c == choice {
-				found = true
-			}
-		}
-		if !found {
-			return nil, errors.Errorf("Argument %s has invalid choice %s", p.Name, choice)
-		}
-		return choice, nil
-
-	case ParameterTypeDate:
-		parsedDate, err := ParseDate(v[0])
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse argument %s as date", p.Name)
-		}
-		return parsedDate, nil
-
-	case ParameterTypeObjectListFromFile:
-		fallthrough
-	case ParameterTypeObjectFromFile:
-		fallthrough
-	case ParameterTypeStringFromFile:
-		fallthrough
-	case ParameterTypeStringListFromFile:
-		fileName := v[0]
-		if fileName == "" {
-			return p.Default, nil
-		}
-		var f io.Reader
-		if fileName == "-" {
-			f = os.Stdin
-		} else {
-			f2, err := os.Open(fileName)
-			if err != nil {
-				return nil, errors.Wrapf(err, "Could not read file %s", v[0])
-			}
-			defer func(f2 *os.File) {
-				_ = f2.Close()
-			}(f2)
-
-			f = f2
-		}
-
-		ret, err := p.ParseFromReader(f, fileName)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not read file %s", v[0])
-		}
-
-		return ret, nil
-
-	case ParameterTypeKeyValue:
-		if len(v) == 0 {
-			return p.Default, nil
-		}
-		ret := map[string]interface{}{}
-		if len(v) == 1 && strings.HasPrefix(v[0], "@") {
-			// load from file
-			templateDataFile := v[0][1:]
-
-			var f io.Reader
-			if templateDataFile == "-" {
-				f = os.Stdin
-			} else {
-				f2, err := os.Open(templateDataFile)
-				if err != nil {
-					return nil, errors.Wrapf(err, "Could not read file %s", templateDataFile)
-				}
-				defer func(f2 *os.File) {
-					_ = f2.Close()
-				}(f2)
-				f = f2
-			}
-
-			return p.ParseFromReader(f, templateDataFile)
-		} else {
-			for _, arg := range v {
-				// TODO(2023-02-11): The separator could be stored in the parameter itself?
-				// It was configurable before.
-				//
-				// See https://github.com/go-go-golems/glazed/issues/129
-				parts := strings.Split(arg, ":")
-				if len(parts) != 2 {
-					return nil, errors.Errorf("Could not parse argument %s as key=value pair", arg)
-				}
-				ret[parts[0]] = parts[1]
-			}
-		}
-		return ret, nil
-
-	case ParameterTypeFloatList:
-		floats := make([]float64, 0)
-		for _, arg := range v {
-			// parse to float
-			f, err := strconv.ParseFloat(arg, 64)
-			if err != nil {
-				return nil, errors.Wrapf(err, "Could not parse argument %s as integer", p.Name)
-			}
-			floats = append(floats, f)
-		}
-		return floats, nil
-	}
-
-	return nil, errors.Errorf("Unknown parameter type %s", p.Type)
-}
-
-func (p *ParameterDefinition) ParseFromReader(f io.Reader, name string) (interface{}, error) {
-	var err error
-	//exhaustive:ignore
-	switch p.Type {
-	case ParameterTypeStringListFromFile:
-		ret := make([]string, 0)
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			ret = append(ret, scanner.Text())
-		}
-		if err = scanner.Err(); err != nil {
-			return nil, err
-		}
-
-		return ret, nil
-
-	case ParameterTypeObjectFromFile:
-		object := interface{}(nil)
-		if name == "-" || strings.HasSuffix(name, ".json") {
-			err = json.NewDecoder(f).Decode(&object)
-		} else if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
-			err = yaml.NewDecoder(f).Decode(&object)
-		} else {
-			return nil, errors.Errorf("Could not parse file %s: unknown file type", name)
-		}
-
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse file %s", name)
-		}
-
-		return object, nil
-
-	case ParameterTypeObjectListFromFile:
-		objectList := []interface{}{}
-		if name == "-" || strings.HasSuffix(name, ".json") {
-			err = json.NewDecoder(f).Decode(&objectList)
-		} else if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
-			err = yaml.NewDecoder(f).Decode(&objectList)
-		} else {
-			return nil, errors.Errorf("Could not parse file %s: unknown file type", name)
-		}
-
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse file %s", name)
-		}
-
-		return objectList, nil
-
-	case ParameterTypeKeyValue:
-		ret := interface{}(nil)
-		if name == "-" || strings.HasSuffix(name, ".json") {
-			err = json.NewDecoder(f).Decode(&ret)
-		} else if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
-			err = yaml.NewDecoder(f).Decode(&ret)
-		} else {
-			return nil, errors.Errorf("Could not parse file %s: unknown file type", name)
-		}
-
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse file %s", name)
-		}
-		return ret, nil
-
-	case ParameterTypeStringFromFile:
-		var b bytes.Buffer
-		_, err := io.Copy(&b, f)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not read from stdin")
-		}
-		return b.String(), nil
-
-	default:
-		return nil, errors.New("Cannot parse from file for this parameter type")
-	}
-}
-
-func convertToStringList(value []interface{}) ([]string, error) {
-	stringList := make([]string, len(value))
-	for i, v := range value {
-		s, ok := v.(string)
-		if !ok {
-			return nil, errors.Errorf("Not a string: %v", v)
-		}
-		stringList[i] = s
-	}
-	return stringList, nil
-}
-
-// refTime is used to set a reference time for natural date parsing for unit test purposes
-var refTime *time.Time
-
-func ParseDate(value string) (time.Time, error) {
-	parsedDate, err := dateparse.ParseAny(value)
-	if err != nil {
-		refTime_ := time.Now()
-		if refTime != nil {
-			refTime_ = *refTime
-		}
-		parsedDate, err = naturaldate.Parse(value, refTime_)
-		if err != nil {
-			return time.Time{}, errors.Wrapf(err, "Could not parse date: %s", value)
-		}
-	}
-
-	return parsedDate, nil
 }
 
 func InitFlagsFromYaml(yamlContent []byte) (map[string]*ParameterDefinition, []*ParameterDefinition) {

--- a/pkg/cmds/parameters/parse.go
+++ b/pkg/cmds/parameters/parse.go
@@ -26,19 +26,28 @@ func (p *ParameterDefinition) ParseParameter(v []string) (interface{}, error) {
 
 	switch p.Type {
 	case ParameterTypeString:
+		if len(v) > 1 {
+			return nil, errors.Errorf("Argument %s must be a single string", p.Name)
+		}
 		return v[0], nil
 	case ParameterTypeInteger:
+		if len(v) > 1 {
+			return nil, errors.Errorf("Argument %s must be a single integer", p.Name)
+		}
 		i, err := strconv.Atoi(v[0])
 		if err != nil {
 			return nil, errors.Wrapf(err, "Could not parse argument %s as integer", p.Name)
 		}
 		return i, nil
 	case ParameterTypeFloat:
-		f, err := strconv.ParseFloat(v[0], 32)
+		if len(v) > 1 {
+			return nil, errors.Errorf("Argument %s must be a single float", p.Name)
+		}
+		f, err := strconv.ParseFloat(v[0], 64)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Could not parse argument %s as float", p.Name)
 		}
-		return float32(f), nil
+		return f, nil
 	case ParameterTypeStringList:
 		return v, nil
 	case ParameterTypeIntegerList:
@@ -53,6 +62,9 @@ func (p *ParameterDefinition) ParseParameter(v []string) (interface{}, error) {
 		return ints, nil
 
 	case ParameterTypeBool:
+		if len(v) > 1 {
+			return nil, errors.Errorf("Argument %s must be a single boolean", p.Name)
+		}
 		b, err := strconv.ParseBool(v[0])
 		if err != nil {
 			return nil, errors.Wrapf(err, "Could not parse argument %s as bool", p.Name)
@@ -60,6 +72,9 @@ func (p *ParameterDefinition) ParseParameter(v []string) (interface{}, error) {
 		return b, nil
 
 	case ParameterTypeChoice:
+		if len(v) > 1 {
+			return nil, errors.Errorf("Argument %s must be a single choice", p.Name)
+		}
 		choice := v[0]
 		found := false
 		for _, c := range p.Choices {
@@ -167,7 +182,7 @@ func (p *ParameterDefinition) ParseParameter(v []string) (interface{}, error) {
 	return nil, errors.Errorf("Unknown parameter type %s", p.Type)
 }
 
-func (p *ParameterDefinition) ParseFromReader(f io.Reader, name string) (interface{}, error) {
+func (p *ParameterDefinition) ParseFromReader(f io.Reader, filename string) (interface{}, error) {
 	var err error
 	//exhaustive:ignore
 	switch p.Type {
@@ -185,48 +200,48 @@ func (p *ParameterDefinition) ParseFromReader(f io.Reader, name string) (interfa
 
 	case ParameterTypeObjectFromFile:
 		object := interface{}(nil)
-		if name == "-" || strings.HasSuffix(name, ".json") {
+		if filename == "-" || strings.HasSuffix(filename, ".json") {
 			err = json.NewDecoder(f).Decode(&object)
-		} else if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+		} else if strings.HasSuffix(filename, ".yaml") || strings.HasSuffix(filename, ".yml") {
 			err = yaml.NewDecoder(f).Decode(&object)
 		} else {
-			return nil, errors.Errorf("Could not parse file %s: unknown file type", name)
+			return nil, errors.Errorf("Could not parse file %s: unknown file type", filename)
 		}
 
 		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse file %s", name)
+			return nil, errors.Wrapf(err, "Could not parse file %s", filename)
 		}
 
 		return object, nil
 
 	case ParameterTypeObjectListFromFile:
 		objectList := []interface{}{}
-		if name == "-" || strings.HasSuffix(name, ".json") {
+		if filename == "-" || strings.HasSuffix(filename, ".json") {
 			err = json.NewDecoder(f).Decode(&objectList)
-		} else if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+		} else if strings.HasSuffix(filename, ".yaml") || strings.HasSuffix(filename, ".yml") {
 			err = yaml.NewDecoder(f).Decode(&objectList)
 		} else {
-			return nil, errors.Errorf("Could not parse file %s: unknown file type", name)
+			return nil, errors.Errorf("Could not parse file %s: unknown file type", filename)
 		}
 
 		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse file %s", name)
+			return nil, errors.Wrapf(err, "Could not parse file %s", filename)
 		}
 
 		return objectList, nil
 
 	case ParameterTypeKeyValue:
 		ret := interface{}(nil)
-		if name == "-" || strings.HasSuffix(name, ".json") {
+		if filename == "-" || strings.HasSuffix(filename, ".json") {
 			err = json.NewDecoder(f).Decode(&ret)
-		} else if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+		} else if strings.HasSuffix(filename, ".yaml") || strings.HasSuffix(filename, ".yml") {
 			err = yaml.NewDecoder(f).Decode(&ret)
 		} else {
-			return nil, errors.Errorf("Could not parse file %s: unknown file type", name)
+			return nil, errors.Errorf("Could not parse file %s: unknown file type", filename)
 		}
 
 		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse file %s", name)
+			return nil, errors.Wrapf(err, "Could not parse file %s", filename)
 		}
 		return ret, nil
 

--- a/pkg/cmds/parameters/parse.go
+++ b/pkg/cmds/parameters/parse.go
@@ -299,6 +299,15 @@ func (p *ParameterDefinition) ParseFromReader(f io.Reader, filename string) (int
 			err = json.NewDecoder(f).Decode(&ret)
 		} else if strings.HasSuffix(filename, ".yaml") || strings.HasSuffix(filename, ".yml") {
 			err = yaml.NewDecoder(f).Decode(&ret)
+		} else if strings.HasSuffix(filename, ".csv") || strings.HasSuffix(filename, ".tsv") {
+			objects, err := parseObjectListFromCSV(f, filename)
+			if err != nil {
+				return nil, err
+			}
+			if len(objects) != 1 {
+				return nil, errors.Errorf("File %s does not contain exactly one object", filename)
+			}
+			ret = objects[0]
 		} else {
 			return nil, errors.Errorf("Could not parse file %s: unknown file type", filename)
 		}

--- a/pkg/cmds/parameters/parse.go
+++ b/pkg/cmds/parameters/parse.go
@@ -197,6 +197,12 @@ func parseObjectListFromCSV(f io.Reader, filename string) ([]interface{}, error)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not parse file %s", filename)
 	}
+
+	// if the file is entirely empty, return an empty list
+	if len(csvData) == 0 {
+		return []interface{}{}, nil
+	}
+
 	// check we have both headers and more than one line
 	if len(csvData) < 2 {
 		return nil, errors.Errorf("File %s does not contain a header line", filename)
@@ -272,6 +278,11 @@ func (p *ParameterDefinition) ParseFromReader(f io.Reader, filename string) (int
 			err = json.NewDecoder(f).Decode(&objectList)
 		} else if strings.HasSuffix(filename, ".yaml") || strings.HasSuffix(filename, ".yml") {
 			err = yaml.NewDecoder(f).Decode(&objectList)
+		} else if strings.HasSuffix(filename, ".csv") || strings.HasSuffix(filename, ".tsv") {
+			objectList, err = parseObjectListFromCSV(f, filename)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			return nil, errors.Errorf("Could not parse file %s: unknown file type", filename)
 		}

--- a/pkg/cmds/parameters/parse.go
+++ b/pkg/cmds/parameters/parse.go
@@ -1,0 +1,263 @@
+package parameters
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"github.com/araddon/dateparse"
+	"github.com/pkg/errors"
+	"github.com/tj/go-naturaldate"
+	"gopkg.in/yaml.v3"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func (p *ParameterDefinition) ParseParameter(v []string) (interface{}, error) {
+	if len(v) == 0 {
+		if p.Required {
+			return nil, errors.Errorf("Argument %s not found", p.Name)
+		} else {
+			return p.Default, nil
+		}
+	}
+
+	switch p.Type {
+	case ParameterTypeString:
+		return v[0], nil
+	case ParameterTypeInteger:
+		i, err := strconv.Atoi(v[0])
+		if err != nil {
+			return nil, errors.Wrapf(err, "Could not parse argument %s as integer", p.Name)
+		}
+		return i, nil
+	case ParameterTypeFloat:
+		f, err := strconv.ParseFloat(v[0], 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Could not parse argument %s as float", p.Name)
+		}
+		return float32(f), nil
+	case ParameterTypeStringList:
+		return v, nil
+	case ParameterTypeIntegerList:
+		ints := make([]int, 0)
+		for _, arg := range v {
+			i, err := strconv.Atoi(arg)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Could not parse argument %s as integer", p.Name)
+			}
+			ints = append(ints, i)
+		}
+		return ints, nil
+
+	case ParameterTypeBool:
+		b, err := strconv.ParseBool(v[0])
+		if err != nil {
+			return nil, errors.Wrapf(err, "Could not parse argument %s as bool", p.Name)
+		}
+		return b, nil
+
+	case ParameterTypeChoice:
+		choice := v[0]
+		found := false
+		for _, c := range p.Choices {
+			if c == choice {
+				found = true
+			}
+		}
+		if !found {
+			return nil, errors.Errorf("Argument %s has invalid choice %s", p.Name, choice)
+		}
+		return choice, nil
+
+	case ParameterTypeDate:
+		parsedDate, err := ParseDate(v[0])
+		if err != nil {
+			return nil, errors.Wrapf(err, "Could not parse argument %s as date", p.Name)
+		}
+		return parsedDate, nil
+
+	case ParameterTypeObjectListFromFile:
+		fallthrough
+	case ParameterTypeObjectFromFile:
+		fallthrough
+	case ParameterTypeStringFromFile:
+		fallthrough
+	case ParameterTypeStringListFromFile:
+		fileName := v[0]
+		if fileName == "" {
+			return p.Default, nil
+		}
+		var f io.Reader
+		if fileName == "-" {
+			f = os.Stdin
+		} else {
+			f2, err := os.Open(fileName)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Could not read file %s", v[0])
+			}
+			defer func(f2 *os.File) {
+				_ = f2.Close()
+			}(f2)
+
+			f = f2
+		}
+
+		ret, err := p.ParseFromReader(f, fileName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Could not read file %s", v[0])
+		}
+
+		return ret, nil
+
+	case ParameterTypeKeyValue:
+		if len(v) == 0 {
+			return p.Default, nil
+		}
+		ret := map[string]interface{}{}
+		if len(v) == 1 && strings.HasPrefix(v[0], "@") {
+			// load from file
+			templateDataFile := v[0][1:]
+
+			var f io.Reader
+			if templateDataFile == "-" {
+				f = os.Stdin
+			} else {
+				f2, err := os.Open(templateDataFile)
+				if err != nil {
+					return nil, errors.Wrapf(err, "Could not read file %s", templateDataFile)
+				}
+				defer func(f2 *os.File) {
+					_ = f2.Close()
+				}(f2)
+				f = f2
+			}
+
+			return p.ParseFromReader(f, templateDataFile)
+		} else {
+			for _, arg := range v {
+				// TODO(2023-02-11): The separator could be stored in the parameter itself?
+				// It was configurable before.
+				//
+				// See https://github.com/go-go-golems/glazed/issues/129
+				parts := strings.Split(arg, ":")
+				if len(parts) != 2 {
+					return nil, errors.Errorf("Could not parse argument %s as key=value pair", arg)
+				}
+				ret[parts[0]] = parts[1]
+			}
+		}
+		return ret, nil
+
+	case ParameterTypeFloatList:
+		floats := make([]float64, 0)
+		for _, arg := range v {
+			// parse to float
+			f, err := strconv.ParseFloat(arg, 64)
+			if err != nil {
+				return nil, errors.Wrapf(err, "Could not parse argument %s as integer", p.Name)
+			}
+			floats = append(floats, f)
+		}
+		return floats, nil
+	}
+
+	return nil, errors.Errorf("Unknown parameter type %s", p.Type)
+}
+
+func (p *ParameterDefinition) ParseFromReader(f io.Reader, name string) (interface{}, error) {
+	var err error
+	//exhaustive:ignore
+	switch p.Type {
+	case ParameterTypeStringListFromFile:
+		ret := make([]string, 0)
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			ret = append(ret, scanner.Text())
+		}
+		if err = scanner.Err(); err != nil {
+			return nil, err
+		}
+
+		return ret, nil
+
+	case ParameterTypeObjectFromFile:
+		object := interface{}(nil)
+		if name == "-" || strings.HasSuffix(name, ".json") {
+			err = json.NewDecoder(f).Decode(&object)
+		} else if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+			err = yaml.NewDecoder(f).Decode(&object)
+		} else {
+			return nil, errors.Errorf("Could not parse file %s: unknown file type", name)
+		}
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "Could not parse file %s", name)
+		}
+
+		return object, nil
+
+	case ParameterTypeObjectListFromFile:
+		objectList := []interface{}{}
+		if name == "-" || strings.HasSuffix(name, ".json") {
+			err = json.NewDecoder(f).Decode(&objectList)
+		} else if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+			err = yaml.NewDecoder(f).Decode(&objectList)
+		} else {
+			return nil, errors.Errorf("Could not parse file %s: unknown file type", name)
+		}
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "Could not parse file %s", name)
+		}
+
+		return objectList, nil
+
+	case ParameterTypeKeyValue:
+		ret := interface{}(nil)
+		if name == "-" || strings.HasSuffix(name, ".json") {
+			err = json.NewDecoder(f).Decode(&ret)
+		} else if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+			err = yaml.NewDecoder(f).Decode(&ret)
+		} else {
+			return nil, errors.Errorf("Could not parse file %s: unknown file type", name)
+		}
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "Could not parse file %s", name)
+		}
+		return ret, nil
+
+	case ParameterTypeStringFromFile:
+		var b bytes.Buffer
+		_, err := io.Copy(&b, f)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Could not read from stdin")
+		}
+		return b.String(), nil
+
+	default:
+		return nil, errors.New("Cannot parse from file for this parameter type")
+	}
+}
+
+// refTime is used to set a reference time for natural date parsing for unit test purposes
+var refTime *time.Time
+
+func ParseDate(value string) (time.Time, error) {
+	parsedDate, err := dateparse.ParseAny(value)
+	if err != nil {
+		refTime_ := time.Now()
+		if refTime != nil {
+			refTime_ = *refTime
+		}
+		parsedDate, err = naturaldate.Parse(value, refTime_)
+		if err != nil {
+			return time.Time{}, errors.Wrapf(err, "Could not parse date: %s", value)
+		}
+	}
+
+	return parsedDate, nil
+}

--- a/pkg/cmds/parameters/parse_test.go
+++ b/pkg/cmds/parameters/parse_test.go
@@ -1,0 +1,457 @@
+package parameters
+
+import (
+	"fmt"
+	"github.com/go-go-golems/glazed/pkg/helpers/cast"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestParameterString(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeString,
+		WithDefault("default"),
+	)
+
+	i, err := parameter.ParseParameter([]string{"test"})
+	require.NoError(t, err)
+	assert.Equal(t, "test", i)
+
+	_, err = parameter.ParseParameter([]string{"test", "test2"})
+	assert.Error(t, err)
+
+	i, err = parameter.ParseParameter([]string{})
+	require.NoError(t, err)
+	assert.Equal(t, "default", i)
+}
+
+func TestParameterStringList(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeStringList,
+		WithDefault([]string{"default"}),
+	)
+
+	i, err := parameter.ParseParameter([]string{"test"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test"}, i)
+
+	i, err = parameter.ParseParameter([]string{"test", "test2"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test", "test2"}, i)
+
+	i, err = parameter.ParseParameter([]string{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"default"}, i)
+}
+
+func TestParameterInt(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeInteger,
+		WithDefault(1),
+	)
+
+	i, err := parameter.ParseParameter([]string{"1"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, i)
+
+	_, err = parameter.ParseParameter([]string{"test"})
+	assert.Error(t, err)
+
+	_, err = parameter.ParseParameter([]string{"1", "2"})
+	assert.Error(t, err)
+
+	i, err = parameter.ParseParameter([]string{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, i)
+}
+
+func TestParameterIntegerList(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeIntegerList,
+		WithDefault([]int{1}),
+	)
+
+	i, err := parameter.ParseParameter([]string{"1"})
+	require.NoError(t, err)
+	assert.Equal(t, []int{1}, i)
+
+	i, err = parameter.ParseParameter([]string{"1", "2"})
+	require.NoError(t, err)
+	assert.Equal(t, []int{1, 2}, i)
+
+	_, err = parameter.ParseParameter([]string{"test"})
+	assert.Error(t, err)
+
+	i, err = parameter.ParseParameter([]string{})
+	require.NoError(t, err)
+	assert.Equal(t, []int{1}, i)
+}
+
+func TestParameterBool(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeBool,
+		WithDefault(true),
+	)
+
+	i, err := parameter.ParseParameter([]string{"true"})
+	require.NoError(t, err)
+	assert.Equal(t, true, i)
+
+	i, err = parameter.ParseParameter([]string{"false"})
+	require.NoError(t, err)
+	assert.Equal(t, false, i)
+
+	_, err = parameter.ParseParameter([]string{"test"})
+	assert.Error(t, err)
+
+	_, err = parameter.ParseParameter([]string{"true", "false"})
+	assert.Error(t, err)
+
+	i, err = parameter.ParseParameter([]string{})
+	require.NoError(t, err)
+	assert.Equal(t, true, i)
+}
+
+func TestParameterFloat(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeFloat,
+		WithDefault(1.0),
+	)
+
+	i, err := parameter.ParseParameter([]string{"1.0"})
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, i)
+
+	_, err = parameter.ParseParameter([]string{"test"})
+	assert.Error(t, err)
+
+	_, err = parameter.ParseParameter([]string{"1.0", "2.0"})
+	assert.Error(t, err)
+
+	i, err = parameter.ParseParameter([]string{})
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, i)
+}
+
+func TestParameterFloatList(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeFloatList,
+		WithDefault([]float64{1.0}),
+	)
+
+	i, err := parameter.ParseParameter([]string{"1.0"})
+	require.NoError(t, err)
+	assert.Equal(t, []float64{1.0}, i)
+
+	i, err = parameter.ParseParameter([]string{"1.0", "2.0"})
+	require.NoError(t, err)
+	assert.Equal(t, []float64{1.0, 2.0}, i)
+
+	_, err = parameter.ParseParameter([]string{"test"})
+	assert.Error(t, err)
+
+	i, err = parameter.ParseParameter([]string{})
+	require.NoError(t, err)
+	assert.Equal(t, []float64{1.0}, i)
+}
+
+func TestParameterChoice(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeChoice,
+		WithDefault("default"),
+		WithChoices([]string{"default", "test"}),
+	)
+
+	i, err := parameter.ParseParameter([]string{"test"})
+	require.NoError(t, err)
+	assert.Equal(t, "test", i)
+
+	_, err = parameter.ParseParameter([]string{"test2"})
+	assert.Error(t, err)
+
+	_, err = parameter.ParseParameter([]string{"test", "test2"})
+	assert.Error(t, err)
+
+	i, err = parameter.ParseParameter([]string{})
+	require.NoError(t, err)
+	assert.Equal(t, "default", i)
+}
+
+func TestParameterTypeKeyValue(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeKeyValue,
+		WithDefault(map[string]interface{}{"default": "default"}),
+	)
+
+	i, err := parameter.ParseParameter([]string{"test:test"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": "test"}, i)
+
+	i, err = parameter.ParseParameter([]string{"test:test", "test2:test2"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": "test", "test2": "test2"}, i)
+
+	_, err = parameter.ParseParameter([]string{"test"})
+	assert.Error(t, err)
+
+	i, err = parameter.ParseParameter([]string{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"default": "default"}, i)
+}
+
+func TestParseStringListFromReader(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeStringListFromFile,
+		WithDefault([]string{"default"}),
+	)
+
+	reader := strings.NewReader("test\ntest2")
+	i, err := parameter.ParseFromReader(reader, "test.txt")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test", "test2"}, i)
+
+	reader = strings.NewReader("test")
+	i, err = parameter.ParseFromReader(reader, "test.txt")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test"}, i)
+
+	reader = strings.NewReader("")
+	i, err = parameter.ParseFromReader(reader, "test.txt")
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, i)
+}
+
+func TestParseObjecFromFile(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeObjectFromFile,
+		WithDefault(map[string]interface{}{"default": "default"}),
+	)
+
+	reader := strings.NewReader(`{"test":"test"}`)
+	i, err := parameter.ParseFromReader(reader, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": "test"}, i)
+
+	reader = strings.NewReader(`{"test":"test"`)
+	_, err = parameter.ParseFromReader(reader, "test.json")
+	assert.Error(t, err)
+
+	reader = strings.NewReader(`{"test":{"test":"test"}}`)
+	i, err = parameter.ParseFromReader(reader, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": map[string]interface{}{"test": "test"}}, i)
+
+	reader = strings.NewReader(``)
+	_, err = parameter.ParseFromReader(reader, "test.json")
+	assert.Error(t, err)
+
+	// toplevel list
+	reader = strings.NewReader(`["test"]`)
+	v, err := parameter.ParseFromReader(reader, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"test"}, v)
+
+	// toplevel string
+	reader = strings.NewReader(`"test"`)
+	v, err = parameter.ParseFromReader(reader, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, "test", v)
+
+	// toplevel int
+	reader = strings.NewReader(`1`)
+	v, err = parameter.ParseFromReader(reader, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, v)
+
+	// now yaml
+	reader = strings.NewReader(`test: test`)
+	i, err = parameter.ParseFromReader(reader, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": "test"}, i)
+
+	reader = strings.NewReader(`test: test`)
+	i, err = parameter.ParseFromReader(reader, "test.yml")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": "test"}, i)
+
+	// nested object
+	reader = strings.NewReader(`test: {test: test}`)
+	i, err = parameter.ParseFromReader(reader, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": map[string]interface{}{"test": "test"}}, i)
+
+	// toplevel list
+	reader = strings.NewReader("- test\n- test2")
+	v, err = parameter.ParseFromReader(reader, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"test", "test2"}, v)
+
+	// toplevel string
+	reader = strings.NewReader(`test`)
+	v, err = parameter.ParseFromReader(reader, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "test", v)
+}
+
+func TestParseObjectListFromFile(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeObjectListFromFile,
+		WithDefault([]map[string]interface{}{{"default": "default"}}),
+	)
+
+	v, err := parseObjectListFromReader(parameter, `[{"test":"test"}]`, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]interface{}{{"test": "test"}}, v)
+
+	// two elements
+	v, err = parseObjectListFromReader(parameter, `[{"test":"test"},{"test2":"test2"}]`, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]interface{}{{"test": "test"}, {"test2": "test2"}}, v)
+
+	_, err = parseObjectListFromReader(parameter, `{"test":"test"`, "test.json")
+	assert.Error(t, err)
+
+	v, err = parseObjectListFromReader(parameter, `[{"test":{"test":"test"}}]`, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]interface{}{{"test": map[string]interface{}{"test": "test"}}}, v)
+
+	// succeed on empty list
+	v, err = parseObjectListFromReader(parameter, `[]`, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]interface{}{}, v)
+
+	// fail on empty file
+	_, err = parseObjectListFromReader(parameter, ``, "test.json")
+	assert.Error(t, err)
+
+	// fail on toplevel list of string
+	_, err = parseObjectListFromReader(parameter, `["test"]`, "test.json")
+	assert.Error(t, err)
+
+	// now yaml
+	v, err = parseObjectListFromReader(parameter, `- test: test`, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]interface{}{{"test": "test"}}, v)
+
+	v, err = parseObjectListFromReader(parameter, `- test: test`, "test.yml")
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]interface{}{{"test": "test"}}, v)
+
+	// two elements
+	v, err = parseObjectListFromReader(parameter, `- test: test
+- test2: test2`, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]interface{}{{"test": "test"}, {"test2": "test2"}}, v)
+
+	// nested object
+	v, err = parseObjectListFromReader(parameter, `- test: {test: test}`, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]interface{}{{"test": map[string]interface{}{"test": "test"}}}, v)
+
+	// fail on toplevel list of strings
+	_, err = parseObjectListFromReader(parameter, `- test
+- test2`, "test.yaml")
+	assert.Error(t, err)
+
+	// fail on toplevel object
+	_, err = parseObjectListFromReader(parameter, `test: test`, "test.yaml")
+	assert.Error(t, err)
+
+	// succeed on empty list
+	v, err = parseObjectListFromReader(parameter, `[]`, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]interface{}{}, v)
+
+	// fail on empty file
+	_, err = parseObjectListFromReader(parameter, ``, "test.yaml")
+	assert.Error(t, err)
+
+}
+
+func parseObjectListFromReader(parameter *ParameterDefinition, input string, fileName string) ([]map[string]interface{}, error) {
+	reader := strings.NewReader(input)
+	i, err := parameter.ParseFromReader(reader, fileName)
+	if err != nil {
+		return nil, err
+	}
+	v, ok := cast.CastList[map[string]interface{}, interface{}](i.([]interface{}))
+	if !ok {
+		return nil, fmt.Errorf("failed to cast")
+	}
+	return v, nil
+}
+
+func parseObjectFromReader(parameter *ParameterDefinition, input string, fileName string) (map[string]interface{}, error) {
+	reader := strings.NewReader(input)
+	i, err := parameter.ParseFromReader(reader, fileName)
+	if err != nil {
+		return nil, err
+	}
+	v, ok := i.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to cast")
+	}
+	return v, nil
+}
+
+func TestParseStringFromFile(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeStringFromFile,
+		WithDefault("default"),
+	)
+
+	reader := strings.NewReader("test")
+	i, err := parameter.ParseFromReader(reader, "test.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "test", i)
+
+	// multiline
+	reader = strings.NewReader("test\ntest2")
+	i, err = parameter.ParseFromReader(reader, "test.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "test\ntest2", i)
+
+	reader = strings.NewReader("")
+	i, err = parameter.ParseFromReader(reader, "test.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "", i)
+}
+
+func TestParseKeyFromFile(t *testing.T) {
+	parameter := NewParameterDefinition("test", ParameterTypeKeyValue,
+		WithDefault("default"),
+	)
+
+	// from json
+	v, err := parseObjectFromReader(parameter, `{"test":"test"}`, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": "test"}, v)
+
+	v, err = parseObjectFromReader(parameter, `{"test":1}`, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": 1.0}, v)
+
+	v, err = parseObjectFromReader(parameter, `{"test":["test"]}`, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": []interface{}{"test"}}, v)
+
+	// succeed on empty dict
+	v, err = parseObjectFromReader(parameter, `{}`, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{}, v)
+
+	// fail on empty file
+	_, err = parseObjectFromReader(parameter, ``, "test.json")
+	assert.Error(t, err)
+
+	// yaml now
+	v, err = parseObjectFromReader(parameter, `test: test`, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": "test"}, v)
+
+	v, err = parseObjectFromReader(parameter, `test: 1`, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": 1}, v)
+
+	v, err = parseObjectFromReader(parameter, `test: ["test"]`, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": []interface{}{"test"}}, v)
+
+	// succeed on empty dict
+	v, err = parseObjectFromReader(parameter, `{}`, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{}, v)
+
+	// fail on empty file
+	_, err = parseObjectFromReader(parameter, ``, "test.yaml")
+	assert.Error(t, err)
+}

--- a/pkg/cmds/parameters/parse_test.go
+++ b/pkg/cmds/parameters/parse_test.go
@@ -527,4 +527,10 @@ func TestParseKeyFromFile(t *testing.T) {
 	// fail on empty file
 	_, err = parseObjectFromReader(parameter, ``, "test.yaml")
 	assert.Error(t, err)
+
+	// try CSV
+	v, err = parseObjectFromReader(parameter, `test,test2
+test,test2`, "test.csv")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": "test", "test2": "test2"}, v)
 }

--- a/pkg/cmds/parameters/parse_test.go
+++ b/pkg/cmds/parameters/parse_test.go
@@ -211,6 +211,63 @@ func TestParseStringListFromReader(t *testing.T) {
 	i, err = parameter.ParseFromReader(reader, "test.txt")
 	require.NoError(t, err)
 	assert.Equal(t, []string{}, i)
+
+	// try single column CSV with header
+	reader = strings.NewReader("test\ntest2\ntest3\ntest4")
+	i, err = parameter.ParseFromReader(reader, "test.csv")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test2", "test3", "test4"}, i)
+
+	// test single string list json
+	reader = strings.NewReader(`["test","test2"]`)
+	i, err = parameter.ParseFromReader(reader, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test", "test2"}, i)
+
+	// fail single string
+	reader = strings.NewReader(`"test"`)
+	_, err = parameter.ParseFromReader(reader, "test.json")
+	assert.Error(t, err)
+
+	// test fail int
+	reader = strings.NewReader(`1`)
+	_, err = parameter.ParseFromReader(reader, "test.json")
+	assert.Error(t, err)
+
+	// test fail int list
+	reader = strings.NewReader(`[1,2]`)
+	_, err = parameter.ParseFromReader(reader, "test.json")
+	assert.Error(t, err)
+
+	// test fail mixed list
+	reader = strings.NewReader(`["test",1]`)
+	_, err = parameter.ParseFromReader(reader, "test.json")
+	assert.Error(t, err)
+
+	// test fail empty json
+	reader = strings.NewReader(`{}`)
+	_, err = parameter.ParseFromReader(reader, "test.json")
+	assert.Error(t, err)
+
+	// test succeed empty list
+	reader = strings.NewReader(`[]`)
+	i, err = parameter.ParseFromReader(reader, "test.json")
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, i)
+
+	// test yaml
+	reader = strings.NewReader(`- test
+- test2`)
+	i, err = parameter.ParseFromReader(reader, "test.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test", "test2"}, i)
+
+	// test empty csv (just headers)
+	reader = strings.NewReader(`test`)
+	i, err = parameter.ParseFromReader(reader, "test.csv")
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, i)
+
 }
 
 func TestParseObjectFromFile(t *testing.T) {

--- a/pkg/cmds/parameters/parse_test.go
+++ b/pkg/cmds/parameters/parse_test.go
@@ -213,7 +213,7 @@ func TestParseStringListFromReader(t *testing.T) {
 	assert.Equal(t, []string{}, i)
 }
 
-func TestParseObjecFromFile(t *testing.T) {
+func TestParseObjectFromFile(t *testing.T) {
 	parameter := NewParameterDefinition("test", ParameterTypeObjectFromFile,
 		WithDefault(map[string]interface{}{"default": "default"}),
 	)
@@ -282,6 +282,20 @@ func TestParseObjecFromFile(t *testing.T) {
 	v, err = parameter.ParseFromReader(reader, "test.yaml")
 	require.NoError(t, err)
 	assert.Equal(t, "test", v)
+
+	// now, one-line CSV with headers
+	reader = strings.NewReader(`test,test2
+test,test2`)
+	i, err = parameter.ParseFromReader(reader, "test.csv")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{"test": "test", "test2": "test2"}, i)
+
+	// fail on 2 line CSV
+	reader = strings.NewReader(`test,test2
+test,test2
+test,test2`)
+	_, err = parameter.ParseFromReader(reader, "test.csv")
+	assert.Error(t, err)
 }
 
 func TestParseObjectListFromFile(t *testing.T) {

--- a/pkg/helpers/cast/cast.go
+++ b/pkg/helpers/cast/cast.go
@@ -129,20 +129,6 @@ func CastInterfaceToStringMap[To any, From any](m interface{}) (map[string]To, b
 	}
 }
 
-func CastMapMember[To any](m map[string]interface{}, k string) (*To, bool) {
-	v, ok := m[k]
-	if !ok {
-		return nil, false
-	}
-
-	casted, ok := v.(To)
-	if !ok {
-		return nil, false
-	}
-
-	return &casted, true
-}
-
 func CastMapToInterfaceMap[From any](m map[string]From) map[string]interface{} {
 	ret := map[string]interface{}{}
 
@@ -274,4 +260,32 @@ func CastInterfaceToFloatList[To FloatNumber](i interface{}) ([]To, bool) {
 	default:
 		return nil, false
 	}
+}
+
+func CastStringMap2[To any, From any](m interface{}) (map[string]To, bool) {
+	casted, ok := m.(map[string]From)
+	if !ok {
+		// try to cast to map[string]interface{}
+		casted2, ok := m.(map[string]interface{})
+		if !ok {
+			return map[string]To{}, false
+		}
+		return CastStringMap[To, interface{}](casted2)
+	}
+
+	return CastStringMap[To, From](casted)
+}
+
+func CastMapMember[To any](m map[string]interface{}, k string) (*To, bool) {
+	v, ok := m[k]
+	if !ok {
+		return nil, false
+	}
+
+	casted, ok := v.(To)
+	if !ok {
+		return nil, false
+	}
+
+	return &casted, true
 }


### PR DESCRIPTION
Closes #233

- :tractor: Split out parsing into its own separate files for better unit test visibility
- :sparkles: :umbrella: Add tons of unit tests
- :sparkles: Add TSV/CSV parsing for object from file
- :sparkles: Add CSV to ObjectListFromFile
- :sparkles: Add CSV support to keyvalue
