### PR TITLE
Add yaml output-as-objects, fix smaller issues

### DIFF
--- a/pkg/cli/settings_output.go
+++ b/pkg/cli/settings_output.go
@@ -107,6 +107,7 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 			yaml.WithYAMLOutputFile(ofs.OutputFile),
 			yaml.WithOutputMultipleFiles(ofs.OutputMultipleFiles),
 			yaml.WithOutputFileTemplate(ofs.OutputFileTemplate),
+			yaml.WithOutputIndividualRows(ofs.OutputAsObjects),
 		)
 	} else if ofs.Output == "excel" {
 		if ofs.OutputFile == "" {

--- a/pkg/cmds/parameters/cobra.go
+++ b/pkg/cmds/parameters/cobra.go
@@ -513,19 +513,31 @@ func GatherFlagsFromCobraCommand(
 			ps[parameter.Name] = v
 
 		case ParameterTypeStringList:
-			fallthrough
+			v, err := cmd.Flags().GetStringSlice(flagName)
+			if err != nil {
+				return nil, err
+			}
+			ps[parameter.Name] = v
+
 		case ParameterTypeKeyValue:
 			v, err := cmd.Flags().GetStringSlice(flagName)
 			if err != nil {
 				return nil, err
 			}
-			v2, err := parameter.ParseParameter(v)
-			if err != nil {
-				return nil, err
+
+			// if it was changed and is empty, then skip setting from default
+			if cmd.Flags().Changed(flagName) && len(v) == 0 {
+				ps[parameter.Name] = map[string]string{}
+			} else {
+				v2, err := parameter.ParseParameter(v)
+				if err != nil {
+					return nil, err
+				}
+				ps[parameter.Name] = v2
 			}
-			ps[parameter.Name] = v2
 
 		case ParameterTypeIntegerList:
+			// NOTE(manuel, 2023-04-01) Do we not check for default here?
 			v, err := cmd.Flags().GetIntSlice(flagName)
 			if err != nil {
 				return nil, err
@@ -533,6 +545,7 @@ func GatherFlagsFromCobraCommand(
 			ps[parameter.Name] = v
 
 		case ParameterTypeFloatList:
+			// NOTE(manuel, 2023-04-01) Do we not check for default here?
 			v, err := cmd.Flags().GetFloat64Slice(flagName)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
- :art: Allow for empty yaml files
- :sparkles: Add output-as-objects to yaml
- :ambulance: Don't revert to default value if an empty string is passed for stringList
