### PR TITLE
:poop: :broom: :art: Cleanup Processor

### DIFF
--- a/cmd/glaze/cmds/csv.go
+++ b/cmd/glaze/cmds/csv.go
@@ -81,7 +81,7 @@ func (c *CsvCommand) Run(
 	ctx context.Context,
 	parsedLayers map[string]*layers.ParsedParameterLayer,
 	ps map[string]interface{},
-	gp processor.Processor,
+	gp processor.TableProcessor,
 ) error {
 	inputFiles, ok := ps["input-files"].([]string)
 	if !ok {

--- a/cmd/glaze/cmds/csv.go
+++ b/cmd/glaze/cmds/csv.go
@@ -150,11 +150,11 @@ func (c *CsvCommand) Run(
 		}
 	}
 
-	err := gp.Processor().FinalizeTable(ctx)
+	err := gp.Finalize(ctx)
 	if err != nil {
 		return errors.Wrap(err, "could not finalize table")
 	}
-	table := gp.Processor().GetTable()
+	table := gp.GetTable()
 	table.Columns = finalHeaders
 
 	return nil

--- a/cmd/glaze/cmds/csv.go
+++ b/cmd/glaze/cmds/csv.go
@@ -135,7 +135,7 @@ func (c *CsvCommand) Run(
 		}
 
 		for _, row := range s {
-			err = gp.ProcessInputObject(ctx, types.NewRowFromMapWithColumns(row, header))
+			err = gp.AddRow(ctx, types.NewRowFromMapWithColumns(row, header))
 			if err != nil {
 				return errors.Wrap(err, "could not process CSV row")
 			}

--- a/cmd/glaze/cmds/docs.go
+++ b/cmd/glaze/cmds/docs.go
@@ -34,7 +34,7 @@ var DocsCmd = &cobra.Command{
 
 			// TODO(manuel, 2023-06-25) It would be nice to unmarshal the YAML to an orderedmap
 			// See https://github.com/go-go-golems/glazed/issues/305
-			err = gp.ProcessInputObject(ctx, metaData)
+			err = gp.AddRow(ctx, metaData)
 			cobra.CheckErr(err)
 		}
 

--- a/cmd/glaze/cmds/docs.go
+++ b/cmd/glaze/cmds/docs.go
@@ -38,9 +38,9 @@ var DocsCmd = &cobra.Command{
 			cobra.CheckErr(err)
 		}
 
-		err = gp.Processor().FinalizeTable(ctx)
+		err = gp.Finalize(ctx)
 		cobra.CheckErr(err)
-		err = gp.OutputFormatter().Output(ctx, gp.Processor().GetTable(), os.Stdout)
+		err = gp.OutputFormatter().Output(ctx, gp.GetTable(), os.Stdout)
 		cobra.CheckErr(err)
 	},
 }

--- a/cmd/glaze/cmds/html/cmds.go
+++ b/cmd/glaze/cmds/html/cmds.go
@@ -40,10 +40,10 @@ func NewHTMLCommand() (*cobra.Command, error) {
 				cobra.CheckErr(err)
 			}
 
-			err = gp.Processor().FinalizeTable(ctx)
+			err = gp.Finalize(ctx)
 			cobra.CheckErr(err)
 
-			err = gp.OutputFormatter().Output(ctx, gp.Processor().GetTable(), os.Stdout)
+			err = gp.OutputFormatter().Output(ctx, gp.GetTable(), os.Stdout)
 			cobra.CheckErr(err)
 			if _, ok := err.(*cmds.ExitWithoutGlazeError); ok {
 				os.Exit(0)
@@ -98,10 +98,10 @@ func NewHTMLCommand() (*cobra.Command, error) {
 				cobra.CheckErr(err)
 			}
 
-			err = gp.Processor().FinalizeTable(ctx)
+			err = gp.Finalize(ctx)
 			cobra.CheckErr(err)
 
-			err = gp.OutputFormatter().Output(ctx, gp.Processor().GetTable(), os.Stdout)
+			err = gp.OutputFormatter().Output(ctx, gp.GetTable(), os.Stdout)
 			cobra.CheckErr(err)
 			if _, ok := err.(*cmds.ExitWithoutGlazeError); ok {
 				os.Exit(0)

--- a/cmd/glaze/cmds/html/parse.go
+++ b/cmd/glaze/cmds/html/parse.go
@@ -12,13 +12,13 @@ import (
 // When encountering one of the tags in splitTags, it extracts the content below the tag as Title
 // (if extractTitle is true) and the following siblings until the next split tag is encountered as body.
 type HTMLSplitParser struct {
-	gp           processor.Processor
+	gp           processor.TableProcessor
 	removeTags   []string
 	splitTags    []string
 	extractTitle bool
 }
 
-func NewHTMLSplitParser(gp processor.Processor, removeTags, splitTags []string, extractTitle bool) *HTMLSplitParser {
+func NewHTMLSplitParser(gp processor.TableProcessor, removeTags, splitTags []string, extractTitle bool) *HTMLSplitParser {
 	return &HTMLSplitParser{
 		gp:           gp,
 		removeTags:   removeTags,
@@ -29,7 +29,7 @@ func NewHTMLSplitParser(gp processor.Processor, removeTags, splitTags []string, 
 
 // NewHTMLHeadingSplitParser creates a new HTMLSplitParser that splits the document into sections
 // and keeps the titles, by splitting at h1, h2, h3...
-func NewHTMLHeadingSplitParser(gp processor.Processor, removeTags []string) *HTMLSplitParser {
+func NewHTMLHeadingSplitParser(gp processor.TableProcessor, removeTags []string) *HTMLSplitParser {
 	tags := []string{"h1", "h2", "h3", "h4", "h5", "h6"}
 	removeTags = append(removeTags, tags...)
 	return NewHTMLSplitParser(gp, removeTags, tags, true)

--- a/cmd/glaze/cmds/html/parse.go
+++ b/cmd/glaze/cmds/html/parse.go
@@ -96,7 +96,7 @@ func (hsp *HTMLSplitParser) ProcessNode(ctx context.Context, n *html.Node) (*htm
 		}
 		row.Set("Body", strings.TrimSpace(body.String()))
 
-		err := hsp.gp.ProcessInputObject(ctx, row)
+		err := hsp.gp.AddRow(ctx, row)
 		if err != nil {
 			return nil, err
 		}
@@ -197,7 +197,7 @@ func outputNodesDepthFirst(ctx context.Context, doc *html.Node, gp *processor.Gl
 		types.MRP("Attributes", attributes),
 	)
 
-	err := gp.ProcessInputObject(ctx, obj)
+	err := gp.AddRow(ctx, obj)
 	if err != nil {
 		return err
 	}

--- a/cmd/glaze/cmds/html/parse_test.go
+++ b/cmd/glaze/cmds/html/parse_test.go
@@ -16,7 +16,7 @@ import (
 
 type TestProcessor struct {
 	Objects   []types.Row
-	formatter formatters.OutputFormatter
+	formatter formatters.TableOutputFormatter
 	processor *middlewares.Processor
 }
 
@@ -54,7 +54,7 @@ func (t *TestProcessor) AddRow(ctx context.Context, obj types.Row) error {
 	return nil
 }
 
-func (t *TestProcessor) OutputFormatter() formatters.OutputFormatter {
+func (t *TestProcessor) OutputFormatter() formatters.TableOutputFormatter {
 	return nil
 }
 

--- a/cmd/glaze/cmds/html/parse_test.go
+++ b/cmd/glaze/cmds/html/parse_test.go
@@ -20,6 +20,14 @@ type TestProcessor struct {
 	processor *middlewares.Processor
 }
 
+func (t *TestProcessor) Finalize(ctx context.Context) error {
+	return t.processor.Finalize(ctx)
+}
+
+func (t *TestProcessor) GetTable() *types.Table {
+	return t.processor.GetTable()
+}
+
 func NewTestProcessor() *TestProcessor {
 	return &TestProcessor{
 		formatter: &TestFormatter{},
@@ -28,6 +36,10 @@ func NewTestProcessor() *TestProcessor {
 }
 
 type TestFormatter struct{}
+
+func (t TestFormatter) RegisterMiddlewares(mw *middlewares.Processor) error {
+	return nil
+}
 
 func (t TestFormatter) ContentType() string {
 	return "text/plain"

--- a/cmd/glaze/cmds/html/parse_test.go
+++ b/cmd/glaze/cmds/html/parse_test.go
@@ -20,6 +20,9 @@ type TestProcessor struct {
 	processor *middlewares.Processor
 }
 
+func (t *TestProcessor) AddRowMiddleware(mw ...middlewares.RowMiddleware) {
+}
+
 func (t *TestProcessor) Finalize(ctx context.Context) error {
 	return t.processor.Finalize(ctx)
 }

--- a/cmd/glaze/cmds/html/parse_test.go
+++ b/cmd/glaze/cmds/html/parse_test.go
@@ -49,7 +49,7 @@ func (t TestFormatter) Output(context.Context, *types.Table, io.Writer) error {
 	return nil
 }
 
-func (t *TestProcessor) ProcessInputObject(ctx context.Context, obj types.Row) error {
+func (t *TestProcessor) AddRow(ctx context.Context, obj types.Row) error {
 	t.Objects = append(t.Objects, obj)
 	return nil
 }

--- a/cmd/glaze/cmds/html/parse_test.go
+++ b/cmd/glaze/cmds/html/parse_test.go
@@ -66,8 +66,8 @@ func TestSimpleHeaderParse(t *testing.T) {
 	assert.Nil(t, n)
 
 	require.Equal(t, 1, len(gp.Objects))
-	assert2.EqualMapRowValue(t, "Header", gp.Objects[0], "Title")
-	assert2.EqualMapRowValue(t, "h1", gp.Objects[0], "Tag")
+	assert2.EqualRowValue(t, "Header", gp.Objects[0], "Title")
+	assert2.EqualRowValue(t, "h1", gp.Objects[0], "Tag")
 }
 
 func TestTwoHeadersParse(t *testing.T) {
@@ -87,11 +87,11 @@ func TestTwoHeadersParse(t *testing.T) {
 
 	assert.Equal(t, 2, len(gp.Objects))
 
-	assert2.EqualMapRowValue(t, "Header", gp.Objects[0], "Title")
-	assert2.EqualMapRowValue(t, "h1", gp.Objects[0], "Tag")
+	assert2.EqualRowValue(t, "Header", gp.Objects[0], "Title")
+	assert2.EqualRowValue(t, "h1", gp.Objects[0], "Tag")
 
-	assert2.EqualMapRowValue(t, "Subheader", gp.Objects[1], "Title")
-	assert2.EqualMapRowValue(t, "h2", gp.Objects[1], "Tag")
+	assert2.EqualRowValue(t, "Subheader", gp.Objects[1], "Title")
+	assert2.EqualRowValue(t, "h2", gp.Objects[1], "Tag")
 }
 
 func TestTwoHeadersBody(t *testing.T) {
@@ -121,11 +121,11 @@ func TestTwoHeadersBody(t *testing.T) {
 
 	assert.Equal(t, 2, len(gp.Objects))
 
-	assert2.EqualMapRowValue(t, "Header", gp.Objects[0], "Title")
-	assert2.EqualMapRowValue(t, "h1", gp.Objects[0], "Tag")
+	assert2.EqualRowValue(t, "Header", gp.Objects[0], "Title")
+	assert2.EqualRowValue(t, "h1", gp.Objects[0], "Tag")
 
-	assert2.EqualMapRowValue(t, "Subheader", gp.Objects[1], "Title")
-	assert2.EqualMapRowValue(t, "h2", gp.Objects[1], "Tag")
+	assert2.EqualRowValue(t, "Subheader", gp.Objects[1], "Title")
+	assert2.EqualRowValue(t, "h2", gp.Objects[1], "Tag")
 }
 
 func TestTwoHeadersSomeTextBody(t *testing.T) {
@@ -157,13 +157,13 @@ func TestTwoHeadersSomeTextBody(t *testing.T) {
 
 	assert.Equal(t, 2, len(gp.Objects))
 
-	assert2.EqualMapRowValue(t, "Header", gp.Objects[0], "Title")
-	assert2.EqualMapRowValue(t, "h1", gp.Objects[0], "Tag")
-	assert2.EqualMapRowValue(t, "<p>Some text</p>", gp.Objects[0], "Body")
+	assert2.EqualRowValue(t, "Header", gp.Objects[0], "Title")
+	assert2.EqualRowValue(t, "h1", gp.Objects[0], "Tag")
+	assert2.EqualRowValue(t, "<p>Some text</p>", gp.Objects[0], "Body")
 
-	assert2.EqualMapRowValue(t, "Subheader", gp.Objects[1], "Title")
-	assert2.EqualMapRowValue(t, "h2", gp.Objects[1], "Tag")
-	assert2.EqualMapRowValue(t, "<p>Some text</p>", gp.Objects[1], "Body")
+	assert2.EqualRowValue(t, "Subheader", gp.Objects[1], "Title")
+	assert2.EqualRowValue(t, "h2", gp.Objects[1], "Tag")
+	assert2.EqualRowValue(t, "<p>Some text</p>", gp.Objects[1], "Body")
 }
 
 func TestTwoHeadersSomeTextNodes(t *testing.T) {
@@ -197,13 +197,13 @@ func TestTwoHeadersSomeTextNodes(t *testing.T) {
 
 	assert.Equal(t, 2, len(gp.Objects))
 
-	assert2.EqualMapRowValue(t, "Header", gp.Objects[0], "Title")
-	assert2.EqualMapRowValue(t, "h1", gp.Objects[0], "Tag")
-	assert2.EqualMapRowValue(t, "<p>Some text</p>\n\t\t<p>Some text2</p>\n\t\t<p>Some text3</p>", gp.Objects[0], "Body")
+	assert2.EqualRowValue(t, "Header", gp.Objects[0], "Title")
+	assert2.EqualRowValue(t, "h1", gp.Objects[0], "Tag")
+	assert2.EqualRowValue(t, "<p>Some text</p>\n\t\t<p>Some text2</p>\n\t\t<p>Some text3</p>", gp.Objects[0], "Body")
 
-	assert2.EqualMapRowValue(t, "Subheader", gp.Objects[1], "Title")
-	assert2.EqualMapRowValue(t, "h2", gp.Objects[1], "Tag")
-	assert2.EqualMapRowValue(t, "<p>Some text</p>", gp.Objects[1], "Body")
+	assert2.EqualRowValue(t, "Subheader", gp.Objects[1], "Title")
+	assert2.EqualRowValue(t, "h2", gp.Objects[1], "Tag")
+	assert2.EqualRowValue(t, "<p>Some text</p>", gp.Objects[1], "Body")
 
 	gp = NewTestProcessor()
 	hsp = NewHTMLHeadingSplitParser(gp, []string{"p"})
@@ -214,13 +214,13 @@ func TestTwoHeadersSomeTextNodes(t *testing.T) {
 
 	assert.Equal(t, 2, len(gp.Objects))
 
-	assert2.EqualMapRowValue(t, "Header", gp.Objects[0], "Title")
-	assert2.EqualMapRowValue(t, "h1", gp.Objects[0], "Tag")
-	assert2.EqualMapRowValue(t, "Some text\n\t\tSome text2\n\t\tSome text3", gp.Objects[0], "Body")
+	assert2.EqualRowValue(t, "Header", gp.Objects[0], "Title")
+	assert2.EqualRowValue(t, "h1", gp.Objects[0], "Tag")
+	assert2.EqualRowValue(t, "Some text\n\t\tSome text2\n\t\tSome text3", gp.Objects[0], "Body")
 
-	assert2.EqualMapRowValue(t, "Subheader", gp.Objects[1], "Title")
-	assert2.EqualMapRowValue(t, "h2", gp.Objects[1], "Tag")
-	assert2.EqualMapRowValue(t, "Some text", gp.Objects[1], "Body")
+	assert2.EqualRowValue(t, "Subheader", gp.Objects[1], "Title")
+	assert2.EqualRowValue(t, "h2", gp.Objects[1], "Tag")
+	assert2.EqualRowValue(t, "Some text", gp.Objects[1], "Body")
 }
 
 func TestStripTags(t *testing.T) {
@@ -251,13 +251,13 @@ func TestStripTags(t *testing.T) {
 
 	assert.Equal(t, 2, len(gp.Objects))
 
-	assert2.EqualMapRowValue(t, "Header", gp.Objects[0], "Title")
-	assert2.EqualMapRowValue(t, "h1", gp.Objects[0], "Tag")
-	assert2.EqualMapRowValue(t, "Some text<b>Foobar</b> <strong>Test</strong>", gp.Objects[0], "Body")
+	assert2.EqualRowValue(t, "Header", gp.Objects[0], "Title")
+	assert2.EqualRowValue(t, "h1", gp.Objects[0], "Tag")
+	assert2.EqualRowValue(t, "Some text<b>Foobar</b> <strong>Test</strong>", gp.Objects[0], "Body")
 
-	assert2.EqualMapRowValue(t, "Subheader <strong>Foobar</strong>Test", gp.Objects[1], "Title")
-	assert2.EqualMapRowValue(t, "h2", gp.Objects[1], "Tag")
-	assert2.EqualMapRowValue(t, "Some text", gp.Objects[1], "Body")
+	assert2.EqualRowValue(t, "Subheader <strong>Foobar</strong>Test", gp.Objects[1], "Title")
+	assert2.EqualRowValue(t, "h2", gp.Objects[1], "Tag")
+	assert2.EqualRowValue(t, "Some text", gp.Objects[1], "Body")
 }
 
 func TestSplitOtherTags(t *testing.T) {
@@ -278,11 +278,11 @@ func TestSplitOtherTags(t *testing.T) {
 
 	assert.Equal(t, 2, len(gp.Objects))
 
-	assert2.EqualMapRowValue(t, "Foobar", gp.Objects[0], "Title")
-	assert2.EqualMapRowValue(t, "p", gp.Objects[0], "Tag")
+	assert2.EqualRowValue(t, "Foobar", gp.Objects[0], "Title")
+	assert2.EqualRowValue(t, "p", gp.Objects[0], "Tag")
 
-	assert2.EqualMapRowValue(t, "Test", gp.Objects[1], "Title")
-	assert2.EqualMapRowValue(t, "p", gp.Objects[1], "Tag")
+	assert2.EqualRowValue(t, "Test", gp.Objects[1], "Title")
+	assert2.EqualRowValue(t, "p", gp.Objects[1], "Tag")
 }
 
 func TestSplitOtherTagsWithoutTitle(t *testing.T) {
@@ -303,13 +303,13 @@ func TestSplitOtherTagsWithoutTitle(t *testing.T) {
 
 	assert.Equal(t, 2, len(gp.Objects))
 
-	assert2.EqualMapRowValue(t, "", gp.Objects[0], "Title")
-	assert2.EqualMapRowValue(t, "p", gp.Objects[0], "Tag")
-	assert2.EqualMapRowValue(t, "Foobar", gp.Objects[0], "Body")
+	assert2.EqualRowValue(t, "", gp.Objects[0], "Title")
+	assert2.EqualRowValue(t, "p", gp.Objects[0], "Tag")
+	assert2.EqualRowValue(t, "Foobar", gp.Objects[0], "Body")
 
-	assert2.EqualMapRowValue(t, "", gp.Objects[1], "Title")
-	assert2.EqualMapRowValue(t, "p", gp.Objects[1], "Tag")
-	assert2.EqualMapRowValue(t, "Test", gp.Objects[1], "Body")
+	assert2.EqualRowValue(t, "", gp.Objects[1], "Title")
+	assert2.EqualRowValue(t, "p", gp.Objects[1], "Tag")
+	assert2.EqualRowValue(t, "Test", gp.Objects[1], "Body")
 
 	gp = NewTestProcessor()
 	hsp = NewHTMLSplitParser(gp, []string{}, []string{"p"}, false)
@@ -320,11 +320,11 @@ func TestSplitOtherTagsWithoutTitle(t *testing.T) {
 
 	assert.Equal(t, 2, len(gp.Objects))
 
-	assert2.EqualMapRowValue(t, "", gp.Objects[0], "Title")
-	assert2.EqualMapRowValue(t, "p", gp.Objects[0], "Tag")
-	assert2.EqualMapRowValue(t, "<p>Foobar</p>", gp.Objects[0], "Body")
+	assert2.EqualRowValue(t, "", gp.Objects[0], "Title")
+	assert2.EqualRowValue(t, "p", gp.Objects[0], "Tag")
+	assert2.EqualRowValue(t, "<p>Foobar</p>", gp.Objects[0], "Body")
 
-	assert2.EqualMapRowValue(t, "", gp.Objects[1], "Title")
-	assert2.EqualMapRowValue(t, "p", gp.Objects[1], "Tag")
-	assert2.EqualMapRowValue(t, "<p>Test</p>", gp.Objects[1], "Body")
+	assert2.EqualRowValue(t, "", gp.Objects[1], "Title")
+	assert2.EqualRowValue(t, "p", gp.Objects[1], "Tag")
+	assert2.EqualRowValue(t, "<p>Test</p>", gp.Objects[1], "Body")
 }

--- a/cmd/glaze/cmds/json.go
+++ b/cmd/glaze/cmds/json.go
@@ -84,7 +84,7 @@ func (j *JsonCommand) Run(
 
 			i := 1
 			for _, d := range data {
-				err = gp.ProcessInputObject(ctx, d)
+				err = gp.AddRow(ctx, d)
 				if err != nil {
 					return errors.Wrapf(err, "Error processing row %d of file %s as object", i, arg)
 				}
@@ -98,7 +98,7 @@ func (j *JsonCommand) Run(
 				return errors.Wrapf(err, "Error decoding file %s as object", arg)
 			}
 
-			err = gp.ProcessInputObject(ctx, data)
+			err = gp.AddRow(ctx, data)
 			if err != nil {
 				return errors.Wrapf(err, "Error processing file %s as object", arg)
 			}

--- a/cmd/glaze/cmds/json.go
+++ b/cmd/glaze/cmds/json.go
@@ -54,7 +54,7 @@ func (j *JsonCommand) Run(
 	ctx context.Context,
 	parsedLayers map[string]*layers.ParsedParameterLayer,
 	ps map[string]interface{},
-	gp processor.Processor,
+	gp processor.TableProcessor,
 ) error {
 	inputIsArray, ok := ps["input-is-array"].(bool)
 	if !ok {

--- a/cmd/glaze/cmds/markdown.go
+++ b/cmd/glaze/cmds/markdown.go
@@ -166,10 +166,10 @@ var parseCmd = &cobra.Command{
 
 		_ = gp
 
-		err = gp.Processor().FinalizeTable(ctx)
+		err = gp.Finalize(ctx)
 		cobra.CheckErr(err)
 
-		err = gp.OutputFormatter().Output(ctx, gp.Processor().GetTable(), os.Stdout)
+		err = gp.OutputFormatter().Output(ctx, gp.GetTable(), os.Stdout)
 		if _, ok := err.(*cmds.ExitWithoutGlazeError); ok {
 			os.Exit(0)
 		}
@@ -389,10 +389,10 @@ var splitByHeadingCmd = &cobra.Command{
 
 		_ = gp
 
-		err = gp.Processor().FinalizeTable(ctx)
+		err = gp.Finalize(ctx)
 		cobra.CheckErr(err)
 
-		err = gp.OutputFormatter().Output(ctx, gp.Processor().GetTable(), os.Stdout)
+		err = gp.OutputFormatter().Output(ctx, gp.GetTable(), os.Stdout)
 		if _, ok := err.(*cmds.ExitWithoutGlazeError); ok {
 			os.Exit(0)
 		}

--- a/cmd/glaze/cmds/markdown.go
+++ b/cmd/glaze/cmds/markdown.go
@@ -255,7 +255,7 @@ func splitByHeading(ctx context.Context, md goldmark.Markdown, s []byte, gp *pro
 	// fold the headings
 
 	for _, elt := range outputStack {
-		err = gp.ProcessInputObject(ctx, elt)
+		err = gp.AddRow(ctx, elt)
 		if err != nil {
 			return err
 		}
@@ -307,7 +307,7 @@ func simpleLinearize(ctx context.Context, md goldmark.Markdown, s []byte, gp *pr
 	}
 
 	for _, elt := range outputStack {
-		err = gp.ProcessInputObject(ctx, elt)
+		err = gp.AddRow(ctx, elt)
 		if err != nil {
 			return err
 		}
@@ -364,7 +364,7 @@ var splitByHeadingCmd = &cobra.Command{
 						types.MRP("heading", currentTitle),
 						types.MRP("content", strings.Trim(strings.Join(current, "\n"), " \n\t")),
 					)
-					err = gp.ProcessInputObject(ctx, row)
+					err = gp.AddRow(ctx, row)
 					cobra.CheckErr(err)
 
 					currentTitle = ""

--- a/cmd/glaze/cmds/yaml.go
+++ b/cmd/glaze/cmds/yaml.go
@@ -121,7 +121,7 @@ func (y *YamlCommand) Run(
 
 			i := 1
 			for _, d := range data {
-				err = gp.ProcessInputObject(ctx, d)
+				err = gp.AddRow(ctx, d)
 				if err != nil {
 					return errors.Wrapf(err, "Error processing row %d of file %s as object", i, arg)
 				}
@@ -138,7 +138,7 @@ func (y *YamlCommand) Run(
 				}
 				return errors.Wrapf(err, "Error decoding file %s as object", arg)
 			}
-			err = gp.ProcessInputObject(ctx, data)
+			err = gp.AddRow(ctx, data)
 			if err != nil {
 				return errors.Wrapf(err, "Error processing file %s as object", arg)
 			}

--- a/cmd/glaze/cmds/yaml.go
+++ b/cmd/glaze/cmds/yaml.go
@@ -64,7 +64,7 @@ func (y *YamlCommand) Run(
 	ctx context.Context,
 	_ map[string]*layers.ParsedParameterLayer,
 	ps map[string]interface{},
-	gp processor.Processor,
+	gp processor.TableProcessor,
 ) error {
 	inputIsArray, ok := ps["input-is-array"].(bool)
 	if !ok {

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -569,10 +569,10 @@ func BuildCobraCommandFromGlazeCommand(cmd_ cmds.GlazeCommand) (*cobra.Command, 
 			cobra.CheckErr(err)
 		}
 
-		err = gp.Processor().FinalizeTable(ctx)
+		err = gp.Finalize(ctx)
 		cobra.CheckErr(err)
 
-		err = gp.OutputFormatter().Output(ctx, gp.Processor().GetTable(), os.Stdout)
+		err = gp.OutputFormatter().Output(ctx, gp.GetTable(), os.Stdout)
 		cobra.CheckErr(err)
 		return nil
 	})

--- a/pkg/cmds/alias/alias.go
+++ b/pkg/cmds/alias/alias.go
@@ -121,7 +121,7 @@ func (a *CommandAlias) Run(
 	ctx context.Context,
 	parsedLayers map[string]*layers.ParsedParameterLayer,
 	ps map[string]interface{},
-	gp processor.Processor,
+	gp processor.TableProcessor,
 ) error {
 	if a.AliasedCommand == nil {
 		return errors.New("no aliased command")

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -267,7 +267,7 @@ type GlazeCommand interface {
 		ctx context.Context,
 		parsedLayers map[string]*layers.ParsedParameterLayer,
 		ps map[string]interface{},
-		gp processor.Processor,
+		gp processor.TableProcessor,
 	) error
 }
 

--- a/pkg/formatters/csv/csv.go
+++ b/pkg/formatters/csv/csv.go
@@ -5,6 +5,8 @@ import (
 	"encoding/csv"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/middlewares/row"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"io"
 	"os"
@@ -16,6 +18,11 @@ type OutputFormatter struct {
 	OutputMultipleFiles bool
 	WithHeaders         bool
 	Separator           rune
+}
+
+func (f *OutputFormatter) RegisterMiddlewares(mw *middlewares.Processor) error {
+	mw.AddRowMiddlewareInFront(row.NewFlattenObjectMiddleware())
+	return nil
 }
 
 func (f *OutputFormatter) ContentType() string {

--- a/pkg/formatters/csv/csv_test.go
+++ b/pkg/formatters/csv/csv_test.go
@@ -23,7 +23,7 @@ func TestCSVRenameEndToEnd(t *testing.T) {
 	err := p_.AddRow(ctx, types.NewRow(types.MRP("a", 1)))
 	require.NoError(t, err)
 
-	err = p_.FinalizeTable(ctx)
+	err = p_.Finalize(ctx)
 	require.NoError(t, err)
 	table_ := p_.GetTable()
 

--- a/pkg/formatters/excel/excel.go
+++ b/pkg/formatters/excel/excel.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	strings2 "github.com/go-go-golems/glazed/pkg/helpers/strings"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/middlewares/row"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/xuri/excelize/v2"
 	"io"
@@ -13,6 +15,11 @@ import (
 type OutputFormatter struct {
 	SheetName  string
 	OutputFile string
+}
+
+func (E *OutputFormatter) RegisterMiddlewares(mw *middlewares.Processor) error {
+	mw.AddRowMiddlewareInFront(row.NewFlattenObjectMiddleware())
+	return nil
 }
 
 func (E *OutputFormatter) Output(_ context.Context, table_ *types.Table, w io.Writer) error {

--- a/pkg/formatters/formatter.go
+++ b/pkg/formatters/formatter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/helpers/templating"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
@@ -39,6 +40,14 @@ import (
 // The following is all geared towards tabulated output
 
 type OutputFormatter interface {
+	// RegisterMiddlewares allows individual OutputFormatters to register middlewares that might be
+	// necessary for them to do the proper output. For example, table and excel output require
+	// flattening the row objects before output.
+	//
+	// TODO(manuel, 2023-06-28) We could add the indication if this output formatter can stream here
+	// Not all output formatters should have to take a full table, but could instead output a single row
+	RegisterMiddlewares(mw *middlewares.Processor) error
+
 	Output(ctx context.Context, table *types.Table, w io.Writer) error
 	ContentType() string
 }

--- a/pkg/formatters/formatter.go
+++ b/pkg/formatters/formatter.go
@@ -1,6 +1,7 @@
 package formatters
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/helpers/templating"
@@ -39,7 +40,13 @@ import (
 
 // The following is all geared towards tabulated output
 
-type OutputFormatter interface {
+// TableOutputFormatter is an output formatter that requires an entire table to be computed up
+// front before it can be output.
+//
+// NOTE(manuel, 2023-06-28) Since this is actually the first type of Formatter that was implemented,
+// it is the current de facto standard. RowOutputFormatter has been added later and is thus not
+// in wide spread use.
+type TableOutputFormatter interface {
 	// RegisterMiddlewares allows individual OutputFormatters to register middlewares that might be
 	// necessary for them to do the proper output. For example, table and excel output require
 	// flattening the row objects before output.
@@ -49,6 +56,12 @@ type OutputFormatter interface {
 	RegisterMiddlewares(mw *middlewares.Processor) error
 
 	Output(ctx context.Context, table *types.Table, w io.Writer) error
+	ContentType() string
+}
+
+type RowOutputFormatter interface {
+	RegisterMiddlewares(mw *middlewares.Processor) error
+	Output(ctx context.Context, row types.Row, w io.Writer) error
 	ContentType() string
 }
 
@@ -83,13 +96,13 @@ func ComputeOutputFilename(
 	return outputFileName, nil
 }
 
-// StartFormatIntoChannel outputs the data from an OutputFormatter into a channel.
+// StartFormatIntoChannel outputs the data from an TableOutputFormatter into a channel.
 // This is useful to render a table into a stream, for example when rendering larger outputs
 // into HTML when serving.
 func StartFormatIntoChannel[T interface{ ~string }](
 	ctx context.Context,
 	table *types.Table,
-	formatter OutputFormatter,
+	formatter TableOutputFormatter,
 ) <-chan T {
 	reader, writer := io.Pipe()
 	c := make(chan T)
@@ -138,4 +151,71 @@ func StartFormatIntoChannel[T interface{ ~string }](
 	}()
 
 	return c
+}
+
+func StreamRows(
+	ctx context.Context,
+	formatter RowOutputFormatter,
+	inputChannel <-chan types.Row,
+	outputChannel <-chan string,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case row, ok := <-inputChannel:
+			if !ok {
+				return nil
+			}
+
+			var buf bytes.Buffer
+			err := formatter.Output(ctx, row, &buf)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// StartStreamRows starts a background goroutine that returns two channels. The first
+// channel is used to send rows to the background goroutine, the second channel is used
+// to receive the formatted output.
+//
+// This background goroutine will close the output channel when it is done.
+func StartStreamRows[T interface{ ~string }](
+	ctx context.Context,
+	formatter RowOutputFormatter,
+) (chan<- types.Row, <-chan T) {
+	// the inputChannel is buffered, so that a slow output stream still allows
+	// the producer to move forward, to avoid having both latencies queue
+	inputChannel := make(chan types.Row, 100)
+	outputChannel := make(chan T)
+
+	eg, ctx2 := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		defer close(outputChannel)
+
+		for {
+			select {
+			case <-ctx2.Done():
+				return nil
+
+			case row, ok := <-inputChannel:
+				if !ok {
+					return nil
+				}
+				var buf bytes.Buffer
+				err := formatter.Output(ctx2, row, &buf)
+				if err != nil {
+					return err
+				}
+
+				outputChannel <- T(buf.String())
+			}
+		}
+	})
+
+	return inputChannel, outputChannel
 }

--- a/pkg/formatters/json/json.go
+++ b/pkg/formatters/json/json.go
@@ -160,3 +160,48 @@ func NewOutputFormatter(options ...OutputFormatterOption) *OutputFormatter {
 
 	return ret
 }
+
+// RowOutputFormatter is a streaming formatter that can only output individual rows as dictionaries.
+type RowOutputFormatter struct {
+	indent string
+}
+
+type RowOutputFormatterOption func(*RowOutputFormatter)
+
+func WithIndent(indent string) RowOutputFormatterOption {
+	return func(formatter *RowOutputFormatter) {
+		formatter.indent = indent
+	}
+}
+
+func NewRowOutputFormatter(options ...RowOutputFormatterOption) *RowOutputFormatter {
+	ret := &RowOutputFormatter{
+		indent: "  ",
+	}
+
+	for _, option := range options {
+		option(ret)
+	}
+
+	return ret
+}
+
+func (r *RowOutputFormatter) RegisterMiddlewares(mw *middlewares.Processor) error {
+	return nil
+}
+
+func (r *RowOutputFormatter) Output(ctx context.Context, row types.Row, w io.Writer) error {
+	m := types.RowToMap(row)
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", r.indent)
+	err := encoder.Encode(m)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *RowOutputFormatter) ContentType() string {
+	return "application/json"
+}

--- a/pkg/formatters/json/json.go
+++ b/pkg/formatters/json/json.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/ugorji/go/codec"
 	"io"
@@ -16,6 +17,10 @@ type OutputFormatter struct {
 	OutputFile           string
 	OutputFileTemplate   string
 	OutputMultipleFiles  bool
+}
+
+func (f *OutputFormatter) RegisterMiddlewares(mw *middlewares.Processor) error {
+	return nil
 }
 
 func (f *OutputFormatter) ContentType() string {

--- a/pkg/formatters/json/json_test.go
+++ b/pkg/formatters/json/json_test.go
@@ -23,7 +23,7 @@ func TestJSONRenameEndToEnd(t *testing.T) {
 	p_ := middlewares.NewProcessor(middlewares.WithRowMiddleware(row.NewFieldRenameColumnMiddleware(renames)))
 	err := p_.AddRow(ctx, obj)
 	require.NoError(t, err)
-	err = p_.FinalizeTable(ctx)
+	err = p_.Finalize(ctx)
 	require.NoError(t, err)
 
 	buf := &bytes.Buffer{}

--- a/pkg/formatters/simple/simple.go
+++ b/pkg/formatters/simple/simple.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"io"
 	"os"
@@ -15,6 +16,10 @@ type SingleColumnFormatter struct {
 	OutputFileTemplate  string
 	OutputMultipleFiles bool
 	Separator           string
+}
+
+func (s *SingleColumnFormatter) RegisterMiddlewares(mw *middlewares.Processor) error {
+	return nil
 }
 
 type SingleColumnFormatterOption func(*SingleColumnFormatter)

--- a/pkg/formatters/table/table.go
+++ b/pkg/formatters/table/table.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
 	"github.com/go-go-golems/glazed/pkg/helpers/cast"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/middlewares/row"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/jedib0t/go-pretty/table"
 	"github.com/jedib0t/go-pretty/text"
@@ -47,6 +49,11 @@ type OutputFormatter struct {
 	TableStyleFile      string
 	OutputFile          string
 	PrintTableStyle     bool
+}
+
+func (tof *OutputFormatter) RegisterMiddlewares(mw *middlewares.Processor) error {
+	mw.AddRowMiddlewareInFront(row.NewFlattenObjectMiddleware())
+	return nil
 }
 
 type OutputFormatterOption func(*OutputFormatter)

--- a/pkg/formatters/table/table_test.go
+++ b/pkg/formatters/table/table_test.go
@@ -23,7 +23,7 @@ func TestTableRenameEndToEnd(t *testing.T) {
 	p_ := middlewares.NewProcessor(middlewares.WithRowMiddleware(row.NewFieldRenameColumnMiddleware(renames)))
 	err := p_.AddRow(ctx, obj)
 	require.NoError(t, err)
-	err = p_.FinalizeTable(ctx)
+	err = p_.Finalize(ctx)
 	require.NoError(t, err)
 
 	buf := &bytes.Buffer{}

--- a/pkg/formatters/template/template.go
+++ b/pkg/formatters/template/template.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"io"
 	"os"
@@ -17,6 +18,10 @@ type OutputFormatter struct {
 	OutputMultipleFiles bool
 	OutputFile          string
 	AdditionalData      interface{}
+}
+
+func (t *OutputFormatter) RegisterMiddlewares(mw *middlewares.Processor) error {
+	return nil
 }
 
 func (t *OutputFormatter) Output(ctx context.Context, table_ *types.Table, w io.Writer) error {

--- a/pkg/formatters/template/template_test.go
+++ b/pkg/formatters/template/template_test.go
@@ -31,7 +31,7 @@ func TestTemplateRenameEndToEnd(t *testing.T) {
 	p_ := middlewares.NewProcessor(middlewares.WithRowMiddleware(row.NewFieldRenameColumnMiddleware(renames)))
 	err := p_.AddRow(ctx, obj)
 	require.NoError(t, err)
-	err = p_.FinalizeTable(ctx)
+	err = p_.Finalize(ctx)
 	require.NoError(t, err)
 
 	buf := &bytes.Buffer{}

--- a/pkg/formatters/yaml/yaml.go
+++ b/pkg/formatters/yaml/yaml.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-go-golems/glazed/pkg/formatters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"gopkg.in/yaml.v3"
 	"io"
@@ -15,6 +16,10 @@ type OutputFormatter struct {
 	OutputFileTemplate   string
 	OutputMultipleFiles  bool
 	OutputIndividualRows bool
+}
+
+func (f *OutputFormatter) RegisterMiddlewares(mw *middlewares.Processor) error {
+	return nil
 }
 
 func (f *OutputFormatter) Output(ctx context.Context, table_ *types.Table, w io.Writer) error {

--- a/pkg/formatters/yaml/yaml_test.go
+++ b/pkg/formatters/yaml/yaml_test.go
@@ -23,7 +23,7 @@ func TestYAMLRenameEndToEnd(t *testing.T) {
 	p_ := middlewares.NewProcessor(middlewares.WithRowMiddleware(row.NewFieldRenameColumnMiddleware(renames)))
 	err := p_.AddRow(ctx, obj)
 	require.NoError(t, err)
-	err = p_.FinalizeTable(ctx)
+	err = p_.Finalize(ctx)
 	require.NoError(t, err)
 
 	buf := bytes.Buffer{}

--- a/pkg/helpers/assert/assert.go
+++ b/pkg/helpers/assert/assert.go
@@ -6,18 +6,18 @@ import (
 	"testing"
 )
 
-func EqualMapRowValue(t *testing.T, expected interface{}, obj types.Row, key string) {
+func EqualRowValue(t *testing.T, expected interface{}, obj types.Row, key string) {
 	v, ok := obj.Get(key)
 	assert.True(t, ok)
 	assert.Equal(t, expected, v)
 }
 
-func NilMapRowValue(t *testing.T, obj types.Row, key string) {
+func NilRowValue(t *testing.T, obj types.Row, key string) {
 	_, ok := obj.Get(key)
 	assert.False(t, ok)
 }
 
-func EqualMapRows(t *testing.T, expected types.Row, actual types.Row) {
+func EqualRow(t *testing.T, expected types.Row, actual types.Row) {
 	assert.Equal(t, expected.Len(), actual.Len())
 
 	// test one side
@@ -29,7 +29,15 @@ func EqualMapRows(t *testing.T, expected types.Row, actual types.Row) {
 	}
 }
 
-func EqualMapRowValues(t *testing.T, obj types.Row, values map[types.FieldName]types.GenericCellValue) {
+func EqualRows(t *testing.T, expected []types.Row, actual []types.Row) {
+	assert.Equal(t, len(expected), len(actual))
+
+	for i := range expected {
+		EqualRow(t, expected[i], actual[i])
+	}
+}
+
+func EqualRowValues(t *testing.T, obj types.Row, values map[types.FieldName]types.GenericCellValue) {
 	for k, v := range values {
 		v_, ok := obj.Get(k)
 		assert.True(t, ok)
@@ -37,7 +45,7 @@ func EqualMapRowValues(t *testing.T, obj types.Row, values map[types.FieldName]t
 	}
 }
 
-func EqualMapRowMap(t *testing.T, expected map[types.FieldName]types.GenericCellValue, actual types.Row) {
+func EqualRowMap(t *testing.T, expected map[types.FieldName]types.GenericCellValue, actual types.Row) {
 	// test one side
 	for k, v := range expected {
 		v_, ok := actual.Get(k)

--- a/pkg/middlewares/jq_test.go
+++ b/pkg/middlewares/jq_test.go
@@ -58,7 +58,7 @@ func TestEmptyObjectMiddleware(t *testing.T) {
 	o2, err := m.Process(ctx, obj)
 	require.NoError(t, err)
 	assert.Len(t, o2, 1)
-	assert2.EqualMapRows(t, obj, o2[0])
+	assert2.EqualRow(t, obj, o2[0])
 }
 
 func TestSimpleJqConstant(t *testing.T) {
@@ -71,7 +71,7 @@ func TestSimpleJqConstant(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, o2, 1)
 	expected := types.NewRow(types.MRP("a", 2))
-	assert2.EqualMapRows(t, expected, o2[0])
+	assert2.EqualRow(t, expected, o2[0])
 }
 
 func TestSimpleJqConstantArray(t *testing.T) {
@@ -84,7 +84,7 @@ func TestSimpleJqConstantArray(t *testing.T) {
 	require.NoError(t, err)
 	expected := types.NewRow(types.MRP("a", []interface{}{2}))
 	assert.Len(t, o2, 1)
-	assert2.EqualMapRows(t, expected, o2[0])
+	assert2.EqualRow(t, expected, o2[0])
 }
 
 func TestSimpleJqExtractNestedArray(t *testing.T) {
@@ -97,7 +97,7 @@ func TestSimpleJqExtractNestedArray(t *testing.T) {
 	require.NoError(t, err)
 	expected := types.NewRow(types.MRP("b", 2))
 	assert.Len(t, o2, 1)
-	assert2.EqualMapRows(t, expected, o2[0])
+	assert2.EqualRow(t, expected, o2[0])
 }
 
 func TestSimpleJqExtract(t *testing.T) {
@@ -110,9 +110,9 @@ func TestSimpleJqExtract(t *testing.T) {
 	o2, err := m.Process(ctx, v2)
 	require.NoError(t, err)
 	assert.Len(t, o2, 3)
-	assert2.EqualMapRowMap(t, map[string]interface{}{"field": 1}, o2[0])
-	assert2.EqualMapRowMap(t, map[string]interface{}{"field": 2}, o2[1])
-	assert2.EqualMapRowMap(t, map[string]interface{}{"field": 3}, o2[2])
+	assert2.EqualRowMap(t, map[string]interface{}{"field": 1}, o2[0])
+	assert2.EqualRowMap(t, map[string]interface{}{"field": 2}, o2[1])
+	assert2.EqualRowMap(t, map[string]interface{}{"field": 3}, o2[2])
 }
 
 func TestSimpleJqTableConstant(t *testing.T) {
@@ -129,11 +129,11 @@ func TestSimpleJqTableConstant(t *testing.T) {
 	v, ok := row.Get("a")
 	assert.True(t, ok)
 	assert.Equal(t, 2, v)
-	assert2.EqualMapRowValue(t, 2, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
-	assert2.EqualMapRowValue(t, map[string]interface{}{"d": 3}, row, "c")
-	assert2.EqualMapRowValue(t, "hello", row, "e")
-	assert2.EqualMapRowValue(t, []interface{}{1, 2, 3}, row, "f")
+	assert2.EqualRowValue(t, 2, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, map[string]interface{}{"d": 3}, row, "c")
+	assert2.EqualRowValue(t, "hello", row, "e")
+	assert2.EqualRowValue(t, []interface{}{1, 2, 3}, row, "f")
 }
 
 func TestSimpleJqTableTwoFields(t *testing.T) {
@@ -147,9 +147,9 @@ func TestSimpleJqTableTwoFields(t *testing.T) {
 	require.NoError(t, err)
 
 	row := t2.Rows[0]
-	assert2.EqualMapRowValue(t, 2, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
-	assert2.EqualMapRowValue(t, 3, row, "c")
-	assert2.EqualMapRowValue(t, "hello", row, "e")
-	assert2.EqualMapRowValue(t, []interface{}{1, 2, 3}, row, "f")
+	assert2.EqualRowValue(t, 2, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 3, row, "c")
+	assert2.EqualRowValue(t, "hello", row, "e")
+	assert2.EqualRowValue(t, []interface{}{1, 2, 3}, row, "f")
 }

--- a/pkg/middlewares/processor.go
+++ b/pkg/middlewares/processor.go
@@ -67,7 +67,7 @@ func (p *Processor) GetTable() *types.Table {
 	return p.Table
 }
 
-func (p *Processor) FinalizeTable(ctx context.Context) error {
+func (p *Processor) Finalize(ctx context.Context) error {
 	for _, tm := range p.TableMiddlewares {
 		table, err := tm.Process(ctx, p.Table)
 		if err != nil {

--- a/pkg/middlewares/row/add-field_test.go
+++ b/pkg/middlewares/row/add-field_test.go
@@ -33,14 +33,14 @@ func TestSingleAddField(t *testing.T) {
 	require.Equal(t, 2, len(finalRows))
 
 	row := finalRows[0]
-	assert2.EqualMapRowValue(t, "skip", row, "field1")
-	assert2.EqualMapRowValue(t, "value2", row, "field2")
-	assert2.EqualMapRowValue(t, "value3", row, "field3")
+	assert2.EqualRowValue(t, "skip", row, "field1")
+	assert2.EqualRowValue(t, "value2", row, "field2")
+	assert2.EqualRowValue(t, "value3", row, "field3")
 
 	row = finalRows[1]
-	assert2.EqualMapRowValue(t, "value1", row, "field1")
-	assert2.EqualMapRowValue(t, "value3 blabla", row, "field2")
-	assert2.EqualMapRowValue(t, "value3", row, "field3")
+	assert2.EqualRowValue(t, "value1", row, "field1")
+	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
+	assert2.EqualRowValue(t, "value3", row, "field3")
 }
 
 func processRows(rm middlewares.RowMiddleware, rows []types.Row) ([]types.Row, error) {
@@ -69,14 +69,14 @@ func TestMultipleAddField(t *testing.T) {
 	require.Equal(t, 2, len(finalRows))
 
 	row := finalRows[0]
-	assert2.EqualMapRowValue(t, "skip", row, "field1")
-	assert2.EqualMapRowValue(t, "value2", row, "field2")
-	assert2.EqualMapRowValue(t, "value3", row, "field3")
-	assert2.EqualMapRowValue(t, "value4", row, "field4")
+	assert2.EqualRowValue(t, "skip", row, "field1")
+	assert2.EqualRowValue(t, "value2", row, "field2")
+	assert2.EqualRowValue(t, "value3", row, "field3")
+	assert2.EqualRowValue(t, "value4", row, "field4")
 
 	row = finalRows[1]
-	assert2.EqualMapRowValue(t, "value1", row, "field1")
-	assert2.EqualMapRowValue(t, "value3 blabla", row, "field2")
-	assert2.EqualMapRowValue(t, "value3", row, "field3")
-	assert2.EqualMapRowValue(t, "value4", row, "field4")
+	assert2.EqualRowValue(t, "value1", row, "field1")
+	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
+	assert2.EqualRowValue(t, "value3", row, "field3")
+	assert2.EqualRowValue(t, "value4", row, "field4")
 }

--- a/pkg/middlewares/row/fields-filter_test.go
+++ b/pkg/middlewares/row/fields-filter_test.go
@@ -35,9 +35,9 @@ func TestNoFieldsFilter(t *testing.T) {
 	finalRows, err := processRows(mw, rows)
 	require.NoError(t, err)
 	require.Len(t, finalRows, 3)
-	assert2.EqualMapRowValues(t, rows[0], map[string]interface{}{"a": 1, "b": 2, "c": 3})
-	assert2.EqualMapRowValues(t, rows[1], map[string]interface{}{"a": 4, "b": 5, "c": 6})
-	assert2.EqualMapRowValues(t, rows[2], map[string]interface{}{"a": 7, "b": 8, "c": 9, "d": 10})
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{"a": 1, "b": 2, "c": 3})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{"a": 4, "b": 5, "c": 6})
+	assert2.EqualRowValues(t, rows[2], map[string]interface{}{"a": 7, "b": 8, "c": 9, "d": 10})
 }
 
 func TestFieldsA(t *testing.T) {
@@ -47,9 +47,9 @@ func TestFieldsA(t *testing.T) {
 	finalRows, err := processRows(mw, rows)
 	require.NoError(t, err)
 	require.Len(t, finalRows, 3)
-	assert2.EqualMapRowValues(t, rows[0], map[string]interface{}{"a": 1})
-	assert2.EqualMapRowValues(t, rows[1], map[string]interface{}{"a": 4})
-	assert2.EqualMapRowValues(t, rows[2], map[string]interface{}{"a": 7})
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{"a": 1})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{"a": 4})
+	assert2.EqualRowValues(t, rows[2], map[string]interface{}{"a": 7})
 }
 
 func TestFieldsBD(t *testing.T) {
@@ -59,9 +59,9 @@ func TestFieldsBD(t *testing.T) {
 	finalRows, err := processRows(mw, rows)
 	require.NoError(t, err)
 	require.Len(t, finalRows, 3)
-	assert2.EqualMapRowValues(t, rows[0], map[string]interface{}{"b": 2})
-	assert2.EqualMapRowValues(t, rows[1], map[string]interface{}{"b": 5})
-	assert2.EqualMapRowValues(t, rows[2], map[string]interface{}{"b": 8, "d": 10})
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{"b": 2})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{"b": 5})
+	assert2.EqualRowValues(t, rows[2], map[string]interface{}{"b": 8, "d": 10})
 }
 
 func TestFilterA(t *testing.T) {
@@ -71,9 +71,9 @@ func TestFilterA(t *testing.T) {
 	finalRows, err := processRows(mw, rows)
 	require.NoError(t, err)
 	require.Len(t, finalRows, 3)
-	assert2.EqualMapRowValues(t, rows[0], map[string]interface{}{"b": 2, "c": 3})
-	assert2.EqualMapRowValues(t, rows[1], map[string]interface{}{"b": 5, "c": 6})
-	assert2.EqualMapRowValues(t, rows[2], map[string]interface{}{"b": 8, "c": 9, "d": 10})
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{"b": 2, "c": 3})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{"b": 5, "c": 6})
+	assert2.EqualRowValues(t, rows[2], map[string]interface{}{"b": 8, "c": 9, "d": 10})
 }
 
 func TestFilterBD(t *testing.T) {
@@ -83,7 +83,7 @@ func TestFilterBD(t *testing.T) {
 	finalRows, err := processRows(mw, rows)
 	require.NoError(t, err)
 	require.Len(t, finalRows, 3)
-	assert2.EqualMapRowValues(t, rows[0], map[string]interface{}{"a": 1, "c": 3})
-	assert2.EqualMapRowValues(t, rows[1], map[string]interface{}{"a": 4, "c": 6})
-	assert2.EqualMapRowValues(t, rows[2], map[string]interface{}{"a": 7, "c": 9})
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{"a": 1, "c": 3})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{"a": 4, "c": 6})
+	assert2.EqualRowValues(t, rows[2], map[string]interface{}{"a": 7, "c": 9})
 }

--- a/pkg/middlewares/row/flatten-object_test.go
+++ b/pkg/middlewares/row/flatten-object_test.go
@@ -20,7 +20,7 @@ func TestFlattenNoNestedObjects(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, newRows, 1)
-	assert2.EqualMapRows(t, row, newRows[0])
+	assert2.EqualRow(t, row, newRows[0])
 }
 
 func TestFlattenSingleNestedObject(t *testing.T) {
@@ -37,7 +37,7 @@ func TestFlattenSingleNestedObject(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, newRows, 1)
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("a", "value1"),
 		types.MRP("b", "value2"),
 		types.MRP("c.d", "value3"),
@@ -62,7 +62,7 @@ func TestFlattenTwoObjects(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, newRows, 1)
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("a", "value1"),
 
 		types.MRP("b", "value2"),
@@ -90,7 +90,7 @@ func TestNestedMapInterface(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, newRows, 1)
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("a", "value1"),
 		types.MRP("b", "value2"),
 		types.MRP("c.a", "value4"),
@@ -118,7 +118,7 @@ func TestNestedMapInterfaceRow(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, newRows, 1)
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("a", "value1"),
 		types.MRP("b", "value2"),
 		types.MRP("c.d", "value3"),

--- a/pkg/middlewares/row/remove-duplicates_test.go
+++ b/pkg/middlewares/row/remove-duplicates_test.go
@@ -45,9 +45,9 @@ func TestRemoveDuplicatesSingle(t *testing.T) {
 
 	require.Equal(t, 1, len(newRows))
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
-	assert2.EqualMapRowValue(t, 3, row, "c")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 3, row, "c")
 }
 
 func TestRemoveDuplicatesTwoDifferent(t *testing.T) {
@@ -62,13 +62,13 @@ func TestRemoveDuplicatesTwoDifferent(t *testing.T) {
 
 	require.Equal(t, 2, len(newRows))
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
-	assert2.EqualMapRowValue(t, 3, row, "c")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 3, row, "c")
 	row = newRows[1]
-	assert2.EqualMapRowValue(t, 4, row, "a")
-	assert2.EqualMapRowValue(t, 5, row, "b")
-	assert2.EqualMapRowValue(t, 6, row, "c")
+	assert2.EqualRowValue(t, 4, row, "a")
+	assert2.EqualRowValue(t, 5, row, "b")
+	assert2.EqualRowValue(t, 6, row, "c")
 }
 
 func TestRemoveDuplicatesTwoSame(t *testing.T) {
@@ -83,9 +83,9 @@ func TestRemoveDuplicatesTwoSame(t *testing.T) {
 
 	require.Equal(t, 1, len(newRows))
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
-	assert2.EqualMapRowValue(t, 3, row, "c")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 3, row, "c")
 }
 
 func TestRemoveDuplicatesTwoSameOneDifferent(t *testing.T) {
@@ -101,13 +101,13 @@ func TestRemoveDuplicatesTwoSameOneDifferent(t *testing.T) {
 
 	require.Equal(t, 2, len(newRows))
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
-	assert2.EqualMapRowValue(t, 3, row, "c")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 3, row, "c")
 	row = newRows[1]
-	assert2.EqualMapRowValue(t, 4, row, "a")
-	assert2.EqualMapRowValue(t, 5, row, "b")
-	assert2.EqualMapRowValue(t, 6, row, "c")
+	assert2.EqualRowValue(t, 4, row, "a")
+	assert2.EqualRowValue(t, 5, row, "b")
+	assert2.EqualRowValue(t, 6, row, "c")
 }
 
 func TestRemoveDuplicatesTwoTimesTwoSame(t *testing.T) {
@@ -124,13 +124,13 @@ func TestRemoveDuplicatesTwoTimesTwoSame(t *testing.T) {
 
 	require.Equal(t, 2, len(newRows))
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
-	assert2.EqualMapRowValue(t, 3, row, "c")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 3, row, "c")
 	row = newRows[1]
-	assert2.EqualMapRowValue(t, 4, row, "a")
-	assert2.EqualMapRowValue(t, 5, row, "b")
-	assert2.EqualMapRowValue(t, 6, row, "c")
+	assert2.EqualRowValue(t, 4, row, "a")
+	assert2.EqualRowValue(t, 5, row, "b")
+	assert2.EqualRowValue(t, 6, row, "c")
 }
 
 func TestRemoveDuplicatesTwoTimesTwoSameOneDifferent(t *testing.T) {
@@ -148,17 +148,17 @@ func TestRemoveDuplicatesTwoTimesTwoSameOneDifferent(t *testing.T) {
 
 	require.Equal(t, 3, len(newRows))
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
-	assert2.EqualMapRowValue(t, 3, row, "c")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 3, row, "c")
 	row = newRows[1]
-	assert2.EqualMapRowValue(t, 4, row, "a")
-	assert2.EqualMapRowValue(t, 5, row, "b")
-	assert2.EqualMapRowValue(t, 6, row, "c")
+	assert2.EqualRowValue(t, 4, row, "a")
+	assert2.EqualRowValue(t, 5, row, "b")
+	assert2.EqualRowValue(t, 6, row, "c")
 	row = newRows[2]
-	assert2.EqualMapRowValue(t, 7, row, "a")
-	assert2.EqualMapRowValue(t, 8, row, "b")
-	assert2.EqualMapRowValue(t, 9, row, "c")
+	assert2.EqualRowValue(t, 7, row, "a")
+	assert2.EqualRowValue(t, 8, row, "b")
+	assert2.EqualRowValue(t, 9, row, "c")
 }
 
 func TestRemoveDuplicatesTwoSameWithTwoColumns(t *testing.T) {
@@ -173,7 +173,7 @@ func TestRemoveDuplicatesTwoSameWithTwoColumns(t *testing.T) {
 
 	require.Equal(t, 1, len(newRows))
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
-	assert2.EqualMapRowValue(t, 3, row, "c")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 3, row, "c")
 }

--- a/pkg/middlewares/row/rename-columns_test.go
+++ b/pkg/middlewares/row/rename-columns_test.go
@@ -20,10 +20,10 @@ func TestSingleRename(t *testing.T) {
 	require.NoError(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.EqualMapRowValue(t, 1, row, "bar")
-	assert2.EqualMapRowValue(t, 2, row, "baz")
-	assert2.EqualMapRowValue(t, 3, row, "foobar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.EqualRowValue(t, 1, row, "bar")
+	assert2.EqualRowValue(t, 2, row, "baz")
+	assert2.EqualRowValue(t, 3, row, "foobar")
 }
 
 func TestRenameTwoFieldColumns(t *testing.T) {
@@ -37,10 +37,10 @@ func TestRenameTwoFieldColumns(t *testing.T) {
 	require.NoError(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.EqualMapRowValue(t, 1, row, "bar")
-	assert2.EqualMapRowValue(t, 2, row, "qux")
-	assert2.EqualMapRowValue(t, 3, row, "foobar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.EqualRowValue(t, 1, row, "bar")
+	assert2.EqualRowValue(t, 2, row, "qux")
+	assert2.EqualRowValue(t, 3, row, "foobar")
 }
 
 func TestRenameOverrideColumn(t *testing.T) {
@@ -53,10 +53,10 @@ func TestRenameOverrideColumn(t *testing.T) {
 	require.NoError(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foo")
+	assert2.NilRowValue(t, row, "foo")
 	// we get 3 because our keys are ordered now, and foobar comes last, thus overwriting the renamed foo
-	assert2.EqualMapRowValue(t, 3, row, "foobar")
-	assert2.EqualMapRowValue(t, 2, row, "baz")
+	assert2.EqualRowValue(t, 3, row, "foobar")
+	assert2.EqualRowValue(t, 2, row, "baz")
 
 }
 
@@ -70,10 +70,10 @@ func TestRenameOverrideColumnLast(t *testing.T) {
 	require.NoError(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foobar")
+	assert2.NilRowValue(t, row, "foobar")
 	// the renamed foobar -> foo now overwrites the original foo value
-	assert2.EqualMapRowValue(t, 3, row, "foo")
-	assert2.EqualMapRowValue(t, 2, row, "baz")
+	assert2.EqualRowValue(t, 3, row, "foo")
+	assert2.EqualRowValue(t, 2, row, "baz")
 
 }
 
@@ -90,10 +90,10 @@ func TestRenameRegexpSimpleMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.EqualMapRowValue(t, 1, row, "bar")
-	assert2.EqualMapRowValue(t, 2, row, "baz")
-	assert2.EqualMapRowValue(t, 3, row, "foobar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.EqualRowValue(t, 1, row, "bar")
+	assert2.EqualRowValue(t, 2, row, "baz")
+	assert2.EqualRowValue(t, 3, row, "foobar")
 }
 
 func TestRenameRegexpDoubleMatch(t *testing.T) {
@@ -109,11 +109,11 @@ func TestRenameRegexpDoubleMatch(t *testing.T) {
 
 	row := newRows[0]
 	// here, f.. should match both fields
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.NilMapRowValue(t, row, "foobar")
-	assert2.EqualMapRowValue(t, 1, row, "bar")
-	assert2.EqualMapRowValue(t, 2, row, "baz")
-	assert2.EqualMapRowValue(t, 3, row, "barbar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.NilRowValue(t, row, "foobar")
+	assert2.EqualRowValue(t, 1, row, "bar")
+	assert2.EqualRowValue(t, 2, row, "baz")
+	assert2.EqualRowValue(t, 3, row, "barbar")
 }
 
 func TestRenameRegexpOrderedMatch(t *testing.T) {
@@ -137,12 +137,12 @@ func TestRenameRegexpOrderedMatch(t *testing.T) {
 	row := newRows[0]
 	// it's going to be hard to test that these will happen in the right
 	// order as it really depends on the map
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.NilMapRowValue(t, row, "bar2")
-	assert2.NilMapRowValue(t, row, "bar3")
-	assert2.EqualMapRowValue(t, 1, row, "bar")
-	assert2.EqualMapRowValue(t, 2, row, "baz")
-	assert2.EqualMapRowValue(t, 3, row, "foobar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.NilRowValue(t, row, "bar2")
+	assert2.NilRowValue(t, row, "bar3")
+	assert2.EqualRowValue(t, 1, row, "bar")
+	assert2.EqualRowValue(t, 2, row, "baz")
+	assert2.EqualRowValue(t, 3, row, "foobar")
 }
 
 func createTestRows() []types.Row {
@@ -182,12 +182,12 @@ func TestBothFieldAndRegexpRenames(t *testing.T) {
 	require.Nil(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.NilMapRowValue(t, row, "baz")
-	assert2.NilMapRowValue(t, row, "foobar")
-	assert2.EqualMapRowValue(t, 1, row, "bar")
-	assert2.EqualMapRowValue(t, 2, row, "qux")
-	assert2.EqualMapRowValue(t, 3, row, "bar2bar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.NilRowValue(t, row, "baz")
+	assert2.NilRowValue(t, row, "foobar")
+	assert2.EqualRowValue(t, 1, row, "bar")
+	assert2.EqualRowValue(t, 2, row, "qux")
+	assert2.EqualRowValue(t, 3, row, "bar2bar")
 }
 
 func TestParseFromYAML(t *testing.T) {
@@ -206,11 +206,11 @@ renames:
 	require.Nil(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.NilMapRowValue(t, row, "baz")
-	assert2.EqualMapRowValue(t, 1, row, "bar")
-	assert2.EqualMapRowValue(t, 2, row, "qux")
-	assert2.EqualMapRowValue(t, 3, row, "foobar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.NilRowValue(t, row, "baz")
+	assert2.EqualRowValue(t, 1, row, "bar")
+	assert2.EqualRowValue(t, 2, row, "qux")
+	assert2.EqualRowValue(t, 3, row, "foobar")
 }
 
 func TestParseRegexpFromYAML(t *testing.T) {
@@ -230,12 +230,12 @@ regexpRenames:
 	require.Nil(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.NilMapRowValue(t, row, "baz")
-	assert2.NilMapRowValue(t, row, "foobar")
-	assert2.EqualMapRowValue(t, 1, row, "bar2")
-	assert2.EqualMapRowValue(t, 2, row, "qux")
-	assert2.EqualMapRowValue(t, 3, row, "barbar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.NilRowValue(t, row, "baz")
+	assert2.NilRowValue(t, row, "foobar")
+	assert2.EqualRowValue(t, 1, row, "bar2")
+	assert2.EqualRowValue(t, 2, row, "qux")
+	assert2.EqualRowValue(t, 3, row, "barbar")
 }
 
 func TestParseBothFromYAML(t *testing.T) {
@@ -258,12 +258,12 @@ regexpRenames:
 	require.Nil(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.NilMapRowValue(t, row, "baz")
-	assert2.NilMapRowValue(t, row, "foobar")
-	assert2.EqualMapRowValue(t, 1, row, "bar")
-	assert2.EqualMapRowValue(t, 2, row, "qux")
-	assert2.EqualMapRowValue(t, 3, row, "barbar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.NilRowValue(t, row, "baz")
+	assert2.NilRowValue(t, row, "foobar")
+	assert2.EqualRowValue(t, 1, row, "bar")
+	assert2.EqualRowValue(t, 2, row, "qux")
+	assert2.EqualRowValue(t, 3, row, "barbar")
 }
 
 func TestRegexpCaptureGroupRename(t *testing.T) {
@@ -278,11 +278,11 @@ func TestRegexpCaptureGroupRename(t *testing.T) {
 	require.Nil(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.NilMapRowValue(t, row, "foobar")
-	assert2.EqualMapRowValue(t, 1, row, "bar")
-	assert2.EqualMapRowValue(t, 2, row, "baz")
-	assert2.EqualMapRowValue(t, 3, row, "barbar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.NilRowValue(t, row, "foobar")
+	assert2.EqualRowValue(t, 1, row, "bar")
+	assert2.EqualRowValue(t, 2, row, "baz")
+	assert2.EqualRowValue(t, 3, row, "barbar")
 }
 
 func TestRegexpCaptureGroupRenameFromYAML(t *testing.T) {
@@ -300,9 +300,9 @@ regexpRenames:
 	require.Nil(t, err)
 
 	row := newRows[0]
-	assert2.NilMapRowValue(t, row, "foo")
-	assert2.NilMapRowValue(t, row, "foobar")
-	assert2.EqualMapRowValue(t, 1, row, "bar")
-	assert2.EqualMapRowValue(t, 2, row, "baz")
-	assert2.EqualMapRowValue(t, 3, row, "barbar")
+	assert2.NilRowValue(t, row, "foo")
+	assert2.NilRowValue(t, row, "foobar")
+	assert2.EqualRowValue(t, 1, row, "bar")
+	assert2.EqualRowValue(t, 2, row, "baz")
+	assert2.EqualRowValue(t, 3, row, "barbar")
 }

--- a/pkg/middlewares/row/reorder-column_test.go
+++ b/pkg/middlewares/row/reorder-column_test.go
@@ -22,7 +22,7 @@ func TestSimpleReorder(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, newRows, 1)
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("c", "value3"),
 		types.MRP("a", "value1"),
 		types.MRP("b", "value2"),
@@ -43,7 +43,7 @@ func TestSimpleReorderNotAllColumns(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, newRows, 1)
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("c", "value3"),
 		types.MRP("a", "value1"),
 		types.MRP("b", "value2"),
@@ -65,7 +65,7 @@ func TestReorderDot(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, newRows, 1)
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("c.d", "value3"),
 		types.MRP("c.e", "value4"),
 		types.MRP("a", "value1"),
@@ -89,7 +89,7 @@ func TestReorderDotOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, newRows, 1)
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("c.e", "value4"),
 		types.MRP("a", "value1"),
 		types.MRP("c.d", "value3"),

--- a/pkg/middlewares/row/replace_test.go
+++ b/pkg/middlewares/row/replace_test.go
@@ -43,8 +43,8 @@ func TestSingleSkip(t *testing.T) {
 	require.Equal(t, 1, len(newRows))
 
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, "value1", row, "field1")
-	assert2.EqualMapRowValue(t, "value3 blabla", row, "field2")
+	assert2.EqualRowValue(t, "value1", row, "field1")
+	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
 }
 
 func TestSingleReplacement(t *testing.T) {
@@ -69,11 +69,11 @@ func TestSingleReplacement(t *testing.T) {
 	require.Equal(t, 2, len(newRows))
 
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, "skip", row, "field1")
-	assert2.EqualMapRowValue(t, "value2", row, "field2")
+	assert2.EqualRowValue(t, "skip", row, "field1")
+	assert2.EqualRowValue(t, "value2", row, "field2")
 	row = newRows[1]
-	assert2.EqualMapRowValue(t, "replaced", row, "field1")
-	assert2.EqualMapRowValue(t, "value3 blabla", row, "field2")
+	assert2.EqualRowValue(t, "replaced", row, "field1")
+	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
 }
 
 func TestTwoSkips(t *testing.T) {
@@ -148,8 +148,8 @@ func TestSingleRegexpSkip(t *testing.T) {
 	require.Equal(t, 1, len(newRows))
 
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, "value1", row, "field1")
-	assert2.EqualMapRowValue(t, "value3 blabla", row, "field2")
+	assert2.EqualRowValue(t, "value1", row, "field1")
+	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
 
 	replaceMiddleware.RegexSkips = map[types.FieldName][]*RegexpSkip{
 		"field1": {
@@ -165,8 +165,8 @@ func TestSingleRegexpSkip(t *testing.T) {
 	require.Equal(t, 1, len(newRows))
 
 	row = newRows[0]
-	assert2.EqualMapRowValue(t, "value1", row, "field1")
-	assert2.EqualMapRowValue(t, "value3 blabla", row, "field2")
+	assert2.EqualRowValue(t, "value1", row, "field1")
+	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
 }
 
 func TestTwoReplacements(t *testing.T) {
@@ -195,11 +195,11 @@ func TestTwoReplacements(t *testing.T) {
 	require.Equal(t, 2, len(newRows))
 
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, "skip", row, "field1")
-	assert2.EqualMapRowValue(t, "value2", row, "field2")
+	assert2.EqualRowValue(t, "skip", row, "field1")
+	assert2.EqualRowValue(t, "value2", row, "field2")
 	row = newRows[1]
-	assert2.EqualMapRowValue(t, "replaced replaced2", row, "field1")
-	assert2.EqualMapRowValue(t, "value3 blabla", row, "field2")
+	assert2.EqualRowValue(t, "replaced replaced2", row, "field1")
+	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
 }
 
 func TestSingleRegexpReplacement(t *testing.T) {
@@ -224,12 +224,12 @@ func TestSingleRegexpReplacement(t *testing.T) {
 	require.Equal(t, 2, len(newRows))
 
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, "skip", row, "field1")
-	assert2.EqualMapRowValue(t, "value2", row, "field2")
+	assert2.EqualRowValue(t, "skip", row, "field1")
+	assert2.EqualRowValue(t, "value2", row, "field2")
 
 	row = newRows[1]
-	assert2.EqualMapRowValue(t, "replaced", row, "field1")
-	assert2.EqualMapRowValue(t, "value3 blabla", row, "field2")
+	assert2.EqualRowValue(t, "replaced", row, "field1")
+	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
 }
 
 func TestSingleRegexpCaptureReplacement(t *testing.T) {
@@ -254,12 +254,12 @@ func TestSingleRegexpCaptureReplacement(t *testing.T) {
 	require.Equal(t, 2, len(newRows))
 
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, "skip", row, "field1")
-	assert2.EqualMapRowValue(t, "value2", row, "field2")
+	assert2.EqualRowValue(t, "skip", row, "field1")
+	assert2.EqualRowValue(t, "value2", row, "field2")
 
 	row = newRows[1]
-	assert2.EqualMapRowValue(t, "replacedalue", row, "field1")
-	assert2.EqualMapRowValue(t, "value3 blabla", row, "field2")
+	assert2.EqualRowValue(t, "replacedalue", row, "field1")
+	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
 }
 
 func TestRegexpAndSkip(t *testing.T) {
@@ -290,8 +290,8 @@ func TestRegexpAndSkip(t *testing.T) {
 	require.Equal(t, 1, len(newRows))
 
 	row := newRows[0]
-	assert2.EqualMapRowValue(t, "replaced", row, "field1")
-	assert2.EqualMapRowValue(t, "value3 blabla", row, "field2")
+	assert2.EqualRowValue(t, "replaced", row, "field1")
+	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
 }
 
 func TestReplaceMiddlewareFromYAML(t *testing.T) {

--- a/pkg/middlewares/row/sort-columns_test.go
+++ b/pkg/middlewares/row/sort-columns_test.go
@@ -20,7 +20,7 @@ func TestSimpleSortColumns(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, newRows, 1)
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("a", "value1"),
 		types.MRP("b", "value2"),
 		types.MRP("c", "value3"),

--- a/pkg/middlewares/row/template_test.go
+++ b/pkg/middlewares/row/template_test.go
@@ -25,7 +25,7 @@ func TestSimpleTemplate(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, newRows, 1)
 
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("a", "value1-value2"),
 		types.MRP("b", "value2"),
 		types.MRP("c", "value3"),
@@ -50,7 +50,7 @@ func TestSimpleDoubleTemplate(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, newRows, 1)
 
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("a", "value1-value2"),
 		types.MRP("b", "value1-value2"),
 		types.MRP("c", "value3"),
@@ -75,7 +75,7 @@ func TestSimpleDoubleTemplateDifferentOrder(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, newRows, 1)
 
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("b", "value1-value2"),
 		types.MRP("a", "value1-value2"),
 		types.MRP("c", "value3"),
@@ -100,7 +100,7 @@ func TestSimpleDoubleTemplateWithDot(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, newRows, 1)
 
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("b.d", "value1-value2"),
 		types.MRP("a", "value1-value2"),
 		types.MRP("c", "value3"),
@@ -124,7 +124,7 @@ func TestSimpleTemplateRow(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, newRows, 1)
 
-	assert2.EqualMapRows(t, types.NewRow(
+	assert2.EqualRow(t, types.NewRow(
 		types.MRP("a", "value1-value2"),
 		types.MRP("b", "value2"),
 		types.MRP("c", "value3"),

--- a/pkg/middlewares/table/sortby_test.go
+++ b/pkg/middlewares/table/sortby_test.go
@@ -39,11 +39,11 @@ func TestSortByMiddlewareSingleIntColumn(t *testing.T) {
 
 	require.Equal(t, 3, len(newtable.Rows))
 	row := newtable.Rows[0]
-	assert2.EqualMapRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 1, row, "a")
 	row = newtable.Rows[1]
-	assert2.EqualMapRowValue(t, 4, row, "a")
+	assert2.EqualRowValue(t, 4, row, "a")
 	row = newtable.Rows[2]
-	assert2.EqualMapRowValue(t, 7, row, "a")
+	assert2.EqualRowValue(t, 7, row, "a")
 }
 
 func TestSortByMiddlewareSingleIntColumnDesc(t *testing.T) {
@@ -60,11 +60,11 @@ func TestSortByMiddlewareSingleIntColumnDesc(t *testing.T) {
 
 	require.Equal(t, 3, len(newtable.Rows))
 	row := newtable.Rows[0]
-	assert2.EqualMapRowValue(t, 7, row, "a")
+	assert2.EqualRowValue(t, 7, row, "a")
 	row = newtable.Rows[1]
-	assert2.EqualMapRowValue(t, 4, row, "a")
+	assert2.EqualRowValue(t, 4, row, "a")
 	row = newtable.Rows[2]
-	assert2.EqualMapRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 1, row, "a")
 }
 
 func TestSortByMiddlewareSingleStringColumn(t *testing.T) {
@@ -81,11 +81,11 @@ func TestSortByMiddlewareSingleStringColumn(t *testing.T) {
 
 	require.Equal(t, 3, len(newtable.Rows))
 	row := newtable.Rows[0]
-	assert2.EqualMapRowValue(t, "a", row, "a")
+	assert2.EqualRowValue(t, "a", row, "a")
 	row = newtable.Rows[1]
-	assert2.EqualMapRowValue(t, "b", row, "a")
+	assert2.EqualRowValue(t, "b", row, "a")
 	row = newtable.Rows[2]
-	assert2.EqualMapRowValue(t, "c", row, "a")
+	assert2.EqualRowValue(t, "c", row, "a")
 }
 
 func TestSortByMiddlewareSingleStringColumnDesc(t *testing.T) {
@@ -102,11 +102,11 @@ func TestSortByMiddlewareSingleStringColumnDesc(t *testing.T) {
 
 	require.Equal(t, 3, len(newtable.Rows))
 	row := newtable.Rows[0]
-	assert2.EqualMapRowValue(t, "c", row, "a")
+	assert2.EqualRowValue(t, "c", row, "a")
 	row = newtable.Rows[1]
-	assert2.EqualMapRowValue(t, "b", row, "a")
+	assert2.EqualRowValue(t, "b", row, "a")
 	row = newtable.Rows[2]
-	assert2.EqualMapRowValue(t, "a", row, "a")
+	assert2.EqualRowValue(t, "a", row, "a")
 
 }
 
@@ -125,17 +125,17 @@ func TestSortByMiddlewareTwoColumns(t *testing.T) {
 
 	require.Equal(t, 4, len(newtable.Rows))
 	row := newtable.Rows[0]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 1, row, "b")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 1, row, "b")
 	row = newtable.Rows[1]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
 	row = newtable.Rows[2]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 3, row, "b")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 3, row, "b")
 	row = newtable.Rows[3]
-	assert2.EqualMapRowValue(t, 2, row, "a")
-	assert2.EqualMapRowValue(t, 1, row, "b")
+	assert2.EqualRowValue(t, 2, row, "a")
+	assert2.EqualRowValue(t, 1, row, "b")
 }
 
 func TestSortByMiddlewareTwoColumnsDesc(t *testing.T) {
@@ -153,17 +153,17 @@ func TestSortByMiddlewareTwoColumnsDesc(t *testing.T) {
 
 	require.Equal(t, 4, len(newtable.Rows))
 	row := newtable.Rows[0]
-	assert2.EqualMapRowValue(t, 2, row, "a")
-	assert2.EqualMapRowValue(t, 1, row, "b")
+	assert2.EqualRowValue(t, 2, row, "a")
+	assert2.EqualRowValue(t, 1, row, "b")
 	row = newtable.Rows[1]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 3, row, "b")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 3, row, "b")
 	row = newtable.Rows[2]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
 	row = newtable.Rows[3]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 1, row, "b")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 1, row, "b")
 }
 
 func TestSortByMiddlewareTwoColumnsDescFirst(t *testing.T) {
@@ -181,17 +181,17 @@ func TestSortByMiddlewareTwoColumnsDescFirst(t *testing.T) {
 
 	require.Equal(t, 4, len(newtable.Rows))
 	row := newtable.Rows[0]
-	assert2.EqualMapRowValue(t, 2, row, "a")
-	assert2.EqualMapRowValue(t, 1, row, "b")
+	assert2.EqualRowValue(t, 2, row, "a")
+	assert2.EqualRowValue(t, 1, row, "b")
 	row = newtable.Rows[1]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 1, row, "b")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 1, row, "b")
 	row = newtable.Rows[2]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 2, row, "b")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 2, row, "b")
 	row = newtable.Rows[3]
-	assert2.EqualMapRowValue(t, 1, row, "a")
-	assert2.EqualMapRowValue(t, 3, row, "b")
+	assert2.EqualRowValue(t, 1, row, "a")
+	assert2.EqualRowValue(t, 3, row, "b")
 }
 
 func TestSortByMiddlewareTwoColumnsDescSecond(t *testing.T) {

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -9,6 +9,9 @@ import (
 )
 
 type TableProcessor interface {
+	// TODO(manuel, 2023-06-28) There is some cleanup to be done on those Processor APIs
+	AddRowMiddleware(mw ...middlewares.RowMiddleware)
+
 	AddRow(ctx context.Context, obj types.Row) error
 	OutputFormatter() formatters.TableOutputFormatter
 	Finalize(ctx context.Context) error

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Processor interface {
-	ProcessInputObject(ctx context.Context, obj types.Row) error
+	AddRow(ctx context.Context, obj types.Row) error
 	OutputFormatter() formatters.OutputFormatter
 	Finalize(ctx context.Context) error
 	GetTable() *types.Table
@@ -63,20 +63,6 @@ func NewGlazeProcessor(of formatters.OutputFormatter, options ...GlazeProcessorO
 	}
 
 	return ret, nil
-}
-
-// ProcessInputObject takes an input object and processes it through the object middleware
-// chain.
-func (gp *GlazeProcessor) ProcessInputObject(ctx context.Context, obj types.Row) error {
-	err := gp.AddRow(ctx, obj)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (gp *GlazeProcessor) Finalize(ctx context.Context) error {
-	return gp.Processor.Finalize(ctx)
 }
 
 func NewSimpleGlazeProcessor(options ...GlazeProcessorOption) (*GlazeProcessor, error) {

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -8,8 +8,6 @@ import (
 	"github.com/go-go-golems/glazed/pkg/types"
 )
 
-// TODO(manuel, 2023-04-27) This is probably a good location for With* constructors for middlewares
-
 type Processor interface {
 	ProcessInputObject(ctx context.Context, obj types.Row) error
 	OutputFormatter() formatters.OutputFormatter
@@ -31,12 +29,6 @@ func (gp *GlazeProcessor) OutputFormatter() formatters.OutputFormatter {
 
 type GlazeProcessorOption func(*GlazeProcessor)
 
-func WithOutputFormatter(of formatters.OutputFormatter) GlazeProcessorOption {
-	return func(gp *GlazeProcessor) {
-		gp.of = of
-	}
-}
-
 func WithMiddlewareProcessor(processor *middlewares.Processor) GlazeProcessorOption {
 	return func(gp *GlazeProcessor) {
 		gp.processor = processor
@@ -56,13 +48,8 @@ func NewGlazeProcessor(of formatters.OutputFormatter, options ...GlazeProcessorO
 	return ret
 }
 
-// TODO(2022-12-18, manuel) we should actually make it possible to order the columns
-// https://github.com/go-go-golems/glazed/issues/56
-
 // ProcessInputObject takes an input object and processes it through the object middleware
 // chain.
-//
-// The final output is added to the output formatter as a single row.
 func (gp *GlazeProcessor) ProcessInputObject(ctx context.Context, obj types.Row) error {
 	err := gp.processor.AddRow(ctx, obj)
 	if err != nil {
@@ -71,21 +58,12 @@ func (gp *GlazeProcessor) ProcessInputObject(ctx context.Context, obj types.Row)
 	return nil
 }
 
-// SimpleGlazeProcessor only collects the output and returns it as a types.Table
-type SimpleGlazeProcessor struct {
-	*GlazeProcessor
-	formatter *table.OutputFormatter
-}
-
-func NewSimpleGlazeProcessor(options ...GlazeProcessorOption) *SimpleGlazeProcessor {
+func NewSimpleGlazeProcessor(options ...GlazeProcessorOption) *GlazeProcessor {
 	formatter := table.NewOutputFormatter("csv")
-	return &SimpleGlazeProcessor{
-		GlazeProcessor: NewGlazeProcessor(formatter, options...),
-		formatter:      formatter,
-	}
+	return NewGlazeProcessor(formatter, options...)
 }
 
-func (gp *SimpleGlazeProcessor) GetTable(ctx context.Context) (*types.Table, error) {
+func (gp *GlazeProcessor) GetTable(ctx context.Context) (*types.Table, error) {
 	err := gp.processor.FinalizeTable(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -8,9 +8,9 @@ import (
 	"github.com/go-go-golems/glazed/pkg/types"
 )
 
-type Processor interface {
+type TableProcessor interface {
 	AddRow(ctx context.Context, obj types.Row) error
-	OutputFormatter() formatters.OutputFormatter
+	OutputFormatter() formatters.TableOutputFormatter
 	Finalize(ctx context.Context) error
 	GetTable() *types.Table
 }
@@ -38,16 +38,16 @@ type Processor interface {
 // through the row middlewares.
 type GlazeProcessor struct {
 	*middlewares.Processor
-	of formatters.OutputFormatter
+	of formatters.TableOutputFormatter
 }
 
-func (gp *GlazeProcessor) OutputFormatter() formatters.OutputFormatter {
+func (gp *GlazeProcessor) OutputFormatter() formatters.TableOutputFormatter {
 	return gp.of
 }
 
 type GlazeProcessorOption func(*GlazeProcessor)
 
-func NewGlazeProcessor(of formatters.OutputFormatter, options ...GlazeProcessorOption) (*GlazeProcessor, error) {
+func NewGlazeProcessor(of formatters.TableOutputFormatter, options ...GlazeProcessorOption) (*GlazeProcessor, error) {
 	ret := &GlazeProcessor{
 		of:        of,
 		Processor: middlewares.NewProcessor(),

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -5,13 +5,15 @@ import (
 	"context"
 	"github.com/go-go-golems/glazed/pkg/formatters/json"
 	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 // BenchmarkSimpleGlazeProcessor benchmarks the simple glaze processor with no middlewares, and CSV output.
 func BenchmarkSimpleGlazeProcessor(b *testing.B) {
 	ctx := context.Background()
-	gp := NewSimpleGlazeProcessor()
+	gp, err := NewSimpleGlazeProcessor()
+	require.NoError(b, err)
 	data := types.NewRow(
 		types.MRP("name", "Manuel Manuel"),
 		types.MRP("age", 30),
@@ -26,18 +28,20 @@ func BenchmarkSimpleGlazeProcessor(b *testing.B) {
 		_ = gp.ProcessInputObject(ctx, data)
 	}
 	buf := &bytes.Buffer{}
-	err := gp.Processor().FinalizeTable(ctx)
+	err = gp.Finalize(ctx)
 	if err != nil {
 		b.Fatal(err)
 	}
 
-	_ = gp.OutputFormatter().Output(ctx, gp.Processor().GetTable(), buf)
+	_ = gp.OutputFormatter().Output(ctx, gp.GetTable(), buf)
 }
 
 func BenchmarkGlazeProcessor_JSONOutputFormatter(b *testing.B) {
 	ctx := context.Background()
 
-	gp := NewGlazeProcessor(json.NewOutputFormatter())
+	gp, err := NewGlazeProcessor(json.NewOutputFormatter())
+	require.NoError(b, err)
+
 	data := types.NewRow(
 		types.MRP("name", "Manuel Manuel"),
 		types.MRP("age", 30),
@@ -52,9 +56,7 @@ func BenchmarkGlazeProcessor_JSONOutputFormatter(b *testing.B) {
 		_ = gp.ProcessInputObject(ctx, data)
 	}
 	buf := &bytes.Buffer{}
-	err := gp.Processor().FinalizeTable(ctx)
-	if err != nil {
-		b.Fatal(err)
-	}
-	_ = gp.OutputFormatter().Output(ctx, gp.Processor().GetTable(), buf)
+	err = gp.Finalize(ctx)
+	require.NoError(b, err)
+	_ = gp.OutputFormatter().Output(ctx, gp.GetTable(), buf)
 }

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -25,7 +25,7 @@ func BenchmarkSimpleGlazeProcessor(b *testing.B) {
 		types.MRP("phone", "+351 123 456 789"),
 	)
 	for i := 0; i < b.N; i++ {
-		_ = gp.ProcessInputObject(ctx, data)
+		_ = gp.AddRow(ctx, data)
 	}
 	buf := &bytes.Buffer{}
 	err = gp.Finalize(ctx)
@@ -53,7 +53,7 @@ func BenchmarkGlazeProcessor_JSONOutputFormatter(b *testing.B) {
 		types.MRP("phone", "+351 123 456 789"),
 	)
 	for i := 0; i < b.N; i++ {
-		_ = gp.ProcessInputObject(ctx, data)
+		_ = gp.AddRow(ctx, data)
 	}
 	buf := &bytes.Buffer{}
 	err = gp.Finalize(ctx)

--- a/pkg/settings/glazed_layer.go
+++ b/pkg/settings/glazed_layer.go
@@ -407,7 +407,7 @@ func SetupProcessor(ps map[string]interface{}, options ...processor.GlazeProcess
 
 	templateSettings.UpdateWithSelectSettings(selectSettings)
 
-	var of formatters.OutputFormatter
+	var of formatters.TableOutputFormatter
 	if selectSettings.SelectField != "" {
 		of = simple.NewSingleColumnFormatter(
 			selectSettings.SelectField,

--- a/pkg/settings/settings_output.go
+++ b/pkg/settings/settings_output.go
@@ -13,8 +13,6 @@ import (
 	template_formatter "github.com/go-go-golems/glazed/pkg/formatters/template"
 	"github.com/go-go-golems/glazed/pkg/formatters/yaml"
 	"github.com/go-go-golems/glazed/pkg/helpers/templating"
-	"github.com/go-go-golems/glazed/pkg/middlewares"
-	"github.com/go-go-golems/glazed/pkg/middlewares/row"
 	"github.com/pkg/errors"
 	"text/template"
 	"unicode/utf8"
@@ -72,7 +70,7 @@ func NewOutputFormatterSettings(ps map[string]interface{}) (*OutputFormatterSett
 	return s, nil
 }
 
-func (ofs *OutputFormatterSettings) CreateOutputFormatter(mwProcessor *middlewares.Processor) (formatters.OutputFormatter, error) {
+func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFormatter, error) {
 	if ofs.Output == "csv" {
 		ofs.Output = "table"
 		ofs.TableFormat = "csv"
@@ -119,7 +117,6 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter(mwProcessor *middlewar
 			excel.WithSheetName(ofs.SheetName),
 			excel.WithOutputFile(ofs.OutputFile),
 		)
-		mwProcessor.AddRowMiddlewareInFront(row.NewFlattenObjectMiddleware())
 	} else if ofs.Output == "table" {
 		if ofs.TableFormat == "csv" {
 			csvOf := csv.NewCSVOutputFormatter(
@@ -150,7 +147,6 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter(mwProcessor *middlewar
 				table_formatter.WithPrintTableStyle(ofs.PrintTableStyle),
 			)
 		}
-		mwProcessor.AddRowMiddlewareInFront(row.NewFlattenObjectMiddleware())
 	} else if ofs.Output == "template" {
 		if ofs.TemplateFormatterSettings == nil {
 			ofs.TemplateFormatterSettings = &TemplateFormatterSettings{

--- a/pkg/settings/settings_output.go
+++ b/pkg/settings/settings_output.go
@@ -70,7 +70,7 @@ func NewOutputFormatterSettings(ps map[string]interface{}) (*OutputFormatterSett
 	return s, nil
 }
 
-func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFormatter, error) {
+func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.TableOutputFormatter, error) {
 	if ofs.Output == "csv" {
 		ofs.Output = "table"
 		ofs.TableFormat = "csv"
@@ -91,7 +91,7 @@ func (ofs *OutputFormatterSettings) CreateOutputFormatter() (formatters.OutputFo
 		}
 	}
 
-	var of formatters.OutputFormatter
+	var of formatters.TableOutputFormatter
 	if ofs.Output == "json" {
 		of = json.NewOutputFormatter(
 			json.WithOutputIndividualRows(ofs.OutputAsObjects),

--- a/pkg/types/mod.go
+++ b/pkg/types/mod.go
@@ -71,6 +71,14 @@ func MRP(key FieldName, value GenericCellValue) MapRowPair {
 	return orderedmap.Pair[FieldName, GenericCellValue]{Key: key, Value: value}
 }
 
+func RowToMap(om Row) map[string]interface{} {
+	ret := make(map[string]interface{})
+	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+		ret[pair.Key] = pair.Value
+	}
+	return ret
+}
+
 func GetFields(om Row) []FieldName {
 	ret := []FieldName{}
 	for pair := om.Oldest(); pair != nil; pair = pair.Next() {

--- a/pkg/types/mod.go
+++ b/pkg/types/mod.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	orderedmap "github.com/wk8/go-ordered-map/v2"
+	"reflect"
 	"sort"
+	"strings"
 )
 
 type TableName = string
@@ -43,6 +45,26 @@ func NewRowFromMapWithColumns(hash map[FieldName]GenericCellValue, columns []Fie
 		ret.Set(column, v)
 	}
 	return ret
+}
+
+func NewRowFromStruct(i interface{}, lowerCaseKeys bool) Row {
+	val := reflect.ValueOf(i)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	t := val.Type()
+	row := NewRow()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		name := field.Name
+		if lowerCaseKeys {
+			name = strings.ToLower(name)
+		}
+		row.Set(name, val.Field(i).Interface())
+	}
+
+	return row
 }
 
 func MRP(key FieldName, value GenericCellValue) MapRowPair {


### PR DESCRIPTION
Closes #308

See also #309 and #310 

This PR does "some" cleanup of the Processor API. It also introduces a RowOutputFormatter
that will allow us to do row level streaming output.

However, this is ll not wired up and how output formatters and processors and middlewares 
interact is not yet clear to me, and i'll need a bit of subconscious work to approach it with
more clarity.

I think I want the output formatters to actually be middlewares, which could for example allow
us to render output on multiple channels, multiple formats at once, and also approach something
like long-running glazed commands that don't have to accumulate all their data into Tables.

This sets the way to transform commands to work on streams.

- :sparkles: Add RowFromStruct utility
- :art: Start cleaning up GlazeProcessor API
- :art: :poop: Try cleaning up GlazeProcessor API
- :art: :poop: Try cleaning up GlazeProcessor API
- :art: Introduce RowOutputFormatter and rename OutputFormatter to TableOutputFormatter
- :poop: Add some hacks to make other dependencies compile
