### PR TITLE
:art: Add new processor options and don't template streams to string for HTML

### DIFF
--- a/pkg/cmds/layers/groups.go
+++ b/pkg/cmds/layers/groups.go
@@ -44,6 +44,14 @@ func (ppl *ParsedParameterLayer) Clone() *ParsedParameterLayer {
 	return ret
 }
 
+// MergeParameters merges the other ParsedParameterLayer into this one, overwriting any
+// existing values. This doesn't replace the actual Layer pointer.
+func (ppl *ParsedParameterLayer) MergeParameters(other *ParsedParameterLayer) {
+	for k, v := range other.Parameters {
+		ppl.Parameters[k] = v
+	}
+}
+
 // ParameterLayerParserFunc is a type meant to represent closures capturing some "complex" process
 // by which a ParsedParameterLayer can be produced, for example parsing a layer out of a cobra.Command
 // after flags were registered (see CobraParser).

--- a/pkg/formatters/formatter.go
+++ b/pkg/formatters/formatter.go
@@ -86,9 +86,9 @@ func ComputeOutputFilename(outputFile string, outputFileTemplate string, row typ
 func StartFormatIntoChannel[T interface{ ~string }](
 	ctx context.Context,
 	formatter OutputFormatter,
-) <-chan T {
+) <-chan string {
 	reader, writer := io.Pipe()
-	c := make(chan T)
+	c := make(chan string)
 
 	eg, ctx2 := errgroup.WithContext(ctx)
 
@@ -107,7 +107,7 @@ func StartFormatIntoChannel[T interface{ ~string }](
 					return err
 				}
 
-				c <- T(buf[:n])
+				c <- string(T(buf[:n]))
 			}
 		}
 	})

--- a/pkg/formatters/formatter.go
+++ b/pkg/formatters/formatter.go
@@ -86,9 +86,9 @@ func ComputeOutputFilename(outputFile string, outputFileTemplate string, row typ
 func StartFormatIntoChannel[T interface{ ~string }](
 	ctx context.Context,
 	formatter OutputFormatter,
-) <-chan string {
+) <-chan T {
 	reader, writer := io.Pipe()
-	c := make(chan string)
+	c := make(chan T)
 
 	eg, ctx2 := errgroup.WithContext(ctx)
 
@@ -107,7 +107,7 @@ func StartFormatIntoChannel[T interface{ ~string }](
 					return err
 				}
 
-				c <- string(T(buf[:n]))
+				c <- T(buf[:n])
 			}
 		}
 	})

--- a/pkg/helpers/templating/templating.go
+++ b/pkg/helpers/templating/templating.go
@@ -11,6 +11,7 @@ import (
 	html "html/template"
 	"io"
 	"io/fs"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -573,6 +574,7 @@ func ParseHTMLFS(t *html.Template, f fs.FS, patterns []string, baseDir string) e
 	list := []string{}
 
 	for _, pattern := range patterns {
+		pattern = filepath.Join(baseDir, pattern)
 		err := doublestar.GlobWalk(f, pattern, func(path string, d fs.DirEntry) error {
 			if !strings.HasPrefix(path, baseDir) {
 				return nil

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -24,10 +24,34 @@ func (gp *GlazeProcessor) OutputFormatter() formatters.OutputFormatter {
 	return gp.of
 }
 
-func NewGlazeProcessor(of formatters.OutputFormatter, oms ...middlewares.ObjectMiddleware) *GlazeProcessor {
+type GlazeProcessorOption func(*GlazeProcessor)
+
+func WithAppendObjectMiddleware(om ...middlewares.ObjectMiddleware) GlazeProcessorOption {
+	return func(gp *GlazeProcessor) {
+		gp.oms = append(gp.oms, om...)
+	}
+}
+
+func WithPrependObjectMiddleware(om ...middlewares.ObjectMiddleware) GlazeProcessorOption {
+	return func(gp *GlazeProcessor) {
+		gp.oms = append(om, gp.oms...)
+	}
+}
+
+func WithOutputFormatter(of formatters.OutputFormatter) GlazeProcessorOption {
+	return func(gp *GlazeProcessor) {
+		gp.of = of
+	}
+}
+
+func NewGlazeProcessor(of formatters.OutputFormatter, options ...GlazeProcessorOption) *GlazeProcessor {
 	ret := &GlazeProcessor{
 		of:  of,
-		oms: oms,
+		oms: []middlewares.ObjectMiddleware{},
+	}
+
+	for _, option := range options {
+		option(ret)
 	}
 
 	return ret
@@ -67,10 +91,10 @@ type SimpleGlazeProcessor struct {
 	formatter *table.OutputFormatter
 }
 
-func NewSimpleGlazeProcessor(oms ...middlewares.ObjectMiddleware) *SimpleGlazeProcessor {
+func NewSimpleGlazeProcessor(options ...GlazeProcessorOption) *SimpleGlazeProcessor {
 	formatter := table.NewOutputFormatter("csv")
 	return &SimpleGlazeProcessor{
-		GlazeProcessor: NewGlazeProcessor(formatter, oms...),
+		GlazeProcessor: NewGlazeProcessor(formatter, options...),
 		formatter:      formatter,
 	}
 }

--- a/pkg/settings/glazed_layer.go
+++ b/pkg/settings/glazed_layer.go
@@ -368,7 +368,7 @@ func NewGlazedParameterLayers(options ...GlazeParameterLayerOption) (*GlazedPara
 	return ret, nil
 }
 
-func SetupProcessor(ps map[string]interface{}) (*processor.GlazeProcessor, error) {
+func SetupProcessor(ps map[string]interface{}, options ...processor.GlazeProcessorOption) (*processor.GlazeProcessor, error) {
 	// TODO(manuel, 2023-03-06): This is where we should check that flags that are mutually incompatible don't clash
 	//
 	// See: https://github.com/go-go-golems/glazed/issues/199
@@ -476,6 +476,8 @@ func SetupProcessor(ps map[string]interface{}) (*processor.GlazeProcessor, error
 	// is not trivial.
 	sortSettings.AddMiddlewares(of)
 
-	gp := processor.NewGlazeProcessor(of, middlewares_...)
+	options_ := append(options, processor.WithAppendObjectMiddleware(middlewares_...))
+
+	gp := processor.NewGlazeProcessor(of, options_...)
 	return gp, nil
 }


### PR DESCRIPTION
- :ambulance: Join baseDir to strip from template name when loading things from ParseHTMLFS
- :art: Add MergeParameters helper method
- :art: Use processor options for configuring processors
- :ambulance: Fix rendering of datatables template
