### PR TITLE
:ambulance: Make output-file work with all formatters

### DIFF
--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -97,7 +97,7 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 	if ofs.Output == "json" {
 		of = formatters.NewJSONOutputFormatter(ofs.OutputAsObjects)
 	} else if ofs.Output == "yaml" {
-		of = formatters.NewYAMLOutputFormatter()
+		of = formatters.NewYAMLOutputFormatter(ofs.OutputFile)
 	} else if ofs.Output == "excel" {
 		if ofs.OutputFile == "" {
 			return nil, errors.New("output-file is required for excel output")

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -119,7 +119,7 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 			tsvOf.WithHeaders = ofs.WithHeaders
 			of = tsvOf
 		} else {
-			of = formatters.NewTableOutputFormatter(ofs.TableFormat)
+			of = formatters.NewTableOutputFormatter(ofs.TableFormat, ofs.OutputFile)
 		}
 		of.AddTableMiddleware(table.NewFlattenObjectMiddleware())
 	} else if ofs.Output == "template" {

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -95,7 +95,7 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 
 	var of formatters.OutputFormatter
 	if ofs.Output == "json" {
-		of = formatters.NewJSONOutputFormatter(ofs.OutputAsObjects)
+		of = formatters.NewJSONOutputFormatter(ofs.OutputAsObjects, ofs.OutputFile)
 	} else if ofs.Output == "yaml" {
 		of = formatters.NewYAMLOutputFormatter(ofs.OutputFile)
 	} else if ofs.Output == "excel" {

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -15,6 +15,7 @@ import (
 
 type TemplateFormatterSettings struct {
 	TemplateFuncMaps []template.FuncMap
+	OutputFile       string
 	AdditionalData   map[string]interface{} `glazed.parameter:"template-data"`
 }
 
@@ -107,13 +108,13 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 		of.AddTableMiddleware(table.NewFlattenObjectMiddleware())
 	} else if ofs.Output == "table" {
 		if ofs.TableFormat == "csv" {
-			csvOf := formatters.NewCSVOutputFormatter()
+			csvOf := formatters.NewCSVOutputFormatter(ofs.OutputFile)
 			csvOf.WithHeaders = ofs.WithHeaders
 			r, _ := utf8.DecodeRuneInString(ofs.CsvSeparator)
 			csvOf.Separator = r
 			of = csvOf
 		} else if ofs.TableFormat == "tsv" {
-			tsvOf := formatters.NewTSVOutputFormatter()
+			tsvOf := formatters.NewTSVOutputFormatter(ofs.OutputFile)
 			tsvOf.WithHeaders = ofs.WithHeaders
 			of = tsvOf
 		} else {

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -13,9 +13,10 @@ import (
 	"unicode/utf8"
 )
 
+// TemplateFormatterSettings is probably obsolete...
 type TemplateFormatterSettings struct {
 	TemplateFuncMaps []template.FuncMap
-	OutputFile       string
+	OutputFile       string                 `glazed.parameter:"output-file"`
 	AdditionalData   map[string]interface{} `glazed.parameter:"template-data"`
 }
 
@@ -124,6 +125,7 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 	} else if ofs.Output == "template" {
 		if ofs.TemplateFormatterSettings == nil {
 			ofs.TemplateFormatterSettings = &TemplateFormatterSettings{
+				OutputFile: ofs.OutputFile,
 				TemplateFuncMaps: []template.FuncMap{
 					sprig.TxtFuncMap(),
 					templating.TemplateFuncs,
@@ -131,11 +133,7 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 				AdditionalData: make(map[string]interface{}),
 			}
 		}
-		of = formatters.NewTemplateOutputFormatter(
-			ofs.Template,
-			ofs.TemplateFormatterSettings.TemplateFuncMaps,
-			ofs.TemplateFormatterSettings.AdditionalData,
-		)
+		of = formatters.NewTemplateOutputFormatter(ofs.Template, ofs.TemplateFormatterSettings.TemplateFuncMaps, ofs.TemplateFormatterSettings.AdditionalData, ofs.TemplateFormatterSettings.OutputFile)
 	} else {
 		return nil, errors.Errorf("Unknown output format: " + ofs.Output)
 	}

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -406,6 +406,7 @@ func (l *YAMLFSCommandLoader) LoadCommandsFromFS(
 				}, options...)
 				commands, err := l.loader.LoadCommandFromYAML(file, options_...)
 				if err != nil {
+					log.Debug().Err(err).Str("file", fileName).Msg("Could not load command from file")
 					return nil, err
 				}
 				if len(commands) != 1 {
@@ -433,6 +434,7 @@ func (l *YAMLFSCommandLoader) LoadCommandsFromFS(
 						log.Debug().Str("file", fileName).Msg("Loading alias from file")
 						aliases, err := l.loader.LoadCommandAliasFromYAML(file)
 						if err != nil {
+							log.Debug().Err(err).Str("file", fileName).Msg("Could not load alias from file")
 							return nil, err
 						}
 						if len(aliases) != 1 {

--- a/pkg/cmds/processor.go
+++ b/pkg/cmds/processor.go
@@ -57,7 +57,7 @@ type SimpleGlazeProcessor struct {
 }
 
 func NewSimpleGlazeProcessor(oms ...middlewares.ObjectMiddleware) *SimpleGlazeProcessor {
-	formatter := formatters.NewTableOutputFormatter("csv")
+	formatter := formatters.NewTableOutputFormatter("csv", "")
 	return &SimpleGlazeProcessor{
 		GlazeProcessor: NewGlazeProcessor(formatter, oms...),
 		formatter:      formatter,

--- a/pkg/formatters/csv.go
+++ b/pkg/formatters/csv.go
@@ -5,28 +5,33 @@ import (
 	"fmt"
 	middlewares2 "github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/rs/zerolog/log"
+	"os"
 	"strings"
 )
 
 type CSVOutputFormatter struct {
 	Table       *types.Table
 	middlewares []middlewares2.TableMiddleware
+	OutputFile  string
 	WithHeaders bool
 	Separator   rune
 }
 
-func NewCSVOutputFormatter() *CSVOutputFormatter {
+func NewCSVOutputFormatter(outputFile string) *CSVOutputFormatter {
 	return &CSVOutputFormatter{
 		Table:       types.NewTable(),
 		middlewares: []middlewares2.TableMiddleware{},
+		OutputFile:  outputFile,
 		WithHeaders: true,
 		Separator:   ',',
 	}
 }
 
-func NewTSVOutputFormatter() *CSVOutputFormatter {
+func NewTSVOutputFormatter(outputFile string) *CSVOutputFormatter {
 	return &CSVOutputFormatter{
 		Table:       types.NewTable(),
+		OutputFile:  outputFile,
 		middlewares: []middlewares2.TableMiddleware{},
 		WithHeaders: true,
 		Separator:   '\t',
@@ -100,6 +105,15 @@ func (f *CSVOutputFormatter) Output() (string, error) {
 
 	if err := w.Error(); err != nil {
 		return "", err
+	}
+
+	if f.OutputFile != "" {
+		log.Debug().Str("file", f.OutputFile).Msg("Writing output to file")
+		err := os.WriteFile(f.OutputFile, []byte(buf.String()), 0644)
+		if err != nil {
+			return "", err
+		}
+		return "", nil
 	}
 
 	return buf.String(), nil

--- a/pkg/formatters/csv_test.go
+++ b/pkg/formatters/csv_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCSVRenameEndToEnd(t *testing.T) {
-	of := NewCSVOutputFormatter()
+	of := NewCSVOutputFormatter("")
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/json.go
+++ b/pkg/formatters/json.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/rs/zerolog/log"
+	"os"
 )
 
 type JSONOutputFormatter struct {
 	OutputIndividualRows bool
+	OutputFile           string
 	Table                *types.Table
 	middlewares          []middlewares.TableMiddleware
 }
@@ -57,6 +60,16 @@ func (J *JSONOutputFormatter) Output() (string, error) {
 			}
 			buf.Write(jsonBytes)
 		}
+
+		if J.OutputFile != "" {
+			log.Debug().Str("file", J.OutputFile).Msg("Writing output to file")
+			err := os.WriteFile(J.OutputFile, buf.Bytes(), 0644)
+			if err != nil {
+				return "", err
+			}
+			return "", nil
+		}
+
 		return buf.String(), nil
 	} else {
 		// TODO(manuel, 2022-11-21) We should build a custom JSONMarshal for Table
@@ -68,14 +81,25 @@ func (J *JSONOutputFormatter) Output() (string, error) {
 		if err != nil {
 			return "", err
 		}
+
+		if J.OutputFile != "" {
+			log.Debug().Str("file", J.OutputFile).Msg("Writing output to file")
+			err := os.WriteFile(J.OutputFile, jsonBytes, 0644)
+			if err != nil {
+				return "", err
+			}
+			return "", nil
+		}
+
 		return string(jsonBytes), nil
 	}
 }
 
-func NewJSONOutputFormatter(outputAsObjects bool) *JSONOutputFormatter {
+func NewJSONOutputFormatter(outputAsObjects bool, outputFile string) *JSONOutputFormatter {
 	return &JSONOutputFormatter{
 		OutputIndividualRows: outputAsObjects,
 		Table:                types.NewTable(),
+		OutputFile:           outputFile,
 		middlewares:          []middlewares.TableMiddleware{},
 	}
 }

--- a/pkg/formatters/json_test.go
+++ b/pkg/formatters/json_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestJSONRenameEndToEnd(t *testing.T) {
-	of := NewJSONOutputFormatter(false)
+	of := NewJSONOutputFormatter(false, "")
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/table_test.go
+++ b/pkg/formatters/table_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTableRenameEndToEnd(t *testing.T) {
-	of := NewTableOutputFormatter("markdown")
+	of := NewTableOutputFormatter("markdown", "")
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/template_test.go
+++ b/pkg/formatters/template_test.go
@@ -14,14 +14,10 @@ import (
 func TestTemplateRenameEndToEnd(t *testing.T) {
 	// template that gets rows[0].b
 	tmpl := `{{ (index .rows 0).b }}`
-	of := NewTemplateOutputFormatter(
-		tmpl,
-		[]template.FuncMap{
-			sprig.TxtFuncMap(),
-			templating.TemplateFuncs,
-		},
-		make(map[string]interface{}),
-	)
+	of := NewTemplateOutputFormatter(tmpl, []template.FuncMap{
+		sprig.TxtFuncMap(),
+		templating.TemplateFuncs,
+	}, make(map[string]interface{}), "")
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/yaml.go
+++ b/pkg/formatters/yaml.go
@@ -3,11 +3,14 @@ package formatters
 import (
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
+	"os"
 )
 
 type YAMLOutputFormatter struct {
 	Table       *types.Table
+	OutputFile  string
 	middlewares []middlewares.TableMiddleware
 }
 
@@ -56,12 +59,23 @@ func (Y *YAMLOutputFormatter) Output() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	if Y.OutputFile != "" {
+		log.Debug().Str("file", Y.OutputFile).Msg("Writing output to file")
+		err := os.WriteFile(Y.OutputFile, d, 0644)
+		if err != nil {
+			return "", err
+		}
+		return "", nil
+	}
+
 	return string(d), nil
 }
 
-func NewYAMLOutputFormatter() *YAMLOutputFormatter {
+func NewYAMLOutputFormatter(outputFile string) *YAMLOutputFormatter {
 	return &YAMLOutputFormatter{
 		Table:       types.NewTable(),
+		OutputFile:  outputFile,
 		middlewares: []middlewares.TableMiddleware{},
 	}
 }

--- a/pkg/formatters/yaml_test.go
+++ b/pkg/formatters/yaml_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestYAMLRenameEndToEnd(t *testing.T) {
-	of := NewYAMLOutputFormatter()
+	of := NewYAMLOutputFormatter("")
 	renames := map[string]string{
 		"a": "b",
 	}


### PR DESCRIPTION
Closes #248

- :ambulance: Make output-file work with CSV
- :ambulance: Add OutputFile to templateoutput formatter
- :ambulance: Add OutputFile to templateoutput formatter
- :ambulance: Add output-file to yaml
- :ambulance: Add output-file to json
