### PR TITLE
Add multiple output files

### DIFF
--- a/cmd/glaze/cmds/html/parse_test.go
+++ b/cmd/glaze/cmds/html/parse_test.go
@@ -1,7 +1,7 @@
 package html
 
 import (
-	"github.com/go-go-golems/glazed/pkg/formatters/table"
+	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/pkg/errors"
@@ -14,7 +14,7 @@ import (
 
 type TestProcessor struct {
 	Objects   []map[string]interface{}
-	formatter table.OutputFormatter
+	formatter formatters.OutputFormatter
 }
 
 func NewTestProcessor() *TestProcessor {
@@ -53,7 +53,7 @@ func (t *TestProcessor) ProcessInputObject(obj map[string]interface{}) error {
 	return nil
 }
 
-func (t *TestProcessor) OutputFormatter() table.OutputFormatter {
+func (t *TestProcessor) OutputFormatter() formatters.OutputFormatter {
 	return nil
 }
 

--- a/cmd/glaze/cmds/html/parse_test.go
+++ b/cmd/glaze/cmds/html/parse_test.go
@@ -1,7 +1,7 @@
 package html
 
 import (
-	"github.com/go-go-golems/glazed/pkg/formatters"
+	"github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/pkg/errors"
@@ -14,7 +14,7 @@ import (
 
 type TestProcessor struct {
 	Objects   []map[string]interface{}
-	formatter formatters.OutputFormatter
+	formatter table.OutputFormatter
 }
 
 func NewTestProcessor() *TestProcessor {
@@ -53,7 +53,7 @@ func (t *TestProcessor) ProcessInputObject(obj map[string]interface{}) error {
 	return nil
 }
 
-func (t *TestProcessor) OutputFormatter() formatters.OutputFormatter {
+func (t *TestProcessor) OutputFormatter() table.OutputFormatter {
 	return nil
 }
 

--- a/cmd/glaze/doc/examples/output/multiple-output-file.md
+++ b/cmd/glaze/doc/examples/output/multiple-output-file.md
@@ -1,0 +1,79 @@
+---
+Title: Outputting multiple output files
+Slug: output-multiple-files
+Command: glaze
+Short: |
+  ```
+  glaze csv misc/test-data/employees.csv --output csv \
+     --output-file /tmp/employee.csv --output-multiple-files
+  ```
+Topics:
+- templates
+- output
+Commands:
+- json
+- yaml
+- csv
+Flags:
+- output-multiple-files
+- output-file-template
+- output-file
+IsTemplate: false
+IsTopLevel: false
+ShowPerDefault: false
+SectionType: Example
+---
+
+You can output each row into a separate file using the `--output-multiple-files` flag.
+
+When using this flag, you must also specify the `--output-file` flag or the `--output-file-template` flag.
+
+### Using the `--output-file` flag
+
+When using the `--output-file` flag, the output file name will be the basename with the row index appended.
+For example, if you specify `--output-file /tmp/employee.csv`, 
+the output files will be named `/tmp/employee-0.csv`, `/tmp/employee-1.csv`, etc.
+
+
+``` 
+❯ glaze csv misc/test-data/employees.csv --output csv --output-file /tmp/employee.csv --output-multiple-files             
+Written output to /tmp/employee-0.csv
+Written output to /tmp/employee-1.csv
+Written output to /tmp/employee-2.csv
+Written output to /tmp/employee-3.csv
+Written output to /tmp/employee-4.csv
+Written output to /tmp/employee-5.csv
+Written output to /tmp/employee-6.csv
+Written output to /tmp/employee-7.csv
+Written output to /tmp/employee-8.csv
+Written output to /tmp/employee-9.csv
+
+❯ cat /tmp/employee-0.csv 
+First Name,Last Name,Title,Salary
+John,Doe,Manager,"$75,000"
+```
+
+
+### Using the `--output-file-template` flag
+
+When using the `--output-file-template` flag, the output file name as a template. 
+The row values are available as variables in the template, as well as the row index as the variable `rowIndex`.
+
+``` 
+❯ glaze csv misc/test-data/employees.csv --output csv --output-file /tmp/employee.csv --output-multiple-files --output-file-template '/tmp/employee-{{.Title}}-{{.rowIndex}}.csv' 
+Written output to /tmp/employee-Manager-0.csv
+Written output to /tmp/employee-Software Engineer-1.csv
+Written output to /tmp/employee-Sales Representative-2.csv
+Written output to /tmp/employee-Marketing Manager-3.csv
+Written output to /tmp/employee-Web Developer-4.csv
+Written output to /tmp/employee-Accountant-5.csv
+Written output to /tmp/employee-HR Manager-6.csv
+Written output to /tmp/employee-Software Developer-7.csv
+Written output to /tmp/employee-Customer Service Representative-8.csv
+Written output to /tmp/employee-Data Analyst-9.csv
+
+❯ cat /tmp/employee-Software\ Developer-7.csv 
+First Name,Last Name,Title,Salary
+Sarah,Taylor,Software Developer,"$80,000"
+
+```

--- a/cmd/glaze/doc/topics/03-templates.md
+++ b/cmd/glaze/doc/topics/03-templates.md
@@ -148,13 +148,13 @@ The template is rendered with an object that has a `rows` field.
 
 ```
 
-Additional data can be provided using the `--template-data` argument,
-either as `:` separated pairs, themselves separated by commas,
-or by providing a json or yaml file using a path preceded by a `@`.
+Additional data can be provided using the `--template-data` argument
+which should point to a JSON/CSV/YAML file containing the data to be 
+loaded.
 
 ``` 
 ❯ glaze json misc/test-data/[123].json \
-    --template-data @misc/test-data/book.json \
+    --template-data misc/test-data/book.json \
     --template-file misc/template-file-example2.tmpl.md \
     --output template
 # The Raven
@@ -178,34 +178,6 @@ Author: Edgar Allan Poe
 - a: 100
 ```
 
-or 
-
-``` 
-❯ glaze json misc/test-data/[123].json \
-     --template-data "author:J.R.R Tolkien,title:The Lord of the Rings" \
-     --template-file misc/template-file-example2.tmpl.md \
-     --output template
-# The Lord of the Rings
-
-Author: J.R.R Tolkien
-
-
-## Row 2
-
-- c: [3 4 5]
-- a: 1
-  
-## Row 20
-
-- c: [30 40 50]
-- a: 10
-  
-## Row 200
-
-- c: [300]
-- a: 100
-  %       
-  ```
 
 ## Templating functions
 

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	"github.com/go-go-golems/glazed/pkg/formatters"
+	"github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/helpers"
 	"github.com/go-go-golems/glazed/pkg/helpers/list"
 	strings2 "github.com/go-go-golems/glazed/pkg/helpers/strings"
@@ -377,7 +377,7 @@ func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []cmds.GlazeComma
 // If so, use SetupProcessor instead, and create a proper glazed.GlazeCommand for your command.
 func CreateGlazedProcessorFromCobra(cmd *cobra.Command) (
 	*cmds.GlazeProcessor,
-	formatters.OutputFormatter,
+	table.OutputFormatter,
 	error,
 ) {
 	gpl, err := NewGlazedParameterLayers()

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	"github.com/go-go-golems/glazed/pkg/formatters/table"
+	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/helpers"
 	"github.com/go-go-golems/glazed/pkg/helpers/list"
 	strings2 "github.com/go-go-golems/glazed/pkg/helpers/strings"
@@ -377,7 +377,7 @@ func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []cmds.GlazeComma
 // If so, use SetupProcessor instead, and create a proper glazed.GlazeCommand for your command.
 func CreateGlazedProcessorFromCobra(cmd *cobra.Command) (
 	*cmds.GlazeProcessor,
-	table.OutputFormatter,
+	formatters.OutputFormatter,
 	error,
 ) {
 	gpl, err := NewGlazedParameterLayers()

--- a/pkg/cli/flags/output.yaml
+++ b/pkg/cli/flags/output.yaml
@@ -30,6 +30,15 @@ flags:
     type: stringFromFile
     help: Template file for template output
 
+  - name: output-file-template
+    type: string
+    help: Template for output file name
+
+  - name: output-multiple-files
+    type: bool
+    help: Output multiple files, using the output-file-template if present, otherwise just output-file + index
+    default: false
+
   - name: template-data
     type: stringList
     help: Additional data for template output

--- a/pkg/cli/flags/output.yaml
+++ b/pkg/cli/flags/output.yaml
@@ -40,8 +40,8 @@ flags:
     default: false
 
   - name: template-data
-    type: stringList
-    help: Additional data for template output
+    type: objectFromFile
+    help: Additional data for template output, in JSON/CSV/YAML format
 
   - name: table-format
     type: string

--- a/pkg/cli/glazed_layer.go
+++ b/pkg/cli/glazed_layer.go
@@ -5,7 +5,8 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	"github.com/go-go-golems/glazed/pkg/formatters"
+	"github.com/go-go-golems/glazed/pkg/formatters/simple"
+	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/middlewares/object"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
@@ -369,7 +370,7 @@ func NewGlazedParameterLayers(options ...GlazeParameterLayerOption) (*GlazedPara
 
 func SetupProcessor(ps map[string]interface{}) (
 	*cmds.GlazeProcessor,
-	formatters.OutputFormatter,
+	table2.OutputFormatter,
 	error,
 ) {
 	// TODO(manuel, 2023-03-06): This is where we should check that flags that are mutually incompatible don't clash
@@ -408,11 +409,11 @@ func SetupProcessor(ps map[string]interface{}) (
 		return nil, nil, err
 	}
 
-	var of formatters.OutputFormatter
+	var of table2.OutputFormatter
 	templateSettings.UpdateWithSelectSettings(selectSettings)
 
 	if selectSettings.SelectField != "" {
-		of = formatters.NewSingleColumnFormatter(selectSettings.SelectField, selectSettings.SelectSeparator)
+		of = simple.NewSingleColumnFormatter(selectSettings.SelectField, selectSettings.SelectSeparator)
 	} else {
 		of, err = outputSettings.CreateOutputFormatter()
 		if err != nil {

--- a/pkg/cli/glazed_layer.go
+++ b/pkg/cli/glazed_layer.go
@@ -5,8 +5,8 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/formatters/simple"
-	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/middlewares/object"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
@@ -370,7 +370,7 @@ func NewGlazedParameterLayers(options ...GlazeParameterLayerOption) (*GlazedPara
 
 func SetupProcessor(ps map[string]interface{}) (
 	*cmds.GlazeProcessor,
-	table2.OutputFormatter,
+	formatters.OutputFormatter,
 	error,
 ) {
 	// TODO(manuel, 2023-03-06): This is where we should check that flags that are mutually incompatible don't clash
@@ -409,7 +409,7 @@ func SetupProcessor(ps map[string]interface{}) (
 		return nil, nil, err
 	}
 
-	var of table2.OutputFormatter
+	var of formatters.OutputFormatter
 	templateSettings.UpdateWithSelectSettings(selectSettings)
 
 	if selectSettings.SelectField != "" {

--- a/pkg/cli/glazed_layer.go
+++ b/pkg/cli/glazed_layer.go
@@ -413,7 +413,10 @@ func SetupProcessor(ps map[string]interface{}) (
 	templateSettings.UpdateWithSelectSettings(selectSettings)
 
 	if selectSettings.SelectField != "" {
-		of = simple.NewSingleColumnFormatter(selectSettings.SelectField, selectSettings.SelectSeparator)
+		of = simple.NewSingleColumnFormatter(
+			selectSettings.SelectField,
+			simple.WithSeparator(selectSettings.SelectSeparator),
+		)
 	} else {
 		of, err = outputSettings.CreateOutputFormatter()
 		if err != nil {

--- a/pkg/cli/settings_fields-filters.go
+++ b/pkg/cli/settings_fields-filters.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
+	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -93,7 +93,7 @@ func NewFieldsFilterSettings(ps map[string]interface{}) (*FieldsFilterSettings, 
 	return s, nil
 }
 
-func (ffs *FieldsFilterSettings) AddMiddlewares(of table2.OutputFormatter) {
+func (ffs *FieldsFilterSettings) AddMiddlewares(of formatters.OutputFormatter) {
 	of.AddTableMiddleware(table.NewFieldsFilterMiddleware(ffs.Fields, ffs.Filters))
 	if ffs.RemoveNulls {
 		of.AddTableMiddleware(table.NewRemoveNullsMiddleware())

--- a/pkg/cli/settings_fields-filters.go
+++ b/pkg/cli/settings_fields-filters.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	"github.com/go-go-golems/glazed/pkg/formatters"
+	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -93,7 +93,7 @@ func NewFieldsFilterSettings(ps map[string]interface{}) (*FieldsFilterSettings, 
 	return s, nil
 }
 
-func (ffs *FieldsFilterSettings) AddMiddlewares(of formatters.OutputFormatter) {
+func (ffs *FieldsFilterSettings) AddMiddlewares(of table2.OutputFormatter) {
 	of.AddTableMiddleware(table.NewFieldsFilterMiddleware(ffs.Fields, ffs.Filters))
 	if ffs.RemoveNulls {
 		of.AddTableMiddleware(table.NewRemoveNullsMiddleware())

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -16,7 +16,6 @@ import (
 // TemplateFormatterSettings is probably obsolete...
 type TemplateFormatterSettings struct {
 	TemplateFuncMaps []template.FuncMap
-	OutputFile       string                 `glazed.parameter:"output-file"`
 	AdditionalData   map[string]interface{} `glazed.parameter:"template-data"`
 }
 
@@ -31,18 +30,6 @@ type OutputFormatterSettings struct {
 	CsvSeparator              string `glazed.parameter:"csv-separator"`
 	Template                  string
 	TemplateFormatterSettings *TemplateFormatterSettings
-}
-
-type OutputFlagsDefaults struct {
-	Output          string `glazed.parameter:"output"`
-	OutputFile      string `glazed.parameter:"output-file"`
-	SheetName       string `glazed.parameter:"sheet-name"`
-	TableFormat     string `glazed.parameter:"table-format"`
-	WithHeaders     bool   `glazed.parameter:"with-headers"`
-	CsvSeparator    string `glazed.parameter:"csv-separator"`
-	OutputAsObjects bool   `glazed.parameter:"output-as-objects"`
-	Flatten         bool   `glazed.parameter:"flatten"`
-	TemplateFile    string `glazed.parameter:"template-file"`
 }
 
 //go:embed "flags/output.yaml"
@@ -125,7 +112,6 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 	} else if ofs.Output == "template" {
 		if ofs.TemplateFormatterSettings == nil {
 			ofs.TemplateFormatterSettings = &TemplateFormatterSettings{
-				OutputFile: ofs.OutputFile,
 				TemplateFuncMaps: []template.FuncMap{
 					sprig.TxtFuncMap(),
 					templating.TemplateFuncs,
@@ -133,7 +119,7 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 				AdditionalData: make(map[string]interface{}),
 			}
 		}
-		of = formatters.NewTemplateOutputFormatter(ofs.Template, ofs.TemplateFormatterSettings.TemplateFuncMaps, ofs.TemplateFormatterSettings.AdditionalData, ofs.TemplateFormatterSettings.OutputFile)
+		of = formatters.NewTemplateOutputFormatter(ofs.Template, ofs.TemplateFormatterSettings.TemplateFuncMaps, ofs.TemplateFormatterSettings.AdditionalData, ofs.OutputFile)
 	} else {
 		return nil, errors.Errorf("Unknown output format: " + ofs.Output)
 	}

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -93,10 +93,14 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 		of = json.NewOutputFormatter(
 			json.WithOutputIndividualRows(ofs.OutputAsObjects),
 			json.WithOutputFile(ofs.OutputFile),
+			json.WithOutputMultipleFiles(ofs.OutputMultipleFiles),
+			json.WithOutputFileTemplate(ofs.OutputFileTemplate),
 		)
 	} else if ofs.Output == "yaml" {
 		of = yaml.NewOutputFormatter(
 			yaml.WithYAMLOutputFile(ofs.OutputFile),
+			yaml.WithOutputMultipleFiles(ofs.OutputMultipleFiles),
+			yaml.WithOutputFileTemplate(ofs.OutputFileTemplate),
 		)
 	} else if ofs.Output == "excel" {
 		if ofs.OutputFile == "" {
@@ -105,12 +109,16 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 		of = excel.NewOutputFormatter(
 			excel.WithSheetName(ofs.SheetName),
 			excel.WithOutputFile(ofs.OutputFile),
+			excel.WithOutputMultipleFiles(ofs.OutputMultipleFiles),
+			excel.WithOutputFileTemplate(ofs.OutputFileTemplate),
 		)
 		of.AddTableMiddleware(table.NewFlattenObjectMiddleware())
 	} else if ofs.Output == "table" {
 		if ofs.TableFormat == "csv" {
 			csvOf := csv.NewCSVOutputFormatter(
 				csv.WithOutputFile(ofs.OutputFile),
+				csv.WithOutputMultipleFiles(ofs.OutputMultipleFiles),
+				csv.WithOutputFileTemplate(ofs.OutputFileTemplate),
 			)
 			csvOf.WithHeaders = ofs.WithHeaders
 			r, _ := utf8.DecodeRuneInString(ofs.CsvSeparator)
@@ -119,6 +127,8 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 		} else if ofs.TableFormat == "tsv" {
 			tsvOf := csv.NewTSVOutputFormatter(
 				csv.WithOutputFile(ofs.OutputFile),
+				csv.WithOutputMultipleFiles(ofs.OutputMultipleFiles),
+				csv.WithOutputFileTemplate(ofs.OutputFileTemplate),
 			)
 			tsvOf.WithHeaders = ofs.WithHeaders
 			of = tsvOf
@@ -126,6 +136,8 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 			of = table2.NewOutputFormatter(
 				ofs.TableFormat,
 				table2.WithOutputFile(ofs.OutputFile),
+				table2.WithOutputMultipleFiles(ofs.OutputMultipleFiles),
+				table2.WithOutputFileTemplate(ofs.OutputFileTemplate),
 			)
 		}
 		of.AddTableMiddleware(table.NewFlattenObjectMiddleware())
@@ -144,6 +156,8 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 			template2.WithTemplateFuncMaps(ofs.TemplateFormatterSettings.TemplateFuncMaps),
 			template2.WithAdditionalData(ofs.TemplateFormatterSettings.AdditionalData),
 			template2.WithOutputFile(ofs.OutputFile),
+			template2.WithOutputMultipleFiles(ofs.OutputMultipleFiles),
+			template2.WithOutputFileTemplate(ofs.OutputFileTemplate),
 		)
 	} else {
 		return nil, errors.Errorf("Unknown output format: " + ofs.Output)

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -88,6 +88,12 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 		ofs.TableFormat = "html"
 	}
 
+	if ofs.OutputMultipleFiles {
+		if ofs.OutputFileTemplate == "" && ofs.OutputFile == "" {
+			return nil, errors.New("output-file or output-file-template is required for output-multiple-files")
+		}
+	}
+
 	var of formatters.OutputFormatter
 	if ofs.Output == "json" {
 		of = json.NewOutputFormatter(
@@ -106,11 +112,12 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 		if ofs.OutputFile == "" {
 			return nil, errors.New("output-file is required for excel output")
 		}
+		if ofs.OutputMultipleFiles {
+			return nil, errors.New("output-multiple-files is not supported for excel output")
+		}
 		of = excel.NewOutputFormatter(
 			excel.WithSheetName(ofs.SheetName),
 			excel.WithOutputFile(ofs.OutputFile),
-			excel.WithOutputMultipleFiles(ofs.OutputMultipleFiles),
-			excel.WithOutputFileTemplate(ofs.OutputFileTemplate),
 		)
 		of.AddTableMiddleware(table.NewFlattenObjectMiddleware())
 	} else if ofs.Output == "table" {

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -22,21 +22,21 @@ import (
 // TemplateFormatterSettings is probably obsolete...
 type TemplateFormatterSettings struct {
 	TemplateFuncMaps []template.FuncMap
-	AdditionalData   map[string]interface{} `glazed.parameter:"template-data"`
 }
 
 type OutputFormatterSettings struct {
-	Output                    string `glazed.parameter:"output"`
-	OutputFile                string `glazed.parameter:"output-file"`
-	OutputFileTemplate        string `glazed.parameter:"output-file-template"`
-	OutputMultipleFiles       bool   `glazed.parameter:"output-multiple-files"`
-	SheetName                 string `glazed.parameter:"sheet-name"`
-	TableFormat               string `glazed.parameter:"table-format"`
-	OutputAsObjects           bool   `glazed.parameter:"output-as-objects"`
-	FlattenObjects            bool   `glazed.parameter:"flatten"`
-	WithHeaders               bool   `glazed.parameter:"with-headers"`
-	CsvSeparator              string `glazed.parameter:"csv-separator"`
-	Template                  string
+	Output                    string                 `glazed.parameter:"output"`
+	OutputFile                string                 `glazed.parameter:"output-file"`
+	OutputFileTemplate        string                 `glazed.parameter:"output-file-template"`
+	OutputMultipleFiles       bool                   `glazed.parameter:"output-multiple-files"`
+	SheetName                 string                 `glazed.parameter:"sheet-name"`
+	TableFormat               string                 `glazed.parameter:"table-format"`
+	OutputAsObjects           bool                   `glazed.parameter:"output-as-objects"`
+	FlattenObjects            bool                   `glazed.parameter:"flatten"`
+	WithHeaders               bool                   `glazed.parameter:"with-headers"`
+	CsvSeparator              string                 `glazed.parameter:"csv-separator"`
+	Template                  string                 `glazed.parameter:"template-file"`
+	TemplateData              map[string]interface{} `glazed.parameter:"template-data"`
 	TemplateFormatterSettings *TemplateFormatterSettings
 }
 
@@ -155,13 +155,12 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 					sprig.TxtFuncMap(),
 					templating.TemplateFuncs,
 				},
-				AdditionalData: make(map[string]interface{}),
 			}
 		}
 		of = template2.NewOutputFormatter(
 			ofs.Template,
 			template2.WithTemplateFuncMaps(ofs.TemplateFormatterSettings.TemplateFuncMaps),
-			template2.WithAdditionalData(ofs.TemplateFormatterSettings.AdditionalData),
+			template2.WithAdditionalData(ofs.TemplateData),
 			template2.WithOutputFile(ofs.OutputFile),
 			template2.WithOutputMultipleFiles(ofs.OutputMultipleFiles),
 			template2.WithOutputFileTemplate(ofs.OutputFileTemplate),

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -89,31 +89,43 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (table2.OutputFormat
 
 	var of table2.OutputFormatter
 	if ofs.Output == "json" {
-		of = json.NewJSONOutputFormatter(ofs.OutputAsObjects, ofs.OutputFile)
+		of = json.NewJSONOutputFormatter(
+			json.WithOutputIndividualRows(ofs.OutputAsObjects),
+			json.WithOutputFile(ofs.OutputFile),
+		)
 	} else if ofs.Output == "yaml" {
-		of = yaml.NewYAMLOutputFormatter(ofs.OutputFile)
+		of = yaml.NewYAMLOutputFormatter(
+			yaml.WithYAMLOutputFile(ofs.OutputFile),
+		)
 	} else if ofs.Output == "excel" {
 		if ofs.OutputFile == "" {
 			return nil, errors.New("output-file is required for excel output")
 		}
 		of = excel.NewExcelOutputFormatter(
-			ofs.SheetName,
-			ofs.OutputFile,
+			excel.WithSheetName(ofs.SheetName),
+			excel.WithOutputFile(ofs.OutputFile),
 		)
 		of.AddTableMiddleware(table.NewFlattenObjectMiddleware())
 	} else if ofs.Output == "table" {
 		if ofs.TableFormat == "csv" {
-			csvOf := csv.NewCSVOutputFormatter(ofs.OutputFile)
+			csvOf := csv.NewCSVOutputFormatter(
+				csv.WithOutputFile(ofs.OutputFile),
+			)
 			csvOf.WithHeaders = ofs.WithHeaders
 			r, _ := utf8.DecodeRuneInString(ofs.CsvSeparator)
 			csvOf.Separator = r
 			of = csvOf
 		} else if ofs.TableFormat == "tsv" {
-			tsvOf := csv.NewTSVOutputFormatter(ofs.OutputFile)
+			tsvOf := csv.NewTSVOutputFormatter(
+				csv.WithOutputFile(ofs.OutputFile),
+			)
 			tsvOf.WithHeaders = ofs.WithHeaders
 			of = tsvOf
 		} else {
-			of = table2.NewTableOutputFormatter(ofs.TableFormat, ofs.OutputFile)
+			of = table2.NewTableOutputFormatter(
+				ofs.TableFormat,
+				table2.WithOutputFile(ofs.OutputFile),
+			)
 		}
 		of.AddTableMiddleware(table.NewFlattenObjectMiddleware())
 	} else if ofs.Output == "template" {
@@ -126,7 +138,12 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (table2.OutputFormat
 				AdditionalData: make(map[string]interface{}),
 			}
 		}
-		of = template2.NewTemplateOutputFormatter(ofs.Template, ofs.TemplateFormatterSettings.TemplateFuncMaps, ofs.TemplateFormatterSettings.AdditionalData, ofs.OutputFile)
+		of = template2.NewTemplateOutputFormatter(
+			ofs.Template,
+			template2.WithTemplateFuncMaps(ofs.TemplateFormatterSettings.TemplateFuncMaps),
+			template2.WithAdditionalData(ofs.TemplateFormatterSettings.AdditionalData),
+			template2.WithOutputFile(ofs.OutputFile),
+		)
 	} else {
 		return nil, errors.Errorf("Unknown output format: " + ofs.Output)
 	}

--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Masterminds/sprig"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/formatters/csv"
 	"github.com/go-go-golems/glazed/pkg/formatters/excel"
 	"github.com/go-go-golems/glazed/pkg/formatters/json"
@@ -72,7 +73,7 @@ func NewOutputFormatterSettings(ps map[string]interface{}) (*OutputFormatterSett
 	return s, nil
 }
 
-func (ofs *OutputFormatterSettings) CreateOutputFormatter() (table2.OutputFormatter, error) {
+func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFormatter, error) {
 	if ofs.Output == "csv" {
 		ofs.Output = "table"
 		ofs.TableFormat = "csv"
@@ -87,21 +88,21 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (table2.OutputFormat
 		ofs.TableFormat = "html"
 	}
 
-	var of table2.OutputFormatter
+	var of formatters.OutputFormatter
 	if ofs.Output == "json" {
-		of = json.NewJSONOutputFormatter(
+		of = json.NewOutputFormatter(
 			json.WithOutputIndividualRows(ofs.OutputAsObjects),
 			json.WithOutputFile(ofs.OutputFile),
 		)
 	} else if ofs.Output == "yaml" {
-		of = yaml.NewYAMLOutputFormatter(
+		of = yaml.NewOutputFormatter(
 			yaml.WithYAMLOutputFile(ofs.OutputFile),
 		)
 	} else if ofs.Output == "excel" {
 		if ofs.OutputFile == "" {
 			return nil, errors.New("output-file is required for excel output")
 		}
-		of = excel.NewExcelOutputFormatter(
+		of = excel.NewOutputFormatter(
 			excel.WithSheetName(ofs.SheetName),
 			excel.WithOutputFile(ofs.OutputFile),
 		)
@@ -122,7 +123,7 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (table2.OutputFormat
 			tsvOf.WithHeaders = ofs.WithHeaders
 			of = tsvOf
 		} else {
-			of = table2.NewTableOutputFormatter(
+			of = table2.NewOutputFormatter(
 				ofs.TableFormat,
 				table2.WithOutputFile(ofs.OutputFile),
 			)
@@ -138,7 +139,7 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (table2.OutputFormat
 				AdditionalData: make(map[string]interface{}),
 			}
 		}
-		of = template2.NewTemplateOutputFormatter(
+		of = template2.NewOutputFormatter(
 			ofs.Template,
 			template2.WithTemplateFuncMaps(ofs.TemplateFormatterSettings.TemplateFuncMaps),
 			template2.WithAdditionalData(ofs.TemplateFormatterSettings.AdditionalData),

--- a/pkg/cli/settings_rename.go
+++ b/pkg/cli/settings_rename.go
@@ -3,7 +3,7 @@ package cli
 import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
-	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
+	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/helpers/cast"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
@@ -20,7 +20,7 @@ type RenameSettings struct {
 	YamlFile      string
 }
 
-func (rs *RenameSettings) AddMiddlewares(of table2.OutputFormatter) error {
+func (rs *RenameSettings) AddMiddlewares(of formatters.OutputFormatter) error {
 	if len(rs.RenameFields) > 0 || len(rs.RenameRegexps) > 0 {
 		of.AddTableMiddleware(table.NewRenameColumnMiddleware(rs.RenameFields, rs.RenameRegexps))
 	}

--- a/pkg/cli/settings_rename.go
+++ b/pkg/cli/settings_rename.go
@@ -3,7 +3,7 @@ package cli
 import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
-	"github.com/go-go-golems/glazed/pkg/formatters"
+	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/helpers/cast"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
@@ -20,7 +20,7 @@ type RenameSettings struct {
 	YamlFile      string
 }
 
-func (rs *RenameSettings) AddMiddlewares(of formatters.OutputFormatter) error {
+func (rs *RenameSettings) AddMiddlewares(of table2.OutputFormatter) error {
 	if len(rs.RenameFields) > 0 || len(rs.RenameRegexps) > 0 {
 		of.AddTableMiddleware(table.NewRenameColumnMiddleware(rs.RenameFields, rs.RenameRegexps))
 	}

--- a/pkg/cli/settings_replace.go
+++ b/pkg/cli/settings_replace.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
+	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/pkg/errors"
 	"os"
@@ -14,7 +14,7 @@ type ReplaceSettings struct {
 	ReplaceFile string `glazed.parameter:"replace-file"`
 }
 
-func (rs *ReplaceSettings) AddMiddlewares(of table2.OutputFormatter) error {
+func (rs *ReplaceSettings) AddMiddlewares(of formatters.OutputFormatter) error {
 	if rs.ReplaceFile != "" {
 		b, err := os.ReadFile(rs.ReplaceFile)
 		if err != nil {

--- a/pkg/cli/settings_replace.go
+++ b/pkg/cli/settings_replace.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	"github.com/go-go-golems/glazed/pkg/formatters"
+	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/pkg/errors"
 	"os"
@@ -14,7 +14,7 @@ type ReplaceSettings struct {
 	ReplaceFile string `glazed.parameter:"replace-file"`
 }
 
-func (rs *ReplaceSettings) AddMiddlewares(of formatters.OutputFormatter) error {
+func (rs *ReplaceSettings) AddMiddlewares(of table2.OutputFormatter) error {
 	if rs.ReplaceFile != "" {
 		b, err := os.ReadFile(rs.ReplaceFile)
 		if err != nil {

--- a/pkg/cli/settings_select.go
+++ b/pkg/cli/settings_select.go
@@ -35,12 +35,6 @@ func (tf *TemplateSettings) UpdateWithSelectSettings(ss *SelectSettings) {
 	}
 }
 
-type SelectFlagsDefaults struct {
-	Select         string `glazed.parameter:"select"`
-	SelectTemplate string `glazed.parameter:"select-template"`
-	Separator      string `glazed.parameter:"select-separator"`
-}
-
 type SelectParameterLayer struct {
 	*layers.ParameterLayerImpl
 }

--- a/pkg/cli/settings_sort.go
+++ b/pkg/cli/settings_sort.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	"github.com/go-go-golems/glazed/pkg/formatters"
+	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/pkg/errors"
 )
@@ -41,7 +41,7 @@ func NewSortParameterLayer(options ...layers.ParameterLayerOptions) (*SortParame
 	return ret, nil
 }
 
-func (s *SortFlagsSettings) AddMiddlewares(of formatters.OutputFormatter) {
+func (s *SortFlagsSettings) AddMiddlewares(of table2.OutputFormatter) {
 	if len(s.SortBy) == 0 {
 		return
 	}

--- a/pkg/cli/settings_sort.go
+++ b/pkg/cli/settings_sort.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
+	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/pkg/errors"
 )
@@ -41,7 +41,7 @@ func NewSortParameterLayer(options ...layers.ParameterLayerOptions) (*SortParame
 	return ret, nil
 }
 
-func (s *SortFlagsSettings) AddMiddlewares(of table2.OutputFormatter) {
+func (s *SortFlagsSettings) AddMiddlewares(of formatters.OutputFormatter) {
 	if len(s.SortBy) == 0 {
 		return
 	}

--- a/pkg/cli/settings_template.go
+++ b/pkg/cli/settings_template.go
@@ -3,7 +3,7 @@ package cli
 import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
-	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
+	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/pkg/errors"
@@ -18,7 +18,7 @@ type TemplateSettings struct {
 //go:embed "flags/template.yaml"
 var templateFlagsYaml []byte
 
-func (tf *TemplateSettings) AddMiddlewares(of table2.OutputFormatter) error {
+func (tf *TemplateSettings) AddMiddlewares(of formatters.OutputFormatter) error {
 	if tf.UseRowTemplates && len(tf.Templates) > 0 {
 		middleware, err := table.NewRowGoTemplateMiddleware(tf.Templates, tf.RenameSeparator)
 		if err != nil {

--- a/pkg/cli/settings_template.go
+++ b/pkg/cli/settings_template.go
@@ -3,7 +3,7 @@ package cli
 import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
-	"github.com/go-go-golems/glazed/pkg/formatters"
+	table2 "github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/pkg/errors"
@@ -18,7 +18,7 @@ type TemplateSettings struct {
 //go:embed "flags/template.yaml"
 var templateFlagsYaml []byte
 
-func (tf *TemplateSettings) AddMiddlewares(of formatters.OutputFormatter) error {
+func (tf *TemplateSettings) AddMiddlewares(of table2.OutputFormatter) error {
 	if tf.UseRowTemplates && len(tf.Templates) > 0 {
 		middleware, err := table.NewRowGoTemplateMiddleware(tf.Templates, tf.RenameSeparator)
 		if err != nil {

--- a/pkg/cmds/processor.go
+++ b/pkg/cmds/processor.go
@@ -1,26 +1,26 @@
 package cmds
 
 import (
-	"github.com/go-go-golems/glazed/pkg/formatters"
+	"github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 )
 
 type Processor interface {
 	ProcessInputObject(obj map[string]interface{}) error
-	OutputFormatter() formatters.OutputFormatter
+	OutputFormatter() table.OutputFormatter
 }
 
 type GlazeProcessor struct {
-	of  formatters.OutputFormatter
+	of  table.OutputFormatter
 	oms []middlewares.ObjectMiddleware
 }
 
-func (gp *GlazeProcessor) OutputFormatter() formatters.OutputFormatter {
+func (gp *GlazeProcessor) OutputFormatter() table.OutputFormatter {
 	return gp.of
 }
 
-func NewGlazeProcessor(of formatters.OutputFormatter, oms ...middlewares.ObjectMiddleware) *GlazeProcessor {
+func NewGlazeProcessor(of table.OutputFormatter, oms ...middlewares.ObjectMiddleware) *GlazeProcessor {
 	ret := &GlazeProcessor{
 		of:  of,
 		oms: oms,
@@ -53,11 +53,11 @@ func (gp *GlazeProcessor) ProcessInputObject(obj map[string]interface{}) error {
 // SimpleGlazeProcessor only collects the output and returns it as a types.Table
 type SimpleGlazeProcessor struct {
 	*GlazeProcessor
-	formatter *formatters.TableOutputFormatter
+	formatter *table.TableOutputFormatter
 }
 
 func NewSimpleGlazeProcessor(oms ...middlewares.ObjectMiddleware) *SimpleGlazeProcessor {
-	formatter := formatters.NewTableOutputFormatter("csv", "")
+	formatter := table.NewTableOutputFormatter("csv", "")
 	return &SimpleGlazeProcessor{
 		GlazeProcessor: NewGlazeProcessor(formatter, oms...),
 		formatter:      formatter,

--- a/pkg/cmds/processor.go
+++ b/pkg/cmds/processor.go
@@ -57,7 +57,7 @@ type SimpleGlazeProcessor struct {
 }
 
 func NewSimpleGlazeProcessor(oms ...middlewares.ObjectMiddleware) *SimpleGlazeProcessor {
-	formatter := table.NewTableOutputFormatter("csv", "")
+	formatter := table.NewTableOutputFormatter("csv")
 	return &SimpleGlazeProcessor{
 		GlazeProcessor: NewGlazeProcessor(formatter, oms...),
 		formatter:      formatter,

--- a/pkg/cmds/processor.go
+++ b/pkg/cmds/processor.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
@@ -8,19 +9,19 @@ import (
 
 type Processor interface {
 	ProcessInputObject(obj map[string]interface{}) error
-	OutputFormatter() table.OutputFormatter
+	OutputFormatter() formatters.OutputFormatter
 }
 
 type GlazeProcessor struct {
-	of  table.OutputFormatter
+	of  formatters.OutputFormatter
 	oms []middlewares.ObjectMiddleware
 }
 
-func (gp *GlazeProcessor) OutputFormatter() table.OutputFormatter {
+func (gp *GlazeProcessor) OutputFormatter() formatters.OutputFormatter {
 	return gp.of
 }
 
-func NewGlazeProcessor(of table.OutputFormatter, oms ...middlewares.ObjectMiddleware) *GlazeProcessor {
+func NewGlazeProcessor(of formatters.OutputFormatter, oms ...middlewares.ObjectMiddleware) *GlazeProcessor {
 	ret := &GlazeProcessor{
 		of:  of,
 		oms: oms,
@@ -53,11 +54,11 @@ func (gp *GlazeProcessor) ProcessInputObject(obj map[string]interface{}) error {
 // SimpleGlazeProcessor only collects the output and returns it as a types.Table
 type SimpleGlazeProcessor struct {
 	*GlazeProcessor
-	formatter *table.TableOutputFormatter
+	formatter *table.OutputFormatter
 }
 
 func NewSimpleGlazeProcessor(oms ...middlewares.ObjectMiddleware) *SimpleGlazeProcessor {
-	formatter := table.NewTableOutputFormatter("csv")
+	formatter := table.NewOutputFormatter("csv")
 	return &SimpleGlazeProcessor{
 		GlazeProcessor: NewGlazeProcessor(formatter, oms...),
 		formatter:      formatter,

--- a/pkg/formatters/csv/csv.go
+++ b/pkg/formatters/csv/csv.go
@@ -1,4 +1,4 @@
-package formatters
+package csv
 
 import (
 	"encoding/csv"

--- a/pkg/formatters/csv/csv.go
+++ b/pkg/formatters/csv/csv.go
@@ -11,11 +11,13 @@ import (
 )
 
 type OutputFormatter struct {
-	Table       *types.Table
-	middlewares []middlewares2.TableMiddleware
-	OutputFile  string
-	WithHeaders bool
-	Separator   rune
+	Table               *types.Table
+	middlewares         []middlewares2.TableMiddleware
+	OutputFile          string
+	OutputFileTemplate  string
+	OutputMultipleFiles bool
+	WithHeaders         bool
+	Separator           rune
 }
 
 type OutputFormatterOption func(*OutputFormatter)
@@ -35,6 +37,18 @@ func WithHeaders(withHeaders bool) OutputFormatterOption {
 func WithSeparator(separator rune) OutputFormatterOption {
 	return func(f *OutputFormatter) {
 		f.Separator = separator
+	}
+}
+
+func WithOutputFileTemplate(outputFileTemplate string) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputFileTemplate = outputFileTemplate
+	}
+}
+
+func WithOutputMultipleFiles(outputMultipleFiles bool) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputMultipleFiles = outputMultipleFiles
 	}
 }
 

--- a/pkg/formatters/csv/csv.go
+++ b/pkg/formatters/csv/csv.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-type CSVOutputFormatter struct {
+type OutputFormatter struct {
 	Table       *types.Table
 	middlewares []middlewares2.TableMiddleware
 	OutputFile  string
@@ -18,28 +18,28 @@ type CSVOutputFormatter struct {
 	Separator   rune
 }
 
-type CSVOutputFormatterOption func(*CSVOutputFormatter)
+type OutputFormatterOption func(*OutputFormatter)
 
-func WithOutputFile(outputFile string) CSVOutputFormatterOption {
-	return func(f *CSVOutputFormatter) {
+func WithOutputFile(outputFile string) OutputFormatterOption {
+	return func(f *OutputFormatter) {
 		f.OutputFile = outputFile
 	}
 }
 
-func WithHeaders(withHeaders bool) CSVOutputFormatterOption {
-	return func(f *CSVOutputFormatter) {
+func WithHeaders(withHeaders bool) OutputFormatterOption {
+	return func(f *OutputFormatter) {
 		f.WithHeaders = withHeaders
 	}
 }
 
-func WithSeparator(separator rune) CSVOutputFormatterOption {
-	return func(f *CSVOutputFormatter) {
+func WithSeparator(separator rune) OutputFormatterOption {
+	return func(f *OutputFormatter) {
 		f.Separator = separator
 	}
 }
 
-func NewCSVOutputFormatter(opts ...CSVOutputFormatterOption) *CSVOutputFormatter {
-	f := &CSVOutputFormatter{
+func NewCSVOutputFormatter(opts ...OutputFormatterOption) *OutputFormatter {
+	f := &OutputFormatter{
 		Table:       types.NewTable(),
 		middlewares: []middlewares2.TableMiddleware{},
 		WithHeaders: true,
@@ -51,8 +51,8 @@ func NewCSVOutputFormatter(opts ...CSVOutputFormatterOption) *CSVOutputFormatter
 	return f
 }
 
-func NewTSVOutputFormatter(opts ...CSVOutputFormatterOption) *CSVOutputFormatter {
-	f := &CSVOutputFormatter{
+func NewTSVOutputFormatter(opts ...OutputFormatterOption) *OutputFormatter {
+	f := &OutputFormatter{
 		Table:       types.NewTable(),
 		middlewares: []middlewares2.TableMiddleware{},
 		WithHeaders: true,
@@ -66,31 +66,31 @@ func NewTSVOutputFormatter(opts ...CSVOutputFormatterOption) *CSVOutputFormatter
 	return f
 }
 
-func (f *CSVOutputFormatter) GetTable() (*types.Table, error) {
+func (f *OutputFormatter) GetTable() (*types.Table, error) {
 	return f.Table, nil
 }
 
-func (f *CSVOutputFormatter) AddTableMiddleware(m middlewares2.TableMiddleware) {
+func (f *OutputFormatter) AddTableMiddleware(m middlewares2.TableMiddleware) {
 	f.middlewares = append(f.middlewares, m)
 }
 
-func (f *CSVOutputFormatter) AddTableMiddlewareInFront(m middlewares2.TableMiddleware) {
+func (f *OutputFormatter) AddTableMiddlewareInFront(m middlewares2.TableMiddleware) {
 	f.middlewares = append([]middlewares2.TableMiddleware{m}, f.middlewares...)
 }
 
-func (f *CSVOutputFormatter) AddTableMiddlewareAtIndex(i int, m middlewares2.TableMiddleware) {
+func (f *OutputFormatter) AddTableMiddlewareAtIndex(i int, m middlewares2.TableMiddleware) {
 	f.middlewares = append(f.middlewares[:i], append([]middlewares2.TableMiddleware{m}, f.middlewares[i:]...)...)
 }
 
-func (f *CSVOutputFormatter) AddRow(row types.Row) {
+func (f *OutputFormatter) AddRow(row types.Row) {
 	f.Table.Rows = append(f.Table.Rows, row)
 }
 
-func (f *CSVOutputFormatter) SetColumnOrder(columns []types.FieldName) {
+func (f *OutputFormatter) SetColumnOrder(columns []types.FieldName) {
 	f.Table.Columns = columns
 }
 
-func (f *CSVOutputFormatter) Output() (string, error) {
+func (f *OutputFormatter) Output() (string, error) {
 	f.Table.Finalize()
 
 	for _, middleware := range f.middlewares {

--- a/pkg/formatters/csv/csv.go
+++ b/pkg/formatters/csv/csv.go
@@ -18,24 +18,52 @@ type CSVOutputFormatter struct {
 	Separator   rune
 }
 
-func NewCSVOutputFormatter(outputFile string) *CSVOutputFormatter {
-	return &CSVOutputFormatter{
-		Table:       types.NewTable(),
-		middlewares: []middlewares2.TableMiddleware{},
-		OutputFile:  outputFile,
-		WithHeaders: true,
-		Separator:   ',',
+type CSVOutputFormatterOption func(*CSVOutputFormatter)
+
+func WithOutputFile(outputFile string) CSVOutputFormatterOption {
+	return func(f *CSVOutputFormatter) {
+		f.OutputFile = outputFile
 	}
 }
 
-func NewTSVOutputFormatter(outputFile string) *CSVOutputFormatter {
-	return &CSVOutputFormatter{
+func WithHeaders(withHeaders bool) CSVOutputFormatterOption {
+	return func(f *CSVOutputFormatter) {
+		f.WithHeaders = withHeaders
+	}
+}
+
+func WithSeparator(separator rune) CSVOutputFormatterOption {
+	return func(f *CSVOutputFormatter) {
+		f.Separator = separator
+	}
+}
+
+func NewCSVOutputFormatter(opts ...CSVOutputFormatterOption) *CSVOutputFormatter {
+	f := &CSVOutputFormatter{
 		Table:       types.NewTable(),
-		OutputFile:  outputFile,
+		middlewares: []middlewares2.TableMiddleware{},
+		WithHeaders: true,
+		Separator:   ',',
+	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
+}
+
+func NewTSVOutputFormatter(opts ...CSVOutputFormatterOption) *CSVOutputFormatter {
+	f := &CSVOutputFormatter{
+		Table:       types.NewTable(),
 		middlewares: []middlewares2.TableMiddleware{},
 		WithHeaders: true,
 		Separator:   '\t',
 	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
 }
 
 func (f *CSVOutputFormatter) GetTable() (*types.Table, error) {

--- a/pkg/formatters/csv/csv_test.go
+++ b/pkg/formatters/csv/csv_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCSVRenameEndToEnd(t *testing.T) {
-	of := NewCSVOutputFormatter("")
+	of := NewCSVOutputFormatter()
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/csv/csv_test.go
+++ b/pkg/formatters/csv/csv_test.go
@@ -1,23 +1,17 @@
-package formatters
+package csv
 
 import (
-	"github.com/Masterminds/sprig"
-	"github.com/go-go-golems/glazed/pkg/helpers/templating"
+	"github.com/go-go-golems/glazed/pkg/helpers/csv"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
-	"text/template"
 )
 
-func TestTemplateRenameEndToEnd(t *testing.T) {
-	// template that gets rows[0].b
-	tmpl := `{{ (index .rows 0).b }}`
-	of := NewTemplateOutputFormatter(tmpl, []template.FuncMap{
-		sprig.TxtFuncMap(),
-		templating.TemplateFuncs,
-	}, make(map[string]interface{}), "")
+func TestCSVRenameEndToEnd(t *testing.T) {
+	of := NewCSVOutputFormatter("")
 	renames := map[string]string{
 		"a": "b",
 	}
@@ -26,5 +20,10 @@ func TestTemplateRenameEndToEnd(t *testing.T) {
 	s, err := of.Output()
 	require.NoError(t, err)
 
-	assert.Equal(t, `1`, s)
+	data, err := csv.ParseCSV(strings.NewReader(s))
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+	v, ok := data[0]["b"]
+	assert.True(t, ok)
+	assert.Equal(t, 1, v)
 }

--- a/pkg/formatters/excel/excel.go
+++ b/pkg/formatters/excel/excel.go
@@ -125,11 +125,29 @@ func (E *ExcelOutputFormatter) Output() (string, error) {
 	return fmt.Sprintf("Output file created successfully at %s", E.OutputFile), nil
 }
 
-func NewExcelOutputFormatter(sheetName string, outputFile string) *ExcelOutputFormatter {
-	return &ExcelOutputFormatter{
-		SheetName:   sheetName,
-		OutputFile:  outputFile,
+type ExcelOutputFormatterOption func(*ExcelOutputFormatter)
+
+func WithSheetName(sheetName string) ExcelOutputFormatterOption {
+	return func(formatter *ExcelOutputFormatter) {
+		formatter.SheetName = sheetName
+	}
+}
+
+func WithOutputFile(outputFile string) ExcelOutputFormatterOption {
+	return func(formatter *ExcelOutputFormatter) {
+		formatter.OutputFile = outputFile
+	}
+}
+
+func NewExcelOutputFormatter(opts ...ExcelOutputFormatterOption) *ExcelOutputFormatter {
+	f := &ExcelOutputFormatter{
 		Table:       types.NewTable(),
 		middlewares: []middlewares.TableMiddleware{},
 	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
 }

--- a/pkg/formatters/excel/excel.go
+++ b/pkg/formatters/excel/excel.go
@@ -1,4 +1,4 @@
-package formatters
+package excel
 
 import (
 	"fmt"

--- a/pkg/formatters/excel/excel.go
+++ b/pkg/formatters/excel/excel.go
@@ -10,10 +10,12 @@ import (
 )
 
 type OutputFormatter struct {
-	SheetName   string
-	OutputFile  string
-	Table       *types.Table
-	middlewares []middlewares.TableMiddleware
+	SheetName           string
+	OutputFile          string
+	OutputFileTemplate  string
+	OutputMultipleFiles bool
+	Table               *types.Table
+	middlewares         []middlewares.TableMiddleware
 }
 
 func (E *OutputFormatter) GetTable() (*types.Table, error) {
@@ -136,6 +138,18 @@ func WithSheetName(sheetName string) OutputFormatterOption {
 func WithOutputFile(outputFile string) OutputFormatterOption {
 	return func(formatter *OutputFormatter) {
 		formatter.OutputFile = outputFile
+	}
+}
+
+func WithOutputFileTemplate(outputFileTemplate string) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputFileTemplate = outputFileTemplate
+	}
+}
+
+func WithOutputMultipleFiles(outputMultipleFiles bool) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputMultipleFiles = outputMultipleFiles
 	}
 }
 

--- a/pkg/formatters/excel/excel.go
+++ b/pkg/formatters/excel/excel.go
@@ -9,38 +9,38 @@ import (
 	"strings"
 )
 
-type ExcelOutputFormatter struct {
+type OutputFormatter struct {
 	SheetName   string
 	OutputFile  string
 	Table       *types.Table
 	middlewares []middlewares.TableMiddleware
 }
 
-func (E *ExcelOutputFormatter) GetTable() (*types.Table, error) {
+func (E *OutputFormatter) GetTable() (*types.Table, error) {
 	return E.Table, nil
 }
 
-func (E *ExcelOutputFormatter) AddRow(row types.Row) {
+func (E *OutputFormatter) AddRow(row types.Row) {
 	E.Table.Rows = append(E.Table.Rows, row)
 }
 
-func (E *ExcelOutputFormatter) SetColumnOrder(columns []types.FieldName) {
+func (E *OutputFormatter) SetColumnOrder(columns []types.FieldName) {
 	E.Table.Columns = columns
 }
 
-func (E *ExcelOutputFormatter) AddTableMiddleware(mw middlewares.TableMiddleware) {
+func (E *OutputFormatter) AddTableMiddleware(mw middlewares.TableMiddleware) {
 	E.middlewares = append(E.middlewares, mw)
 }
 
-func (E *ExcelOutputFormatter) AddTableMiddlewareInFront(mw middlewares.TableMiddleware) {
+func (E *OutputFormatter) AddTableMiddlewareInFront(mw middlewares.TableMiddleware) {
 	E.middlewares = append([]middlewares.TableMiddleware{mw}, E.middlewares...)
 }
 
-func (E *ExcelOutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableMiddleware) {
+func (E *OutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableMiddleware) {
 	E.middlewares = append(E.middlewares[:i], append([]middlewares.TableMiddleware{mw}, E.middlewares[i:]...)...)
 }
 
-func (E *ExcelOutputFormatter) Output() (string, error) {
+func (E *OutputFormatter) Output() (string, error) {
 	E.Table.Finalize()
 
 	for _, middleware := range E.middlewares {
@@ -125,22 +125,22 @@ func (E *ExcelOutputFormatter) Output() (string, error) {
 	return fmt.Sprintf("Output file created successfully at %s", E.OutputFile), nil
 }
 
-type ExcelOutputFormatterOption func(*ExcelOutputFormatter)
+type OutputFormatterOption func(*OutputFormatter)
 
-func WithSheetName(sheetName string) ExcelOutputFormatterOption {
-	return func(formatter *ExcelOutputFormatter) {
+func WithSheetName(sheetName string) OutputFormatterOption {
+	return func(formatter *OutputFormatter) {
 		formatter.SheetName = sheetName
 	}
 }
 
-func WithOutputFile(outputFile string) ExcelOutputFormatterOption {
-	return func(formatter *ExcelOutputFormatter) {
+func WithOutputFile(outputFile string) OutputFormatterOption {
+	return func(formatter *OutputFormatter) {
 		formatter.OutputFile = outputFile
 	}
 }
 
-func NewExcelOutputFormatter(opts ...ExcelOutputFormatterOption) *ExcelOutputFormatter {
-	f := &ExcelOutputFormatter{
+func NewOutputFormatter(opts ...OutputFormatterOption) *OutputFormatter {
+	f := &OutputFormatter{
 		Table:       types.NewTable(),
 		middlewares: []middlewares.TableMiddleware{},
 	}

--- a/pkg/formatters/excel/excel.go
+++ b/pkg/formatters/excel/excel.go
@@ -10,12 +10,10 @@ import (
 )
 
 type OutputFormatter struct {
-	SheetName           string
-	OutputFile          string
-	OutputFileTemplate  string
-	OutputMultipleFiles bool
-	Table               *types.Table
-	middlewares         []middlewares.TableMiddleware
+	SheetName   string
+	OutputFile  string
+	Table       *types.Table
+	middlewares []middlewares.TableMiddleware
 }
 
 func (E *OutputFormatter) GetTable() (*types.Table, error) {
@@ -138,18 +136,6 @@ func WithSheetName(sheetName string) OutputFormatterOption {
 func WithOutputFile(outputFile string) OutputFormatterOption {
 	return func(formatter *OutputFormatter) {
 		formatter.OutputFile = outputFile
-	}
-}
-
-func WithOutputFileTemplate(outputFileTemplate string) OutputFormatterOption {
-	return func(f *OutputFormatter) {
-		f.OutputFileTemplate = outputFileTemplate
-	}
-}
-
-func WithOutputMultipleFiles(outputMultipleFiles bool) OutputFormatterOption {
-	return func(f *OutputFormatter) {
-		f.OutputMultipleFiles = outputMultipleFiles
 	}
 }
 

--- a/pkg/formatters/formatter.go
+++ b/pkg/formatters/formatter.go
@@ -1,0 +1,48 @@
+package formatters
+
+import (
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/types"
+)
+
+// This part of the library contains helper functionality to do output formatting
+// for data.
+//
+// We want to do the following:
+//    - print a Table with a header
+//    - print the Table as csv
+//    - render raw data as json
+//    - render data as sqlite (potentially into multiple tables)
+//    - support multiple tables
+//        - transform tree like structures into flattened tables
+//    - make it easy for the user to add data
+//    - make it easy for the user to specify filters and fields
+//    - provide a middleware like structure to chain filters and transformers
+//    - provide a way to add documentation to the output / data schema
+//    - support go templating
+//    - load formatting values from a config file
+//    - streaming functionality (i.e., output as values come in)
+//
+// Advanced functionality:
+//    - excel output
+//    - pager and search
+//    - highlight certain values
+//    - filter the input structure / output structure using a jq like query language
+
+// The following is all geared towards tabulated output
+
+type OutputFormatter interface {
+	// TODO(manuel, 2022-11-12) We need to be able to output to a directory / to a stream / to multiple files
+	AddRow(row types.Row)
+
+	SetColumnOrder(columnOrder []types.FieldName)
+
+	// AddTableMiddleware adds a middleware at the end of the processing list
+	AddTableMiddleware(m middlewares.TableMiddleware)
+	AddTableMiddlewareInFront(m middlewares.TableMiddleware)
+	AddTableMiddlewareAtIndex(i int, m middlewares.TableMiddleware)
+
+	GetTable() (*types.Table, error)
+
+	Output() (string, error)
+}

--- a/pkg/formatters/formatter.go
+++ b/pkg/formatters/formatter.go
@@ -1,8 +1,12 @@
 package formatters
 
 import (
+	"fmt"
+	"github.com/go-go-golems/glazed/pkg/helpers/templating"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
+	"path/filepath"
+	"strings"
 )
 
 // This part of the library contains helper functionality to do output formatting
@@ -45,4 +49,29 @@ type OutputFormatter interface {
 	GetTable() (*types.Table, error)
 
 	Output() (string, error)
+}
+
+func ComputeOutputFilename(outputFile string, outputFileTemplate string, row types.Row, index int) (string, error) {
+	var outputFileName string
+	if outputFileTemplate != "" {
+		data := map[string]interface{}{}
+		values := row.GetValues()
+
+		for k, v := range values {
+			data[k] = v
+		}
+		data["rowIndex"] = index
+		t, err := templating.RenderTemplateString(outputFileTemplate, data)
+		if err != nil {
+			return "", err
+		}
+		outputFileName = t
+	} else {
+		fileType := filepath.Ext(outputFile)
+		baseName := strings.TrimSuffix(outputFile, fileType)
+
+		outputFileName = fmt.Sprintf("%s-%d%s", baseName, index, fileType)
+
+	}
+	return outputFileName, nil
 }

--- a/pkg/formatters/json/json.go
+++ b/pkg/formatters/json/json.go
@@ -12,6 +12,8 @@ import (
 type OutputFormatter struct {
 	OutputIndividualRows bool
 	OutputFile           string
+	OutputFileTemplate   string
+	OutputMultipleFiles  bool
 	Table                *types.Table
 	middlewares          []middlewares.TableMiddleware
 }
@@ -106,6 +108,18 @@ func WithOutputIndividualRows(outputIndividualRows bool) OutputFormatterOption {
 func WithOutputFile(file string) OutputFormatterOption {
 	return func(formatter *OutputFormatter) {
 		formatter.OutputFile = file
+	}
+}
+
+func WithOutputFileTemplate(outputFileTemplate string) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputFileTemplate = outputFileTemplate
+	}
+}
+
+func WithOutputMultipleFiles(outputMultipleFiles bool) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputMultipleFiles = outputMultipleFiles
 	}
 }
 

--- a/pkg/formatters/json/json.go
+++ b/pkg/formatters/json/json.go
@@ -1,4 +1,4 @@
-package formatters
+package json
 
 import (
 	"bytes"
@@ -94,6 +94,8 @@ func (J *JSONOutputFormatter) Output() (string, error) {
 		return string(jsonBytes), nil
 	}
 }
+
+type JSONOutputFormatterOption func(*JSONOutputFormatter)
 
 func NewJSONOutputFormatter(outputAsObjects bool, outputFile string) *JSONOutputFormatter {
 	return &JSONOutputFormatter{

--- a/pkg/formatters/json/json.go
+++ b/pkg/formatters/json/json.go
@@ -97,11 +97,29 @@ func (J *JSONOutputFormatter) Output() (string, error) {
 
 type JSONOutputFormatterOption func(*JSONOutputFormatter)
 
-func NewJSONOutputFormatter(outputAsObjects bool, outputFile string) *JSONOutputFormatter {
-	return &JSONOutputFormatter{
-		OutputIndividualRows: outputAsObjects,
+func WithOutputIndividualRows(outputIndividualRows bool) JSONOutputFormatterOption {
+	return func(formatter *JSONOutputFormatter) {
+		formatter.OutputIndividualRows = outputIndividualRows
+	}
+}
+
+func WithOutputFile(file string) JSONOutputFormatterOption {
+	return func(formatter *JSONOutputFormatter) {
+		formatter.OutputFile = file
+	}
+}
+
+func NewJSONOutputFormatter(options ...JSONOutputFormatterOption) *JSONOutputFormatter {
+	ret := &JSONOutputFormatter{
+		OutputIndividualRows: false,
 		Table:                types.NewTable(),
-		OutputFile:           outputFile,
+		OutputFile:           "",
 		middlewares:          []middlewares.TableMiddleware{},
 	}
+
+	for _, option := range options {
+		option(ret)
+	}
+
+	return ret
 }

--- a/pkg/formatters/json/json_test.go
+++ b/pkg/formatters/json/json_test.go
@@ -1,6 +1,7 @@
-package formatters
+package json
 
 import (
+	"encoding/json"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -8,8 +9,8 @@ import (
 	"testing"
 )
 
-func TestTableRenameEndToEnd(t *testing.T) {
-	of := NewTableOutputFormatter("markdown", "")
+func TestJSONRenameEndToEnd(t *testing.T) {
+	of := NewJSONOutputFormatter(false, "")
 	renames := map[string]string{
 		"a": "b",
 	}
@@ -19,5 +20,13 @@ func TestTableRenameEndToEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	// parse s
-	assert.Equal(t, "| b |\n| - |\n| 1 |\n", s)
+	data := []map[string]interface{}{}
+	err = json.Unmarshal([]byte(s), &data)
+	require.NoError(t, err)
+	require.Len(t, data, 1)
+
+	// check if the rename worked
+	v, ok := data[0]["b"]
+	assert.True(t, ok)
+	assert.Equal(t, 1.0, v)
 }

--- a/pkg/formatters/json/json_test.go
+++ b/pkg/formatters/json/json_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestJSONRenameEndToEnd(t *testing.T) {
-	of := NewJSONOutputFormatter(false, "")
+	of := NewJSONOutputFormatter()
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/json/json_test.go
+++ b/pkg/formatters/json/json_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestJSONRenameEndToEnd(t *testing.T) {
-	of := NewJSONOutputFormatter()
+	of := NewOutputFormatter()
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/simple/simple.go
+++ b/pkg/formatters/simple/simple.go
@@ -1,4 +1,4 @@
-package formatters
+package simple
 
 import (
 	"fmt"

--- a/pkg/formatters/simple/simple.go
+++ b/pkg/formatters/simple/simple.go
@@ -14,12 +14,26 @@ type SingleColumnFormatter struct {
 	middlewares []middlewares.TableMiddleware
 }
 
-func NewSingleColumnFormatter(column types.FieldName, separator string) *SingleColumnFormatter {
-	return &SingleColumnFormatter{
+type SingleColumnFormatterOption func(*SingleColumnFormatter)
+
+func WithSeparator(separator string) SingleColumnFormatterOption {
+	return func(f *SingleColumnFormatter) {
+		f.Separator = separator
+	}
+}
+
+func NewSingleColumnFormatter(column types.FieldName, opts ...SingleColumnFormatterOption) *SingleColumnFormatter {
+	f := &SingleColumnFormatter{
 		Table:     &types.Table{},
 		Column:    column,
-		Separator: separator,
+		Separator: "\n",
 	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
 }
 
 func (s *SingleColumnFormatter) AddRow(row types.Row) {

--- a/pkg/formatters/table/table.go
+++ b/pkg/formatters/table/table.go
@@ -11,10 +11,12 @@ import (
 )
 
 type OutputFormatter struct {
-	Table       *types.Table
-	middlewares []middlewares.TableMiddleware
-	TableFormat string
-	OutputFile  string
+	Table               *types.Table
+	OutputFileTemplate  string
+	OutputMultipleFiles bool
+	middlewares         []middlewares.TableMiddleware
+	TableFormat         string
+	OutputFile          string
 }
 
 type OutputFormatterOption func(*OutputFormatter)
@@ -22,6 +24,18 @@ type OutputFormatterOption func(*OutputFormatter)
 func WithOutputFile(outputFile string) OutputFormatterOption {
 	return func(tof *OutputFormatter) {
 		tof.OutputFile = outputFile
+	}
+}
+
+func WithOutputFileTemplate(outputFileTemplate string) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputFileTemplate = outputFileTemplate
+	}
+}
+
+func WithOutputMultipleFiles(outputMultipleFiles bool) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputMultipleFiles = outputMultipleFiles
 	}
 }
 

--- a/pkg/formatters/table/table.go
+++ b/pkg/formatters/table/table.go
@@ -1,4 +1,4 @@
-package formatters
+package table
 
 import (
 	"fmt"

--- a/pkg/formatters/table/table.go
+++ b/pkg/formatters/table/table.go
@@ -59,13 +59,26 @@ type TableOutputFormatter struct {
 	OutputFile  string
 }
 
-func NewTableOutputFormatter(tableFormat string, outputFile string) *TableOutputFormatter {
-	return &TableOutputFormatter{
+type TableOutputFormatterOption func(*TableOutputFormatter)
+
+func WithOutputFile(outputFile string) TableOutputFormatterOption {
+	return func(tof *TableOutputFormatter) {
+		tof.OutputFile = outputFile
+	}
+}
+
+func NewTableOutputFormatter(tableFormat string, opts ...TableOutputFormatterOption) *TableOutputFormatter {
+	f := &TableOutputFormatter{
 		Table:       types.NewTable(),
-		OutputFile:  outputFile,
 		middlewares: []middlewares.TableMiddleware{},
 		TableFormat: tableFormat,
 	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
 }
 
 func (tof *TableOutputFormatter) GetTable() (*types.Table, error) {

--- a/pkg/formatters/table/table_test.go
+++ b/pkg/formatters/table/table_test.go
@@ -1,7 +1,6 @@
-package formatters
+package table
 
 import (
-	"encoding/json"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -9,8 +8,8 @@ import (
 	"testing"
 )
 
-func TestJSONRenameEndToEnd(t *testing.T) {
-	of := NewJSONOutputFormatter(false, "")
+func TestTableRenameEndToEnd(t *testing.T) {
+	of := NewTableOutputFormatter("markdown", "")
 	renames := map[string]string{
 		"a": "b",
 	}
@@ -20,13 +19,5 @@ func TestJSONRenameEndToEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	// parse s
-	data := []map[string]interface{}{}
-	err = json.Unmarshal([]byte(s), &data)
-	require.NoError(t, err)
-	require.Len(t, data, 1)
-
-	// check if the rename worked
-	v, ok := data[0]["b"]
-	assert.True(t, ok)
-	assert.Equal(t, 1.0, v)
+	assert.Equal(t, "| b |\n| - |\n| 1 |\n", s)
 }

--- a/pkg/formatters/table/table_test.go
+++ b/pkg/formatters/table/table_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTableRenameEndToEnd(t *testing.T) {
-	of := NewTableOutputFormatter("markdown")
+	of := NewOutputFormatter("markdown")
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/table/table_test.go
+++ b/pkg/formatters/table/table_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTableRenameEndToEnd(t *testing.T) {
-	of := NewTableOutputFormatter("markdown", "")
+	of := NewTableOutputFormatter("markdown")
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/template/template.go
+++ b/pkg/formatters/template/template.go
@@ -10,12 +10,14 @@ import (
 )
 
 type OutputFormatter struct {
-	Template         string
-	Table            *types.Table
-	TemplateFuncMaps []template.FuncMap
-	middlewares      []middlewares.TableMiddleware
-	OutputFile       string
-	AdditionalData   interface{}
+	Template            string
+	Table               *types.Table
+	TemplateFuncMaps    []template.FuncMap
+	OutputFileTemplate  string
+	OutputMultipleFiles bool
+	middlewares         []middlewares.TableMiddleware
+	OutputFile          string
+	AdditionalData      interface{}
 }
 
 func (t *OutputFormatter) GetTable() (*types.Table, error) {
@@ -107,6 +109,18 @@ func WithAdditionalData(additionalData interface{}) OutputFormatterOption {
 func WithOutputFile(outputFile string) OutputFormatterOption {
 	return func(t *OutputFormatter) {
 		t.OutputFile = outputFile
+	}
+}
+
+func WithOutputFileTemplate(outputFileTemplate string) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputFileTemplate = outputFileTemplate
+	}
+}
+
+func WithOutputMultipleFiles(outputMultipleFiles bool) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputMultipleFiles = outputMultipleFiles
 	}
 }
 

--- a/pkg/formatters/template/template.go
+++ b/pkg/formatters/template/template.go
@@ -1,4 +1,4 @@
-package formatters
+package template
 
 import (
 	"bytes"

--- a/pkg/formatters/template/template.go
+++ b/pkg/formatters/template/template.go
@@ -9,7 +9,7 @@ import (
 	"text/template"
 )
 
-type TemplateFormatter struct {
+type OutputFormatter struct {
 	Template         string
 	Table            *types.Table
 	TemplateFuncMaps []template.FuncMap
@@ -18,31 +18,31 @@ type TemplateFormatter struct {
 	AdditionalData   interface{}
 }
 
-func (t *TemplateFormatter) GetTable() (*types.Table, error) {
+func (t *OutputFormatter) GetTable() (*types.Table, error) {
 	return t.Table, nil
 }
 
-func (t *TemplateFormatter) AddRow(row types.Row) {
+func (t *OutputFormatter) AddRow(row types.Row) {
 	t.Table.Rows = append(t.Table.Rows, row)
 }
 
-func (t *TemplateFormatter) SetColumnOrder(columnOrder []types.FieldName) {
+func (t *OutputFormatter) SetColumnOrder(columnOrder []types.FieldName) {
 	t.Table.Columns = columnOrder
 }
 
-func (t *TemplateFormatter) AddTableMiddleware(m middlewares.TableMiddleware) {
+func (t *OutputFormatter) AddTableMiddleware(m middlewares.TableMiddleware) {
 	t.middlewares = append(t.middlewares, m)
 }
 
-func (t *TemplateFormatter) AddTableMiddlewareInFront(m middlewares.TableMiddleware) {
+func (t *OutputFormatter) AddTableMiddlewareInFront(m middlewares.TableMiddleware) {
 	t.middlewares = append([]middlewares.TableMiddleware{m}, t.middlewares...)
 }
 
-func (t *TemplateFormatter) AddTableMiddlewareAtIndex(i int, m middlewares.TableMiddleware) {
+func (t *OutputFormatter) AddTableMiddlewareAtIndex(i int, m middlewares.TableMiddleware) {
 	t.middlewares = append(t.middlewares[:i], append([]middlewares.TableMiddleware{m}, t.middlewares[i:]...)...)
 }
 
-func (t *TemplateFormatter) Output() (string, error) {
+func (t *OutputFormatter) Output() (string, error) {
 	t.Table.Finalize()
 
 	for _, middleware := range t.middlewares {
@@ -90,32 +90,32 @@ func (t *TemplateFormatter) Output() (string, error) {
 	return buf.String(), nil
 }
 
-type TemplateOutputFormatterOption func(*TemplateFormatter)
+type OutputFormatterOption func(*OutputFormatter)
 
-func WithTemplateFuncMaps(templateFuncMaps []template.FuncMap) TemplateOutputFormatterOption {
-	return func(t *TemplateFormatter) {
+func WithTemplateFuncMaps(templateFuncMaps []template.FuncMap) OutputFormatterOption {
+	return func(t *OutputFormatter) {
 		t.TemplateFuncMaps = templateFuncMaps
 	}
 }
 
-func WithAdditionalData(additionalData interface{}) TemplateOutputFormatterOption {
-	return func(t *TemplateFormatter) {
+func WithAdditionalData(additionalData interface{}) OutputFormatterOption {
+	return func(t *OutputFormatter) {
 		t.AdditionalData = additionalData
 	}
 }
 
-func WithOutputFile(outputFile string) TemplateOutputFormatterOption {
-	return func(t *TemplateFormatter) {
+func WithOutputFile(outputFile string) OutputFormatterOption {
+	return func(t *OutputFormatter) {
 		t.OutputFile = outputFile
 	}
 }
 
-// NewTemplateOutputFormatter creates a new TemplateFormatter.
+// NewOutputFormatter creates a new OutputFormatter.
 //
 // TODO(manuel, 2023-02-19) This is quite an ugly constructor signature.
 // See: https://github.com/go-go-golems/glazed/issues/147
-func NewTemplateOutputFormatter(template string, opts ...TemplateOutputFormatterOption) *TemplateFormatter {
-	f := &TemplateFormatter{
+func NewOutputFormatter(template string, opts ...OutputFormatterOption) *OutputFormatter {
+	f := &OutputFormatter{
 		Template:       template,
 		AdditionalData: map[string]interface{}{},
 		Table:          types.NewTable(),

--- a/pkg/formatters/template/template.go
+++ b/pkg/formatters/template/template.go
@@ -90,16 +90,40 @@ func (t *TemplateFormatter) Output() (string, error) {
 	return buf.String(), nil
 }
 
+type TemplateOutputFormatterOption func(*TemplateFormatter)
+
+func WithTemplateFuncMaps(templateFuncMaps []template.FuncMap) TemplateOutputFormatterOption {
+	return func(t *TemplateFormatter) {
+		t.TemplateFuncMaps = templateFuncMaps
+	}
+}
+
+func WithAdditionalData(additionalData interface{}) TemplateOutputFormatterOption {
+	return func(t *TemplateFormatter) {
+		t.AdditionalData = additionalData
+	}
+}
+
+func WithOutputFile(outputFile string) TemplateOutputFormatterOption {
+	return func(t *TemplateFormatter) {
+		t.OutputFile = outputFile
+	}
+}
+
 // NewTemplateOutputFormatter creates a new TemplateFormatter.
 //
 // TODO(manuel, 2023-02-19) This is quite an ugly constructor signature.
 // See: https://github.com/go-go-golems/glazed/issues/147
-func NewTemplateOutputFormatter(template string, templateFuncMaps []template.FuncMap, additionalData interface{}, outputFile string) *TemplateFormatter {
-	return &TemplateFormatter{
-		Template:         template,
-		OutputFile:       outputFile,
-		Table:            types.NewTable(),
-		TemplateFuncMaps: templateFuncMaps,
-		AdditionalData:   additionalData,
+func NewTemplateOutputFormatter(template string, opts ...TemplateOutputFormatterOption) *TemplateFormatter {
+	f := &TemplateFormatter{
+		Template:       template,
+		AdditionalData: map[string]interface{}{},
+		Table:          types.NewTable(),
 	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
 }

--- a/pkg/formatters/template/template_test.go
+++ b/pkg/formatters/template/template_test.go
@@ -1,17 +1,23 @@
-package formatters
+package template
 
 import (
-	"github.com/go-go-golems/glazed/pkg/helpers/csv"
+	"github.com/Masterminds/sprig"
+	"github.com/go-go-golems/glazed/pkg/helpers/templating"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"strings"
 	"testing"
+	"text/template"
 )
 
-func TestCSVRenameEndToEnd(t *testing.T) {
-	of := NewCSVOutputFormatter("")
+func TestTemplateRenameEndToEnd(t *testing.T) {
+	// template that gets rows[0].b
+	tmpl := `{{ (index .rows 0).b }}`
+	of := NewTemplateOutputFormatter(tmpl, []template.FuncMap{
+		sprig.TxtFuncMap(),
+		templating.TemplateFuncs,
+	}, make(map[string]interface{}), "")
 	renames := map[string]string{
 		"a": "b",
 	}
@@ -20,10 +26,5 @@ func TestCSVRenameEndToEnd(t *testing.T) {
 	s, err := of.Output()
 	require.NoError(t, err)
 
-	data, err := csv.ParseCSV(strings.NewReader(s))
-	require.NoError(t, err)
-	require.Len(t, data, 1)
-	v, ok := data[0]["b"]
-	assert.True(t, ok)
-	assert.Equal(t, 1, v)
+	assert.Equal(t, `1`, s)
 }

--- a/pkg/formatters/template/template_test.go
+++ b/pkg/formatters/template/template_test.go
@@ -14,10 +14,11 @@ import (
 func TestTemplateRenameEndToEnd(t *testing.T) {
 	// template that gets rows[0].b
 	tmpl := `{{ (index .rows 0).b }}`
-	of := NewTemplateOutputFormatter(tmpl, []template.FuncMap{
-		sprig.TxtFuncMap(),
-		templating.TemplateFuncs,
-	}, make(map[string]interface{}), "")
+	of := NewTemplateOutputFormatter(tmpl,
+		WithTemplateFuncMaps([]template.FuncMap{
+			sprig.TxtFuncMap(),
+			templating.TemplateFuncs,
+		}))
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/template/template_test.go
+++ b/pkg/formatters/template/template_test.go
@@ -14,7 +14,7 @@ import (
 func TestTemplateRenameEndToEnd(t *testing.T) {
 	// template that gets rows[0].b
 	tmpl := `{{ (index .rows 0).b }}`
-	of := NewTemplateOutputFormatter(tmpl,
+	of := NewOutputFormatter(tmpl,
 		WithTemplateFuncMaps([]template.FuncMap{
 			sprig.TxtFuncMap(),
 			templating.TemplateFuncs,

--- a/pkg/formatters/yaml/yaml.go
+++ b/pkg/formatters/yaml/yaml.go
@@ -9,9 +9,11 @@ import (
 )
 
 type OutputFormatter struct {
-	Table       *types.Table
-	OutputFile  string
-	middlewares []middlewares.TableMiddleware
+	Table               *types.Table
+	OutputFile          string
+	OutputFileTemplate  string
+	OutputMultipleFiles bool
+	middlewares         []middlewares.TableMiddleware
 }
 
 func (Y *OutputFormatter) GetTable() (*types.Table, error) {
@@ -77,6 +79,18 @@ type OutputFormatterOption func(*OutputFormatter)
 func WithYAMLOutputFile(outputFile string) OutputFormatterOption {
 	return func(f *OutputFormatter) {
 		f.OutputFile = outputFile
+	}
+}
+
+func WithOutputFileTemplate(outputFileTemplate string) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputFileTemplate = outputFileTemplate
+	}
+}
+
+func WithOutputMultipleFiles(outputMultipleFiles bool) OutputFormatterOption {
+	return func(f *OutputFormatter) {
+		f.OutputMultipleFiles = outputMultipleFiles
 	}
 }
 

--- a/pkg/formatters/yaml/yaml.go
+++ b/pkg/formatters/yaml/yaml.go
@@ -72,10 +72,23 @@ func (Y *YAMLOutputFormatter) Output() (string, error) {
 	return string(d), nil
 }
 
-func NewYAMLOutputFormatter(outputFile string) *YAMLOutputFormatter {
-	return &YAMLOutputFormatter{
+type YAMLOutputFormatterOption func(*YAMLOutputFormatter)
+
+func WithYAMLOutputFile(outputFile string) YAMLOutputFormatterOption {
+	return func(f *YAMLOutputFormatter) {
+		f.OutputFile = outputFile
+	}
+}
+
+func NewYAMLOutputFormatter(opts ...YAMLOutputFormatterOption) *YAMLOutputFormatter {
+	f := &YAMLOutputFormatter{
 		Table:       types.NewTable(),
-		OutputFile:  outputFile,
 		middlewares: []middlewares.TableMiddleware{},
 	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
 }

--- a/pkg/formatters/yaml/yaml.go
+++ b/pkg/formatters/yaml/yaml.go
@@ -1,4 +1,4 @@
-package formatters
+package yaml
 
 import (
 	"github.com/go-go-golems/glazed/pkg/middlewares"

--- a/pkg/formatters/yaml/yaml.go
+++ b/pkg/formatters/yaml/yaml.go
@@ -8,37 +8,37 @@ import (
 	"os"
 )
 
-type YAMLOutputFormatter struct {
+type OutputFormatter struct {
 	Table       *types.Table
 	OutputFile  string
 	middlewares []middlewares.TableMiddleware
 }
 
-func (Y *YAMLOutputFormatter) GetTable() (*types.Table, error) {
+func (Y *OutputFormatter) GetTable() (*types.Table, error) {
 	return Y.Table, nil
 }
 
-func (Y *YAMLOutputFormatter) AddRow(row types.Row) {
+func (Y *OutputFormatter) AddRow(row types.Row) {
 	Y.Table.Rows = append(Y.Table.Rows, row)
 }
 
-func (f *YAMLOutputFormatter) SetColumnOrder(columns []types.FieldName) {
+func (f *OutputFormatter) SetColumnOrder(columns []types.FieldName) {
 	f.Table.Columns = columns
 }
 
-func (Y *YAMLOutputFormatter) AddTableMiddleware(mw middlewares.TableMiddleware) {
+func (Y *OutputFormatter) AddTableMiddleware(mw middlewares.TableMiddleware) {
 	Y.middlewares = append(Y.middlewares, mw)
 }
 
-func (Y *YAMLOutputFormatter) AddTableMiddlewareInFront(mw middlewares.TableMiddleware) {
+func (Y *OutputFormatter) AddTableMiddlewareInFront(mw middlewares.TableMiddleware) {
 	Y.middlewares = append([]middlewares.TableMiddleware{mw}, Y.middlewares...)
 }
 
-func (Y *YAMLOutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableMiddleware) {
+func (Y *OutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableMiddleware) {
 	Y.middlewares = append(Y.middlewares[:i], append([]middlewares.TableMiddleware{mw}, Y.middlewares[i:]...)...)
 }
 
-func (Y *YAMLOutputFormatter) Output() (string, error) {
+func (Y *OutputFormatter) Output() (string, error) {
 	Y.Table.Finalize()
 
 	for _, middleware := range Y.middlewares {
@@ -72,16 +72,16 @@ func (Y *YAMLOutputFormatter) Output() (string, error) {
 	return string(d), nil
 }
 
-type YAMLOutputFormatterOption func(*YAMLOutputFormatter)
+type OutputFormatterOption func(*OutputFormatter)
 
-func WithYAMLOutputFile(outputFile string) YAMLOutputFormatterOption {
-	return func(f *YAMLOutputFormatter) {
+func WithYAMLOutputFile(outputFile string) OutputFormatterOption {
+	return func(f *OutputFormatter) {
 		f.OutputFile = outputFile
 	}
 }
 
-func NewYAMLOutputFormatter(opts ...YAMLOutputFormatterOption) *YAMLOutputFormatter {
-	f := &YAMLOutputFormatter{
+func NewOutputFormatter(opts ...OutputFormatterOption) *OutputFormatter {
+	f := &OutputFormatter{
 		Table:       types.NewTable(),
 		middlewares: []middlewares.TableMiddleware{},
 	}

--- a/pkg/formatters/yaml/yaml_test.go
+++ b/pkg/formatters/yaml/yaml_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestYAMLRenameEndToEnd(t *testing.T) {
-	of := NewYAMLOutputFormatter("")
+	of := NewYAMLOutputFormatter()
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/yaml/yaml_test.go
+++ b/pkg/formatters/yaml/yaml_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestYAMLRenameEndToEnd(t *testing.T) {
-	of := NewYAMLOutputFormatter()
+	of := NewOutputFormatter()
 	renames := map[string]string{
 		"a": "b",
 	}

--- a/pkg/formatters/yaml/yaml_test.go
+++ b/pkg/formatters/yaml/yaml_test.go
@@ -1,4 +1,4 @@
-package formatters
+package yaml
 
 import (
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"


### PR DESCRIPTION
- :fire: Remove deprecated code
- :tractor: Move formatters to their own packages
- :art: Add option builder for all output formatters
- :art: Rename OutputFormatter classes
- :art: Pass in options to output multiple files (but don't handle yet)
- :sparkles: Implement multi-output-files for CSV
- :sparkles: Add documentation for output-file-template
- :sparkles: Add multiple output files to json
- :sparkles: Add multi file output to table output
- :sparkles: Add multi-output-file support to template
- :sparkles: Add multi output files support to yaml
