### PR TITLE
Refactor OutputFormatter API to have context and writer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ build:
 	go generate ./...
 	go build ./...
 
+bench:
+	go test -bench=./... -benchmem
+
 goreleaser:
 	goreleaser release --skip-sign --snapshot --rm-dist
 

--- a/cmd/glaze/cmds/csv.go
+++ b/cmd/glaze/cmds/csv.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
 	"github.com/go-go-golems/glazed/pkg/helpers/csv"
+	"github.com/go-go-golems/glazed/pkg/processor"
 	"github.com/pkg/errors"
 	"os"
 )
@@ -79,7 +80,7 @@ func (c *CsvCommand) Run(
 	ctx context.Context,
 	parsedLayers map[string]*layers.ParsedParameterLayer,
 	ps map[string]interface{},
-	gp cmds.Processor,
+	gp processor.Processor,
 ) error {
 	inputFiles, ok := ps["input-files"].([]string)
 	if !ok {

--- a/cmd/glaze/cmds/csv.go
+++ b/cmd/glaze/cmds/csv.go
@@ -132,7 +132,7 @@ func (c *CsvCommand) Run(
 		}
 
 		for _, row := range s {
-			err = gp.ProcessInputObject(row)
+			err = gp.ProcessInputObject(ctx, row)
 			if err != nil {
 				return errors.Wrap(err, "could not process CSV row")
 			}

--- a/cmd/glaze/cmds/docs.go
+++ b/cmd/glaze/cmds/docs.go
@@ -2,7 +2,6 @@ package cmds
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/adrg/frontmatter"
 	"github.com/go-go-golems/glazed/pkg/cli"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
@@ -35,9 +34,8 @@ var DocsCmd = &cobra.Command{
 			cobra.CheckErr(err)
 		}
 
-		s, err := gp.OutputFormatter().Output(ctx)
+		err = gp.OutputFormatter().Output(ctx, os.Stdout)
 		cobra.CheckErr(err)
-		fmt.Print(s)
 	},
 }
 

--- a/cmd/glaze/cmds/docs.go
+++ b/cmd/glaze/cmds/docs.go
@@ -15,6 +15,7 @@ var DocsCmd = &cobra.Command{
 	Short: "Work with help documents",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := cmd.Context()
 		gp, err := cli.CreateGlazedProcessorFromCobra(cmd)
 		cobra.CheckErr(err)
 
@@ -30,11 +31,11 @@ var DocsCmd = &cobra.Command{
 
 			metaData["path"] = arg
 
-			err = gp.ProcessInputObject(metaData)
+			err = gp.ProcessInputObject(ctx, metaData)
 			cobra.CheckErr(err)
 		}
 
-		s, err := gp.OutputFormatter().Output()
+		s, err := gp.OutputFormatter().Output(ctx)
 		cobra.CheckErr(err)
 		fmt.Print(s)
 	},

--- a/cmd/glaze/cmds/html/cmds.go
+++ b/cmd/glaze/cmds/html/cmds.go
@@ -1,7 +1,6 @@
 package html
 
 import (
-	"fmt"
 	"github.com/go-go-golems/glazed/pkg/cli"
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/spf13/cobra"
@@ -40,12 +39,11 @@ func NewHTMLCommand() (*cobra.Command, error) {
 				cobra.CheckErr(err)
 			}
 
-			s, err := gp.OutputFormatter().Output(ctx)
+			err = gp.OutputFormatter().Output(ctx, os.Stdout)
 			cobra.CheckErr(err)
 			if _, ok := err.(*cmds.ExitWithoutGlazeError); ok {
 				os.Exit(0)
 			}
-			fmt.Print(s)
 		},
 	}
 
@@ -94,12 +92,11 @@ func NewHTMLCommand() (*cobra.Command, error) {
 				cobra.CheckErr(err)
 			}
 
-			s, err := gp.OutputFormatter().Output(ctx)
+			err = gp.OutputFormatter().Output(ctx, os.Stdout)
 			cobra.CheckErr(err)
 			if _, ok := err.(*cmds.ExitWithoutGlazeError); ok {
 				os.Exit(0)
 			}
-			fmt.Print(s)
 		},
 	}
 

--- a/cmd/glaze/cmds/html/cmds.go
+++ b/cmd/glaze/cmds/html/cmds.go
@@ -20,6 +20,8 @@ func NewHTMLCommand() (*cobra.Command, error) {
 		Short: "Parse HTML",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+
 			gp, err := cli.CreateGlazedProcessorFromCobra(cmd)
 			cobra.CheckErr(err)
 
@@ -34,11 +36,11 @@ func NewHTMLCommand() (*cobra.Command, error) {
 				doc, err := html.Parse(f)
 				cobra.CheckErr(err)
 
-				err = outputNodesDepthFirst(doc, gp)
+				err = outputNodesDepthFirst(ctx, doc, gp)
 				cobra.CheckErr(err)
 			}
 
-			s, err := gp.OutputFormatter().Output()
+			s, err := gp.OutputFormatter().Output(ctx)
 			cobra.CheckErr(err)
 			if _, ok := err.(*cmds.ExitWithoutGlazeError); ok {
 				os.Exit(0)
@@ -63,6 +65,8 @@ func NewHTMLCommand() (*cobra.Command, error) {
 		Short: "Extract HTML from sections",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			ctx := cmd.Context()
+
 			gp, err := cli.CreateGlazedProcessorFromCobra(cmd)
 			cobra.CheckErr(err)
 
@@ -86,11 +90,11 @@ func NewHTMLCommand() (*cobra.Command, error) {
 
 				hsp := NewHTMLSplitParser(gp, append(removeTags, splitTags...), splitTags, extractTitle)
 
-				_, err = hsp.ProcessNode(doc)
+				_, err = hsp.ProcessNode(ctx, doc)
 				cobra.CheckErr(err)
 			}
 
-			s, err := gp.OutputFormatter().Output()
+			s, err := gp.OutputFormatter().Output(ctx)
 			cobra.CheckErr(err)
 			if _, ok := err.(*cmds.ExitWithoutGlazeError); ok {
 				os.Exit(0)

--- a/cmd/glaze/cmds/html/parse.go
+++ b/cmd/glaze/cmds/html/parse.go
@@ -1,7 +1,7 @@
 package html
 
 import (
-	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/processor"
 	"golang.org/x/net/html"
 	"strings"
 )
@@ -10,13 +10,13 @@ import (
 // When encountering one of the tags in splitTags, it extracts the content below the tag as Title
 // (if extractTitle is true) and the following siblings until the next split tag is encountered as body.
 type HTMLSplitParser struct {
-	gp           cmds.Processor
+	gp           processor.Processor
 	removeTags   []string
 	splitTags    []string
 	extractTitle bool
 }
 
-func NewHTMLSplitParser(gp cmds.Processor, removeTags, splitTags []string, extractTitle bool) *HTMLSplitParser {
+func NewHTMLSplitParser(gp processor.Processor, removeTags, splitTags []string, extractTitle bool) *HTMLSplitParser {
 	return &HTMLSplitParser{
 		gp:           gp,
 		removeTags:   removeTags,
@@ -27,7 +27,7 @@ func NewHTMLSplitParser(gp cmds.Processor, removeTags, splitTags []string, extra
 
 // NewHTMLHeadingSplitParser creates a new HTMLSplitParser that splits the document into sections
 // and keeps the titles, by splitting at h1, h2, h3...
-func NewHTMLHeadingSplitParser(gp cmds.Processor, removeTags []string) *HTMLSplitParser {
+func NewHTMLHeadingSplitParser(gp processor.Processor, removeTags []string) *HTMLSplitParser {
 	tags := []string{"h1", "h2", "h3", "h4", "h5", "h6"}
 	removeTags = append(removeTags, tags...)
 	return NewHTMLSplitParser(gp, removeTags, tags, true)
@@ -177,7 +177,7 @@ func htmlNodeTypeToString(t html.NodeType) string {
 	}
 }
 
-func outputNodesDepthFirst(doc *html.Node, gp *cmds.GlazeProcessor) error {
+func outputNodesDepthFirst(doc *html.Node, gp *processor.GlazeProcessor) error {
 	attributes := make([]htmlAttribute, 0, len(doc.Attr))
 	for _, attr := range doc.Attr {
 		attributes = append(attributes, htmlAttribute{

--- a/cmd/glaze/cmds/html/parse_test.go
+++ b/cmd/glaze/cmds/html/parse_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/html"
+	"io"
 	"strings"
 	"testing"
 )
@@ -45,8 +46,8 @@ func (t TestFormatter) GetTable() (*types.Table, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (t TestFormatter) Output(context.Context) (string, error) {
-	return "", nil
+func (t TestFormatter) Output(context.Context, io.Writer) error {
+	return nil
 }
 
 func (t *TestProcessor) ProcessInputObject(ctx context.Context, obj map[string]interface{}) error {

--- a/cmd/glaze/cmds/html/parse_test.go
+++ b/cmd/glaze/cmds/html/parse_test.go
@@ -1,6 +1,7 @@
 package html
 
 import (
+	"context"
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
@@ -44,11 +45,11 @@ func (t TestFormatter) GetTable() (*types.Table, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (t TestFormatter) Output() (string, error) {
+func (t TestFormatter) Output(context.Context) (string, error) {
 	return "", nil
 }
 
-func (t *TestProcessor) ProcessInputObject(obj map[string]interface{}) error {
+func (t *TestProcessor) ProcessInputObject(ctx context.Context, obj map[string]interface{}) error {
 	t.Objects = append(t.Objects, obj)
 	return nil
 }
@@ -66,7 +67,9 @@ func TestSimpleHeaderParse(t *testing.T) {
 
 	hsp := NewHTMLHeadingSplitParser(gp, []string{})
 
-	n, err := hsp.ProcessNode(doc)
+	ctx := context.Background()
+
+	n, err := hsp.ProcessNode(ctx, doc)
 	require.NoError(t, err)
 	assert.Nil(t, n)
 
@@ -84,7 +87,9 @@ func TestTwoHeadersParse(t *testing.T) {
 
 	hsp := NewHTMLHeadingSplitParser(gp, []string{})
 
-	n, err := hsp.ProcessNode(doc)
+	ctx := context.Background()
+
+	n, err := hsp.ProcessNode(ctx, doc)
 	require.NoError(t, err)
 	assert.Nil(t, n)
 
@@ -115,7 +120,8 @@ func TestTwoHeadersBody(t *testing.T) {
 
 	hsp := NewHTMLHeadingSplitParser(gp, []string{})
 
-	n, err := hsp.ProcessNode(doc)
+	ctx := context.Background()
+	n, err := hsp.ProcessNode(ctx, doc)
 	require.NoError(t, err)
 	assert.Nil(t, n)
 
@@ -148,7 +154,8 @@ func TestTwoHeadersSomeTextBody(t *testing.T) {
 
 	hsp := NewHTMLHeadingSplitParser(gp, []string{})
 
-	n, err := hsp.ProcessNode(doc)
+	ctx := context.Background()
+	n, err := hsp.ProcessNode(ctx, doc)
 	require.NoError(t, err)
 	assert.Nil(t, n)
 
@@ -186,7 +193,8 @@ func TestTwoHeadersSomeTextNodes(t *testing.T) {
 	gp := NewTestProcessor()
 	hsp := NewHTMLHeadingSplitParser(gp, []string{})
 
-	n, err := hsp.ProcessNode(doc)
+	ctx := context.Background()
+	n, err := hsp.ProcessNode(ctx, doc)
 	require.NoError(t, err)
 	assert.Nil(t, n)
 
@@ -202,7 +210,7 @@ func TestTwoHeadersSomeTextNodes(t *testing.T) {
 	gp = NewTestProcessor()
 	hsp = NewHTMLHeadingSplitParser(gp, []string{"p"})
 
-	n, err = hsp.ProcessNode(doc)
+	n, err = hsp.ProcessNode(ctx, doc)
 	require.NoError(t, err)
 	assert.Nil(t, n)
 
@@ -236,7 +244,9 @@ func TestStripTags(t *testing.T) {
 
 	hsp := NewHTMLHeadingSplitParser(gp, []string{"span", "p"})
 
-	n, err := hsp.ProcessNode(doc)
+	ctx := context.Background()
+
+	n, err := hsp.ProcessNode(ctx, doc)
 	require.NoError(t, err)
 	assert.Nil(t, n)
 
@@ -261,7 +271,8 @@ func TestSplitOtherTags(t *testing.T) {
 
 	hsp := NewHTMLSplitParser(gp, []string{"p"}, []string{"p"}, true)
 
-	n, err := hsp.ProcessNode(doc)
+	ctx := context.Background()
+	n, err := hsp.ProcessNode(ctx, doc)
 	require.NoError(t, err)
 	assert.Nil(t, n)
 
@@ -283,7 +294,8 @@ func TestSplitOtherTagsWithoutTitle(t *testing.T) {
 
 	hsp := NewHTMLSplitParser(gp, []string{"p"}, []string{"p"}, false)
 
-	n, err := hsp.ProcessNode(doc)
+	ctx := context.Background()
+	n, err := hsp.ProcessNode(ctx, doc)
 	require.NoError(t, err)
 	assert.Nil(t, n)
 
@@ -298,7 +310,7 @@ func TestSplitOtherTagsWithoutTitle(t *testing.T) {
 	gp = NewTestProcessor()
 	hsp = NewHTMLSplitParser(gp, []string{}, []string{"p"}, false)
 
-	n, err = hsp.ProcessNode(doc)
+	n, err = hsp.ProcessNode(ctx, doc)
 	require.NoError(t, err)
 	assert.Nil(t, n)
 

--- a/cmd/glaze/cmds/json.go
+++ b/cmd/glaze/cmds/json.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/processor"
 	"github.com/pkg/errors"
 	"os"
 )
@@ -52,7 +53,7 @@ func (j *JsonCommand) Run(
 	ctx context.Context,
 	parsedLayers map[string]*layers.ParsedParameterLayer,
 	ps map[string]interface{},
-	gp cmds.Processor,
+	gp processor.Processor,
 ) error {
 	inputIsArray, ok := ps["input-is-array"].(bool)
 	if !ok {

--- a/cmd/glaze/cmds/json.go
+++ b/cmd/glaze/cmds/json.go
@@ -83,7 +83,7 @@ func (j *JsonCommand) Run(
 
 			i := 1
 			for _, d := range data {
-				err = gp.ProcessInputObject(d)
+				err = gp.ProcessInputObject(ctx, d)
 				if err != nil {
 					return errors.Wrapf(err, "Error processing row %d of file %s as object", i, arg)
 				}
@@ -96,7 +96,7 @@ func (j *JsonCommand) Run(
 			if err != nil {
 				return errors.Wrapf(err, "Error decoding file %s as object", arg)
 			}
-			err = gp.ProcessInputObject(data)
+			err = gp.ProcessInputObject(ctx, data)
 			if err != nil {
 				return errors.Wrapf(err, "Error processing file %s as object", arg)
 			}

--- a/cmd/glaze/cmds/markdown.go
+++ b/cmd/glaze/cmds/markdown.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/cli"
 	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/processor"
 	"github.com/spf13/cobra"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
@@ -184,7 +185,7 @@ var parseCmd = &cobra.Command{
 //		    }
 //
 // ]
-func splitByHeading(md goldmark.Markdown, s []byte, gp *cmds.GlazeProcessor) error {
+func splitByHeading(md goldmark.Markdown, s []byte, gp *processor.GlazeProcessor) error {
 	r := text.NewReader(s)
 
 	// parse options are:
@@ -257,7 +258,7 @@ func splitByHeading(md goldmark.Markdown, s []byte, gp *cmds.GlazeProcessor) err
 // simpleLinearize is a simple walker that will linearize the blocks encountered,
 // and filter out the Document and Text blocks
 // to avoid duplicates, for a very simple document.
-func simpleLinearize(md goldmark.Markdown, s []byte, gp *cmds.GlazeProcessor) error {
+func simpleLinearize(md goldmark.Markdown, s []byte, gp *processor.GlazeProcessor) error {
 	r := text.NewReader(s)
 
 	// parse options are:

--- a/cmd/glaze/cmds/markdown.go
+++ b/cmd/glaze/cmds/markdown.go
@@ -164,12 +164,11 @@ var parseCmd = &cobra.Command{
 
 		_ = gp
 
-		s, err := gp.OutputFormatter().Output(ctx)
+		err = gp.OutputFormatter().Output(ctx, os.Stdout)
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error rendering output: %s\n", err)
 			os.Exit(1)
 		}
-		fmt.Print(s)
 	},
 }
 
@@ -380,12 +379,11 @@ var splitByHeadingCmd = &cobra.Command{
 
 		_ = gp
 
-		s, err := gp.OutputFormatter().Output(ctx)
+		err = gp.OutputFormatter().Output(ctx, os.Stdout)
 		cobra.CheckErr(err)
 		if _, ok := err.(*cmds.ExitWithoutGlazeError); ok {
 			os.Exit(0)
 		}
-		fmt.Print(s)
 
 	},
 }

--- a/cmd/glaze/cmds/yaml.go
+++ b/cmd/glaze/cmds/yaml.go
@@ -60,7 +60,7 @@ func NewYamlCommand() (*YamlCommand, error) {
 }
 
 func (y *YamlCommand) Run(
-	_ context.Context,
+	ctx context.Context,
 	_ map[string]*layers.ParsedParameterLayer,
 	ps map[string]interface{},
 	gp processor.Processor,
@@ -118,7 +118,7 @@ func (y *YamlCommand) Run(
 
 			i := 1
 			for _, d := range data {
-				err = gp.ProcessInputObject(d)
+				err = gp.ProcessInputObject(ctx, d)
 				if err != nil {
 					return errors.Wrapf(err, "Error processing row %d of file %s as object", i, arg)
 				}
@@ -135,7 +135,7 @@ func (y *YamlCommand) Run(
 				}
 				return errors.Wrapf(err, "Error decoding file %s as object", arg)
 			}
-			err = gp.ProcessInputObject(data)
+			err = gp.ProcessInputObject(ctx, data)
 			if err != nil {
 				return errors.Wrapf(err, "Error processing file %s as object", arg)
 			}

--- a/cmd/glaze/cmds/yaml.go
+++ b/cmd/glaze/cmds/yaml.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
 	yaml2 "github.com/go-go-golems/glazed/pkg/helpers/yaml"
+	"github.com/go-go-golems/glazed/pkg/processor"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -62,7 +63,7 @@ func (y *YamlCommand) Run(
 	_ context.Context,
 	_ map[string]*layers.ParsedParameterLayer,
 	ps map[string]interface{},
-	gp cmds.Processor,
+	gp processor.Processor,
 ) error {
 	inputIsArray, ok := ps["input-is-array"].(bool)
 	if !ok {

--- a/go.mod
+++ b/go.mod
@@ -39,11 +39,9 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
-	github.com/felixge/fgprof v0.9.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-openapi/errors v0.20.3 // indirect
 	github.com/go-openapi/strfmt v0.21.7 // indirect
-	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -65,7 +63,6 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
-	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/richardlehane/mscfb v1.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -39,9 +39,11 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
+	github.com/felixge/fgprof v0.9.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-openapi/errors v0.20.3 // indirect
 	github.com/go-openapi/strfmt v0.21.7 // indirect
+	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
@@ -63,6 +65,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/richardlehane/mscfb v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/felixge/fgprof v0.9.3 h1:VvyZxILNuCiUCSXtPtYmmtGvb65nqXh2QFWc0Wpf2/g=
+github.com/felixge/fgprof v0.9.3/go.mod h1:RdbpDgzqYVh/T9fPELJyV7EYJuHB55UTEULNun8eiPw=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
@@ -146,6 +148,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20211214055906-6f57359322fd h1:1FjCyPC+syAzJ5/2S8fqdZK1R22vvA0J7JZKcuOIQ7Y=
+github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
@@ -163,6 +167,7 @@ github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
@@ -230,6 +235,8 @@ github.com/piprate/json-gold v0.5.0 h1:RmGh1PYboCFcchVFuh2pbSWAZy4XJaqTMU4KQYsAp
 github.com/piprate/json-gold v0.5.0/go.mod h1:WZ501QQMbZZ+3pXFPhQKzNwS1+jls0oqov3uQ2WasLs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=
+github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -460,6 +467,7 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/felixge/fgprof v0.9.3 h1:VvyZxILNuCiUCSXtPtYmmtGvb65nqXh2QFWc0Wpf2/g=
-github.com/felixge/fgprof v0.9.3/go.mod h1:RdbpDgzqYVh/T9fPELJyV7EYJuHB55UTEULNun8eiPw=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
@@ -148,8 +146,6 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20211214055906-6f57359322fd h1:1FjCyPC+syAzJ5/2S8fqdZK1R22vvA0J7JZKcuOIQ7Y=
-github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
@@ -167,7 +163,6 @@ github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
@@ -235,8 +230,6 @@ github.com/piprate/json-gold v0.5.0 h1:RmGh1PYboCFcchVFuh2pbSWAZy4XJaqTMU4KQYsAp
 github.com/piprate/json-gold v0.5.0/go.mod h1:WZ501QQMbZZ+3pXFPhQKzNwS1+jls0oqov3uQ2WasLs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=
-github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -467,7 +460,6 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -289,7 +289,7 @@ func BuildCobraCommandFromGlazeCommand(s cmds.GlazeCommand) (*cobra.Command, err
 			cobra.CheckErr(err)
 		}
 
-		s, err := gp.OutputFormatter().Output()
+		s, err := gp.OutputFormatter().Output(ctx)
 		cobra.CheckErr(err)
 
 		fmt.Println(s)

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -272,8 +272,8 @@ func BuildCobraCommandFromWriterCommand(s cmds.WriterCommand) (*cobra.Command, e
 	return cmd, nil
 }
 
-func BuildCobraCommandFromGlazeCommand(s cmds.GlazeCommand) (*cobra.Command, error) {
-	cmd, err := BuildCobraCommandFromCommand(s, func(
+func BuildCobraCommandFromGlazeCommand(cmd_ cmds.GlazeCommand) (*cobra.Command, error) {
+	cmd, err := BuildCobraCommandFromCommand(cmd_, func(
 		ctx context.Context,
 		parsedLayers map[string]*layers.ParsedParameterLayer,
 		ps map[string]interface{},
@@ -281,7 +281,7 @@ func BuildCobraCommandFromGlazeCommand(s cmds.GlazeCommand) (*cobra.Command, err
 		gp, err := SetupProcessor(ps)
 		cobra.CheckErr(err)
 
-		err = s.Run(ctx, parsedLayers, ps, gp)
+		err = cmd_.Run(ctx, parsedLayers, ps, gp)
 		if _, ok := err.(*cmds.ExitWithoutGlazeError); ok {
 			return nil
 		}
@@ -289,10 +289,8 @@ func BuildCobraCommandFromGlazeCommand(s cmds.GlazeCommand) (*cobra.Command, err
 			cobra.CheckErr(err)
 		}
 
-		s, err := gp.OutputFormatter().Output(ctx)
+		err = gp.OutputFormatter().Output(ctx, os.Stdout)
 		cobra.CheckErr(err)
-
-		fmt.Println(s)
 		return nil
 	})
 

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/helpers"
 	"github.com/go-go-golems/glazed/pkg/helpers/list"
 	strings2 "github.com/go-go-golems/glazed/pkg/helpers/strings"
+	"github.com/go-go-golems/glazed/pkg/processor"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -415,7 +416,7 @@ func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []cmds.Command, a
 //
 // If so, use SetupProcessor instead, and create a proper glazed.GlazeCommand for your command.
 func CreateGlazedProcessorFromCobra(cmd *cobra.Command) (
-	*cmds.GlazeProcessor,
+	*processor.GlazeProcessor,
 	error,
 ) {
 	gpl, err := NewGlazedParameterLayers()

--- a/pkg/cli/glazed_layer.go
+++ b/pkg/cli/glazed_layer.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	_ "embed"
-	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
 	"github.com/go-go-golems/glazed/pkg/formatters"
@@ -10,6 +9,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/middlewares/object"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
+	"github.com/go-go-golems/glazed/pkg/processor"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -368,7 +368,7 @@ func NewGlazedParameterLayers(options ...GlazeParameterLayerOption) (*GlazedPara
 	return ret, nil
 }
 
-func SetupProcessor(ps map[string]interface{}) (*cmds.GlazeProcessor, error) {
+func SetupProcessor(ps map[string]interface{}) (*processor.GlazeProcessor, error) {
 	// TODO(manuel, 2023-03-06): This is where we should check that flags that are mutually incompatible don't clash
 	//
 	// See: https://github.com/go-go-golems/glazed/issues/199
@@ -476,6 +476,6 @@ func SetupProcessor(ps map[string]interface{}) (*cmds.GlazeProcessor, error) {
 	// is not trivial.
 	sortSettings.AddMiddlewares(of)
 
-	gp := cmds.NewGlazeProcessor(of, middlewares_...)
+	gp := processor.NewGlazeProcessor(of, middlewares_...)
 	return gp, nil
 }

--- a/pkg/cmds/alias/alias.go
+++ b/pkg/cmds/alias/alias.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/layout"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/processor"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	"io"
@@ -120,7 +121,7 @@ func (a *CommandAlias) Run(
 	ctx context.Context,
 	parsedLayers map[string]*layers.ParsedParameterLayer,
 	ps map[string]interface{},
-	gp cmds.Processor,
+	gp processor.Processor,
 ) error {
 	if a.AliasedCommand == nil {
 		return errors.New("no aliased command")

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/layout"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/processor"
 	"io"
 )
 
@@ -266,7 +267,7 @@ type GlazeCommand interface {
 		ctx context.Context,
 		parsedLayers map[string]*layers.ParsedParameterLayer,
 		ps map[string]interface{},
-		gp Processor,
+		gp processor.Processor,
 	) error
 }
 

--- a/pkg/formatters/csv/csv.go
+++ b/pkg/formatters/csv/csv.go
@@ -7,9 +7,8 @@ import (
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	middlewares2 "github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
-	"github.com/rs/zerolog/log"
+	"io"
 	"os"
-	"strings"
 )
 
 type OutputFormatter struct {
@@ -106,93 +105,98 @@ func (f *OutputFormatter) SetColumnOrder(columns []types.FieldName) {
 	f.Table.Columns = columns
 }
 
-func (f *OutputFormatter) Output(ctx context.Context) (string, error) {
+func (f *OutputFormatter) Output(ctx context.Context, w_ io.Writer) error {
 	f.Table.Finalize()
 
 	for _, middleware := range f.middlewares {
 		newTable, err := middleware.Process(f.Table)
 		if err != nil {
-			return "", err
+			return err
 		}
 		f.Table = newTable
 	}
 
 	if f.OutputMultipleFiles {
-		s := ""
-
 		for i, row := range f.Table.Rows {
 			outputFileName, err := formatters.ComputeOutputFilename(f.OutputFile, f.OutputFileTemplate, row, i)
 			if err != nil {
-				return "", err
+				return err
 			}
 
-			buf, w, err := f.newCSVWriter()
+			f_, err := os.Create(outputFileName)
 			if err != nil {
-				return "", err
+				return err
 			}
+			defer f_.Close()
 
-			err = f.writeRow(row, w)
+			csvWriter, err := f.newCSVWriter(f_)
 			if err != nil {
-				return "", err
+				return err
 			}
 
-			w.Flush()
-
-			if err := w.Error(); err != nil {
-				return "", err
-			}
-
-			err = os.WriteFile(outputFileName, []byte(buf.String()), 0644)
+			err = f.writeRow(row, csvWriter)
 			if err != nil {
-				return "", err
+				return err
 			}
-			s += fmt.Sprintf("Written output to %s\n", outputFileName)
+
+			csvWriter.Flush()
+
+			if err := csvWriter.Error(); err != nil {
+				return err
+			}
+
+			_, _ = fmt.Fprintf(w_, "Written output to %s\n", outputFileName)
 		}
 
-		return s, nil
+		return nil
 	}
 
-	buf, w, err := f.newCSVWriter()
-	if err != nil {
-		return "", err
+	var csvWriter *csv.Writer
+	if f.OutputFile != "" {
+		f_, err := os.Create(f.OutputFile)
+		if err != nil {
+			return err
+		}
+		defer f_.Close()
+
+		csvWriter, err = f.newCSVWriter(w_)
+		if err != nil {
+			return err
+		}
+	} else {
+		var err error
+		csvWriter, err = f.newCSVWriter(w_)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, row := range f.Table.Rows {
-		err2 := f.writeRow(row, w)
+		err2 := f.writeRow(row, csvWriter)
 		if err2 != nil {
-			return "", err2
+			return err2
 		}
 	}
 
-	w.Flush()
+	csvWriter.Flush()
 
-	if err := w.Error(); err != nil {
-		return "", err
+	if err := csvWriter.Error(); err != nil {
+		return err
 	}
 
-	if f.OutputFile != "" {
-		log.Debug().Str("file", f.OutputFile).Msg("Writing output to file")
-		err := os.WriteFile(f.OutputFile, []byte(buf.String()), 0644)
-		if err != nil {
-			return "", err
-		}
-		return fmt.Sprintf("Written output to %s\n", f.OutputFile), nil
-	}
-
-	return buf.String(), nil
+	return nil
 }
 
-func (f *OutputFormatter) newCSVWriter() (*strings.Builder, *csv.Writer, error) {
+func (f *OutputFormatter) newCSVWriter(w_ io.Writer) (*csv.Writer, error) {
 	// create a buffer writer
-	buf := strings.Builder{}
-	w := csv.NewWriter(&buf)
+	w := csv.NewWriter(w_)
 	w.Comma = f.Separator
 
 	var err error
 	if f.WithHeaders {
 		err = w.Write(f.Table.Columns)
 	}
-	return &buf, w, err
+	return w, err
 }
 
 func (f *OutputFormatter) writeRow(row types.Row, w *csv.Writer) error {

--- a/pkg/formatters/csv/csv.go
+++ b/pkg/formatters/csv/csv.go
@@ -1,6 +1,7 @@
 package csv
 
 import (
+	"context"
 	"encoding/csv"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
@@ -105,7 +106,7 @@ func (f *OutputFormatter) SetColumnOrder(columns []types.FieldName) {
 	f.Table.Columns = columns
 }
 
-func (f *OutputFormatter) Output() (string, error) {
+func (f *OutputFormatter) Output(ctx context.Context) (string, error) {
 	f.Table.Finalize()
 
 	for _, middleware := range f.middlewares {

--- a/pkg/formatters/csv/csv_test.go
+++ b/pkg/formatters/csv/csv_test.go
@@ -1,6 +1,7 @@
 package csv
 
 import (
+	"bytes"
 	"context"
 	"github.com/go-go-golems/glazed/pkg/helpers/csv"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
@@ -19,10 +20,11 @@ func TestCSVRenameEndToEnd(t *testing.T) {
 	of.AddTableMiddleware(&table.RenameColumnMiddleware{Renames: renames})
 	of.AddRow(&types.SimpleRow{Hash: map[string]interface{}{"a": 1}})
 	ctx := context.Background()
-	s, err := of.Output(ctx)
+	buf := &bytes.Buffer{}
+	err := of.Output(ctx, buf)
 	require.NoError(t, err)
 
-	_, data, err := csv.ParseCSV(strings.NewReader(s))
+	_, data, err := csv.ParseCSV(strings.NewReader(buf.String()))
 	require.NoError(t, err)
 	require.Len(t, data, 1)
 	v, ok := data[0]["b"]

--- a/pkg/formatters/csv/csv_test.go
+++ b/pkg/formatters/csv/csv_test.go
@@ -1,6 +1,7 @@
 package csv
 
 import (
+	"context"
 	"github.com/go-go-golems/glazed/pkg/helpers/csv"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
@@ -17,7 +18,8 @@ func TestCSVRenameEndToEnd(t *testing.T) {
 	}
 	of.AddTableMiddleware(&table.RenameColumnMiddleware{Renames: renames})
 	of.AddRow(&types.SimpleRow{Hash: map[string]interface{}{"a": 1}})
-	s, err := of.Output()
+	ctx := context.Background()
+	s, err := of.Output(ctx)
 	require.NoError(t, err)
 
 	_, data, err := csv.ParseCSV(strings.NewReader(s))

--- a/pkg/formatters/excel/excel.go
+++ b/pkg/formatters/excel/excel.go
@@ -1,6 +1,7 @@
 package excel
 
 import (
+	"context"
 	"fmt"
 	strings2 "github.com/go-go-golems/glazed/pkg/helpers/strings"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
@@ -40,7 +41,7 @@ func (E *OutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableM
 	E.middlewares = append(E.middlewares[:i], append([]middlewares.TableMiddleware{mw}, E.middlewares[i:]...)...)
 }
 
-func (E *OutputFormatter) Output() (string, error) {
+func (E *OutputFormatter) Output(context.Context) (string, error) {
 	E.Table.Finalize()
 
 	for _, middleware := range E.middlewares {

--- a/pkg/formatters/formatter.go
+++ b/pkg/formatters/formatter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/helpers/templating"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
+	"io"
 	"path/filepath"
 	"strings"
 )
@@ -49,7 +50,7 @@ type OutputFormatter interface {
 
 	GetTable() (*types.Table, error)
 
-	Output(ctx context.Context) (string, error)
+	Output(ctx context.Context, w io.Writer) error
 }
 
 func ComputeOutputFilename(outputFile string, outputFileTemplate string, row types.Row, index int) (string, error) {

--- a/pkg/formatters/formatter.go
+++ b/pkg/formatters/formatter.go
@@ -1,6 +1,7 @@
 package formatters
 
 import (
+	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/helpers/templating"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
@@ -48,7 +49,7 @@ type OutputFormatter interface {
 
 	GetTable() (*types.Table, error)
 
-	Output() (string, error)
+	Output(ctx context.Context) (string, error)
 }
 
 func ComputeOutputFilename(outputFile string, outputFileTemplate string, row types.Row, index int) (string, error) {

--- a/pkg/formatters/json/json.go
+++ b/pkg/formatters/json/json.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
@@ -46,7 +47,7 @@ func (f *OutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableM
 	f.middlewares = append(f.middlewares[:i], append([]middlewares.TableMiddleware{mw}, f.middlewares[i:]...)...)
 }
 
-func (f *OutputFormatter) Output() (string, error) {
+func (f *OutputFormatter) Output(context.Context) (string, error) {
 	f.Table.Finalize()
 
 	for _, middleware := range f.middlewares {

--- a/pkg/formatters/json/json.go
+++ b/pkg/formatters/json/json.go
@@ -1,14 +1,13 @@
 package json
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
-	"github.com/rs/zerolog/log"
+	"io"
 	"os"
 )
 
@@ -47,84 +46,81 @@ func (f *OutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableM
 	f.middlewares = append(f.middlewares[:i], append([]middlewares.TableMiddleware{mw}, f.middlewares[i:]...)...)
 }
 
-func (f *OutputFormatter) Output(context.Context) (string, error) {
+func (f *OutputFormatter) Output(ctx context.Context, w io.Writer) error {
 	f.Table.Finalize()
 
 	for _, middleware := range f.middlewares {
 		newTable, err := middleware.Process(f.Table)
 		if err != nil {
-			return "", err
+			return err
 		}
 		f.Table = newTable
 	}
 
 	if f.OutputMultipleFiles {
 		if f.OutputFileTemplate == "" && f.OutputFile == "" {
-			return "", fmt.Errorf("neither output file or output file template is set")
+			return fmt.Errorf("neither output file or output file template is set")
 		}
-
-		s := ""
 
 		for i, row := range f.Table.Rows {
 			outputFileName, err := formatters.ComputeOutputFilename(f.OutputFile, f.OutputFileTemplate, row, i)
 			if err != nil {
-				return "", err
+				return err
 			}
 
-			jsonBytes, err := json.MarshalIndent(row.GetValues(), "", "  ")
+			f_, err := os.Create(outputFileName)
 			if err != nil {
-				return "", err
+				return err
 			}
-			err = os.WriteFile(outputFileName, jsonBytes, 0644)
+
+			encoder := json.NewEncoder(f_)
+			encoder.SetIndent("", "  ")
+			err = encoder.Encode(row.GetValues())
 			if err != nil {
-				return "", err
+				f_.Close()
+				return err
 			}
-			s += fmt.Sprintf("Wrote output to %s\n", outputFileName)
+			f_.Close()
+			_, _ = fmt.Fprintf(w, "Wrote output to %s\n", outputFileName)
 		}
 
-		return s, nil
+		return nil
+	}
+
+	if f.OutputFile != "" {
+		f_, err := os.Create(f.OutputFile)
+		if err != nil {
+			return err
+		}
+		defer f_.Close()
+		w = f_
 	}
 
 	if f.OutputIndividualRows {
-		var buf bytes.Buffer
 		for _, row := range f.Table.Rows {
-			jsonBytes, err := json.MarshalIndent(row.GetValues(), "", "  ")
+			encoder := json.NewEncoder(w)
+			encoder.SetIndent("", "  ")
+			err := encoder.Encode(row.GetValues())
 			if err != nil {
-				return "", err
+				return err
 			}
-			buf.Write(jsonBytes)
 		}
 
-		if f.OutputFile != "" {
-			err := os.WriteFile(f.OutputFile, buf.Bytes(), 0644)
-			if err != nil {
-				return "", err
-			}
-			return "", nil
-		}
-
-		return buf.String(), nil
+		return nil
 	} else {
 		// TODO(manuel, 2022-11-21) We should build a custom JSONMarshal for Table
 		var rows []map[string]interface{}
 		for _, row := range f.Table.Rows {
 			rows = append(rows, row.GetValues())
 		}
-		jsonBytes, err := json.MarshalIndent(rows, "", "  ")
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		err := encoder.Encode(rows)
 		if err != nil {
-			return "", err
+			return err
 		}
 
-		if f.OutputFile != "" {
-			log.Debug().Str("file", f.OutputFile).Msg("Writing output to file")
-			err := os.WriteFile(f.OutputFile, jsonBytes, 0644)
-			if err != nil {
-				return "", err
-			}
-			return "", nil
-		}
-
-		return string(jsonBytes), nil
+		return nil
 	}
 }
 

--- a/pkg/formatters/json/json_test.go
+++ b/pkg/formatters/json/json_test.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
@@ -18,9 +19,11 @@ func TestJSONRenameEndToEnd(t *testing.T) {
 	of.AddTableMiddleware(&table.RenameColumnMiddleware{Renames: renames})
 	of.AddRow(&types.SimpleRow{Hash: map[string]interface{}{"a": 1}})
 	ctx := context.Background()
-	s, err := of.Output(ctx)
+	buf := &bytes.Buffer{}
+	err := of.Output(ctx, buf)
 	require.NoError(t, err)
 
+	s := buf.String()
 	// parse s
 	data := []map[string]interface{}{}
 	err = json.Unmarshal([]byte(s), &data)

--- a/pkg/formatters/json/json_test.go
+++ b/pkg/formatters/json/json_test.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
@@ -16,7 +17,8 @@ func TestJSONRenameEndToEnd(t *testing.T) {
 	}
 	of.AddTableMiddleware(&table.RenameColumnMiddleware{Renames: renames})
 	of.AddRow(&types.SimpleRow{Hash: map[string]interface{}{"a": 1}})
-	s, err := of.Output()
+	ctx := context.Background()
+	s, err := of.Output(ctx)
 	require.NoError(t, err)
 
 	// parse s

--- a/pkg/formatters/simple/simple.go
+++ b/pkg/formatters/simple/simple.go
@@ -1,6 +1,7 @@
 package simple
 
 import (
+	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
@@ -83,7 +84,7 @@ func (s *SingleColumnFormatter) GetTable() (*types.Table, error) {
 	return s.Table, nil
 }
 
-func (s *SingleColumnFormatter) Output() (string, error) {
+func (s *SingleColumnFormatter) Output(context.Context) (string, error) {
 	s.Table.Finalize()
 
 	for _, middleware := range s.middlewares {

--- a/pkg/formatters/table/table.go
+++ b/pkg/formatters/table/table.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/helpers/cast"
@@ -117,7 +118,7 @@ func (tof *OutputFormatter) GetTable() (*types.Table, error) {
 	return tof.Table, nil
 }
 
-func (tof *OutputFormatter) Output() (string, error) {
+func (tof *OutputFormatter) Output(context.Context) (string, error) {
 	tof.Table.Finalize()
 
 	for _, middleware := range tof.middlewares {

--- a/pkg/formatters/table/table_test.go
+++ b/pkg/formatters/table/table_test.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"context"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,8 @@ func TestTableRenameEndToEnd(t *testing.T) {
 	}
 	of.AddTableMiddleware(&table.RenameColumnMiddleware{Renames: renames})
 	of.AddRow(&types.SimpleRow{Hash: map[string]interface{}{"a": 1}})
-	s, err := of.Output()
+	ctx := context.Background()
+	s, err := of.Output(ctx)
 	require.NoError(t, err)
 
 	// parse s

--- a/pkg/formatters/table/table_test.go
+++ b/pkg/formatters/table/table_test.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"bytes"
 	"context"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
@@ -17,9 +18,10 @@ func TestTableRenameEndToEnd(t *testing.T) {
 	of.AddTableMiddleware(&table.RenameColumnMiddleware{Renames: renames})
 	of.AddRow(&types.SimpleRow{Hash: map[string]interface{}{"a": 1}})
 	ctx := context.Background()
-	s, err := of.Output(ctx)
+	buf := &bytes.Buffer{}
+	err := of.Output(ctx, buf)
 	require.NoError(t, err)
 
 	// parse s
-	assert.Equal(t, "| b |\n| --- |\n| 1 |", s)
+	assert.Equal(t, "| b |\n| --- |\n| 1 |", buf.String())
 }

--- a/pkg/formatters/template/template.go
+++ b/pkg/formatters/template/template.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
@@ -45,7 +46,7 @@ func (t *OutputFormatter) AddTableMiddlewareAtIndex(i int, m middlewares.TableMi
 	t.middlewares = append(t.middlewares[:i], append([]middlewares.TableMiddleware{m}, t.middlewares[i:]...)...)
 }
 
-func (t *OutputFormatter) Output() (string, error) {
+func (t *OutputFormatter) Output(context.Context) (string, error) {
 	t.Table.Finalize()
 
 	for _, middleware := range t.middlewares {

--- a/pkg/formatters/template/template.go
+++ b/pkg/formatters/template/template.go
@@ -1,12 +1,12 @@
 package template
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
+	"io"
 	"os"
 	"text/template"
 )
@@ -46,13 +46,13 @@ func (t *OutputFormatter) AddTableMiddlewareAtIndex(i int, m middlewares.TableMi
 	t.middlewares = append(t.middlewares[:i], append([]middlewares.TableMiddleware{m}, t.middlewares[i:]...)...)
 }
 
-func (t *OutputFormatter) Output(context.Context) (string, error) {
+func (t *OutputFormatter) Output(ctx context.Context, w io.Writer) error {
 	t.Table.Finalize()
 
 	for _, middleware := range t.middlewares {
 		newTable, err := middleware.Process(t.Table)
 		if err != nil {
-			return "", err
+			return err
 		}
 		t.Table = newTable
 	}
@@ -63,23 +63,26 @@ func (t *OutputFormatter) Output(context.Context) (string, error) {
 	}
 	tmpl, err := t2.Parse(t.Template)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	if t.OutputMultipleFiles {
 		if t.OutputFileTemplate == "" && t.OutputFile == "" {
-			return "", fmt.Errorf("neither output file or output file template is set")
+			return fmt.Errorf("neither output file or output file template is set")
 		}
-
-		s := ""
 
 		for i, row := range t.Table.Rows {
 			outputFileName, err := formatters.ComputeOutputFilename(t.OutputFile, t.OutputFileTemplate, row, i)
 			if err != nil {
-				return "", err
+				return err
 			}
 
-			var buf bytes.Buffer
+			f_, err := os.Create(outputFileName)
+			if err != nil {
+				return err
+			}
+			defer f_.Close()
+
 			tableData := []map[types.FieldName]interface{}{row.GetValues()}
 
 			data := map[string]interface{}{
@@ -87,24 +90,17 @@ func (t *OutputFormatter) Output(context.Context) (string, error) {
 				"data": t.AdditionalData,
 			}
 
-			err = tmpl.Execute(&buf, data)
-
+			err = tmpl.Execute(f_, data)
 			if err != nil {
-				return "", err
+				return err
 			}
 
-			err = os.WriteFile(outputFileName, buf.Bytes(), 0644)
-			if err != nil {
-				return "", err
-			}
-
-			s += fmt.Sprintf("Wrote output to %s\n", outputFileName)
+			_, _ = fmt.Fprintf(w, "Wrote output to %s\n", outputFileName)
 		}
 
-		return s, nil
+		return nil
 	}
 
-	var buf bytes.Buffer
 	var tableData []map[types.FieldName]interface{}
 	for _, row := range t.Table.Rows {
 		tableData = append(tableData, row.GetValues())
@@ -114,21 +110,22 @@ func (t *OutputFormatter) Output(context.Context) (string, error) {
 		"data": t.AdditionalData,
 	}
 
-	err = tmpl.Execute(&buf, data)
-
-	if err != nil {
-		return "", err
-	}
-
 	if t.OutputFile != "" {
-		err = os.WriteFile(t.OutputFile, buf.Bytes(), 0644)
+		f_, err := os.Create(t.OutputFile)
 		if err != nil {
-			return "", err
+			return err
 		}
-		return "", nil
+		defer f_.Close()
+
+		w = f_
 	}
 
-	return buf.String(), nil
+	err = tmpl.Execute(w, data)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type OutputFormatterOption func(*OutputFormatter)

--- a/pkg/formatters/template/template_test.go
+++ b/pkg/formatters/template/template_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"context"
 	"github.com/Masterminds/sprig"
 	"github.com/go-go-golems/glazed/pkg/helpers/templating"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
@@ -24,7 +25,8 @@ func TestTemplateRenameEndToEnd(t *testing.T) {
 	}
 	of.AddTableMiddleware(&table.RenameColumnMiddleware{Renames: renames})
 	of.AddRow(&types.SimpleRow{Hash: map[string]interface{}{"a": 1}})
-	s, err := of.Output()
+	ctx := context.Background()
+	s, err := of.Output(ctx)
 	require.NoError(t, err)
 
 	assert.Equal(t, `1`, s)

--- a/pkg/formatters/template/template_test.go
+++ b/pkg/formatters/template/template_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"bytes"
 	"context"
 	"github.com/Masterminds/sprig"
 	"github.com/go-go-golems/glazed/pkg/helpers/templating"
@@ -26,8 +27,9 @@ func TestTemplateRenameEndToEnd(t *testing.T) {
 	of.AddTableMiddleware(&table.RenameColumnMiddleware{Renames: renames})
 	of.AddRow(&types.SimpleRow{Hash: map[string]interface{}{"a": 1}})
 	ctx := context.Background()
-	s, err := of.Output(ctx)
+	buf := &bytes.Buffer{}
+	err := of.Output(ctx, buf)
 	require.NoError(t, err)
 
-	assert.Equal(t, `1`, s)
+	assert.Equal(t, `1`, buf.String())
 }

--- a/pkg/formatters/yaml/yaml.go
+++ b/pkg/formatters/yaml/yaml.go
@@ -6,8 +6,8 @@ import (
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
-	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
+	"io"
 	"os"
 )
 
@@ -44,99 +44,87 @@ func (f *OutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableM
 	f.middlewares = append(f.middlewares[:i], append([]middlewares.TableMiddleware{mw}, f.middlewares[i:]...)...)
 }
 
-func (f *OutputFormatter) Output(context.Context) (string, error) {
+func (f *OutputFormatter) Output(ctx context.Context, w io.Writer) error {
 	f.Table.Finalize()
 
 	for _, middleware := range f.middlewares {
 		newTable, err := middleware.Process(f.Table)
 		if err != nil {
-			return "", err
+			return err
 		}
 		f.Table = newTable
 	}
 
 	if f.OutputMultipleFiles {
 		if f.OutputFileTemplate == "" && f.OutputFile == "" {
-			return "", fmt.Errorf("neither output file or output file template is set")
+			return fmt.Errorf("neither output file or output file template is set")
 		}
-
-		s := ""
 
 		for i, row := range f.Table.Rows {
 			outputFileName, err := formatters.ComputeOutputFilename(f.OutputFile, f.OutputFileTemplate, row, i)
 			if err != nil {
-				return "", err
+				return err
 			}
 
-			d, err := yaml.Marshal(row.GetValues())
+			f_, err := os.Create(outputFileName)
 			if err != nil {
-				return "", err
+				return err
 			}
 
-			err = os.WriteFile(outputFileName, d, 0644)
+			encoder := yaml.NewEncoder(f_)
+			err = encoder.Encode(row.GetValues())
 			if err != nil {
-				return "", err
+				f_.Close()
+				return err
 			}
-			s += fmt.Sprintf("Wrote output to %s\n", outputFileName)
+
+			_, _ = fmt.Fprintf(w, "Wrote output to %s\n", outputFileName)
+			f_.Close()
 		}
 
-		return s, nil
+		return nil
 	}
 
 	if f.OutputIndividualRows {
 		if len(f.Table.Rows) > 1 {
-			return "", fmt.Errorf("output individual rows is set but there are multiple rows in the table")
-		}
-
-		if len(f.Table.Rows) == 0 {
-			if f.OutputFile != "" {
-				err := os.WriteFile(f.OutputFile, []byte{}, 0644)
-				if err != nil {
-					return "", err
-				}
-
-				return "Empty table, an empty file was created", nil
-			}
-			return "", nil
-		}
-
-		d, err := yaml.Marshal(f.Table.Rows[0].GetValues())
-		if err != nil {
-			return "", err
+			return fmt.Errorf("output individual rows is set but there are multiple rows in the table")
 		}
 
 		if f.OutputFile != "" {
-			err := os.WriteFile(f.OutputFile, d, 0644)
+			f_, err := os.Create(f.OutputFile)
 			if err != nil {
-				return "", err
+				return err
 			}
-			return "", nil
+			w = f_
+			defer f_.Close()
+
+			if len(f.Table.Rows) == 0 {
+				_, _ = fmt.Fprintln(w, "Empty table, an empty file was created")
+				return nil
+			}
 		}
 
-		return string(d), nil
+		encoder := yaml.NewEncoder(w)
+		err := encoder.Encode(f.Table.Rows[0].GetValues())
+		if err != nil {
+			return err
+		}
+
+		return nil
 	} else {
 		var rows []map[string]interface{}
 		for _, row := range f.Table.Rows {
 			rows = append(rows, row.GetValues())
 		}
 
-		d, err := yaml.Marshal(rows)
+		encoder := yaml.NewEncoder(w)
+		err := encoder.Encode(rows)
 		if err != nil {
-			return "", err
+			return err
 		}
 
-		if f.OutputFile != "" {
-			log.Debug().Str("file", f.OutputFile).Msg("Writing output to file")
-			err := os.WriteFile(f.OutputFile, d, 0644)
-			if err != nil {
-				return "", err
-			}
-			return "", nil
-		}
-
-		return string(d), nil
+		return nil
 	}
-
 }
 
 type OutputFormatterOption func(*OutputFormatter)

--- a/pkg/formatters/yaml/yaml.go
+++ b/pkg/formatters/yaml/yaml.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
@@ -43,7 +44,7 @@ func (f *OutputFormatter) AddTableMiddlewareAtIndex(i int, mw middlewares.TableM
 	f.middlewares = append(f.middlewares[:i], append([]middlewares.TableMiddleware{mw}, f.middlewares[i:]...)...)
 }
 
-func (f *OutputFormatter) Output() (string, error) {
+func (f *OutputFormatter) Output(context.Context) (string, error) {
 	f.Table.Finalize()
 
 	for _, middleware := range f.middlewares {

--- a/pkg/formatters/yaml/yaml_test.go
+++ b/pkg/formatters/yaml/yaml_test.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"context"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +17,8 @@ func TestYAMLRenameEndToEnd(t *testing.T) {
 	}
 	of.AddTableMiddleware(&table.RenameColumnMiddleware{Renames: renames})
 	of.AddRow(&types.SimpleRow{Hash: map[string]interface{}{"a": 1}})
-	s, err := of.Output()
+	ctx := context.Background()
+	s, err := of.Output(ctx)
 	require.NoError(t, err)
 
 	// parse s

--- a/pkg/formatters/yaml/yaml_test.go
+++ b/pkg/formatters/yaml/yaml_test.go
@@ -1,6 +1,7 @@
 package yaml
 
 import (
+	"bytes"
 	"context"
 	"github.com/go-go-golems/glazed/pkg/middlewares/table"
 	"github.com/go-go-golems/glazed/pkg/types"
@@ -18,12 +19,13 @@ func TestYAMLRenameEndToEnd(t *testing.T) {
 	of.AddTableMiddleware(&table.RenameColumnMiddleware{Renames: renames})
 	of.AddRow(&types.SimpleRow{Hash: map[string]interface{}{"a": 1}})
 	ctx := context.Background()
-	s, err := of.Output(ctx)
+	buf := bytes.Buffer{}
+	err := of.Output(ctx, &buf)
 	require.NoError(t, err)
 
 	// parse s
 	data := []map[string]interface{}{}
-	err = yaml.Unmarshal([]byte(s), &data)
+	err = yaml.Unmarshal(buf.Bytes(), &data)
 	require.NoError(t, err)
 	require.Len(t, data, 1)
 

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -1,4 +1,4 @@
-package cmds
+package processor
 
 import (
 	"github.com/go-go-golems/glazed/pkg/formatters"

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -1,14 +1,17 @@
 package processor
 
 import (
+	"context"
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/formatters/table"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 )
 
+// TODO(manuel, 2023-04-27) This is probably a good location for With* constructors for middlewares
+
 type Processor interface {
-	ProcessInputObject(obj map[string]interface{}) error
+	ProcessInputObject(ctx context.Context, obj map[string]interface{}) error
 	OutputFormatter() formatters.OutputFormatter
 }
 
@@ -37,7 +40,7 @@ func NewGlazeProcessor(of formatters.OutputFormatter, oms ...middlewares.ObjectM
 // chain.
 //
 // The final output is added to the output formatter as a single row.
-func (gp *GlazeProcessor) ProcessInputObject(obj map[string]interface{}) error {
+func (gp *GlazeProcessor) ProcessInputObject(ctx context.Context, obj map[string]interface{}) error {
 	currentObjects := []map[string]interface{}{obj}
 
 	for _, om := range gp.oms {

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -1,0 +1,47 @@
+package processor
+
+import (
+	"context"
+	"github.com/go-go-golems/glazed/pkg/formatters/json"
+	"testing"
+)
+
+// BenchmarkSimpleGlazeProcessor benchmarks the simple glaze processor with no middlewares, and CSV output.
+func BenchmarkSimpleGlazeProcessor(b *testing.B) {
+	ctx := context.Background()
+	gp := NewSimpleGlazeProcessor()
+	data := map[string]interface{}{
+		"name":    "Manuel Manuel",
+		"age":     30,
+		"job":     "Software Engineer",
+		"city":    "Lisbon",
+		"country": "Portugal",
+		"email":   "manuel@gogogogogogogogo.gogo",
+		"phone":   "+351 123 456 789",
+	}
+	for i := 0; i < b.N; i++ {
+		_ = gp.ProcessInputObject(ctx, data)
+	}
+	s, _ := gp.OutputFormatter().Output(ctx)
+	_ = s
+}
+
+func BenchmarkGlazeProcessor_JSONOutputFormatter(b *testing.B) {
+	ctx := context.Background()
+
+	gp := NewGlazeProcessor(json.NewOutputFormatter())
+	data := map[string]interface{}{
+		"name":    "Manuel Manuel",
+		"age":     30,
+		"job":     "Software Engineer",
+		"city":    "Lisbon",
+		"country": "Portugal",
+		"email":   "manuel@gogogogogogogogo.gogo",
+		"phone":   "+351 123 456 789",
+	}
+	for i := 0; i < b.N; i++ {
+		_ = gp.ProcessInputObject(ctx, data)
+	}
+	s, _ := gp.OutputFormatter().Output(ctx)
+	_ = s
+}

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"bytes"
 	"context"
 	"github.com/go-go-golems/glazed/pkg/formatters/json"
 	"testing"
@@ -22,8 +23,8 @@ func BenchmarkSimpleGlazeProcessor(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = gp.ProcessInputObject(ctx, data)
 	}
-	s, _ := gp.OutputFormatter().Output(ctx)
-	_ = s
+	buf := &bytes.Buffer{}
+	_ = gp.OutputFormatter().Output(ctx, buf)
 }
 
 func BenchmarkGlazeProcessor_JSONOutputFormatter(b *testing.B) {
@@ -42,6 +43,6 @@ func BenchmarkGlazeProcessor_JSONOutputFormatter(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = gp.ProcessInputObject(ctx, data)
 	}
-	s, _ := gp.OutputFormatter().Output(ctx)
-	_ = s
+	buf := &bytes.Buffer{}
+	_ = gp.OutputFormatter().Output(ctx, buf)
 }


### PR DESCRIPTION
- :tractor: Move processor to its own package
- :art: Break API and add Context parameter to Output()
- :art: Bump go.mod
- :fire: :sparkles: Add writer to all output formatters
