### PR TITLE
:ambulance: Fix outputting a proper json array per default

### DIFF
--- a/cmd/glaze/cmds/docs.go
+++ b/cmd/glaze/cmds/docs.go
@@ -50,7 +50,7 @@ var DocsCmd = &cobra.Command{
 func init() {
 	DocsCmd.Flags().SortFlags = false
 	// This is an example of selective use of glazed parameter layers.
-	// If we extracted out the docs command into a cmds.GlazeCommand, which we should
+	// If we extracted out the docs command into a cmd.GlazeCommand, which we should
 	// in order to expose it as a REST API, all of this would not even be necessary,
 	// I think.
 	gpl, err := settings.NewGlazedParameterLayers(

--- a/doc/rfcs/drafts/07_2022-12-03_help-system.md
+++ b/doc/rfcs/drafts/07_2022-12-03_help-system.md
@@ -204,15 +204,15 @@ Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmd := .Commands}}{{if eq (len .Groups) 0}}
 
-Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+Available Commands:{{range $cmd}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
 
-{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+{{.Title}}{{range $cmd}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
 
-Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+Additional Commands:{{range $cmd}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:

--- a/pkg/formatters/csv/csv.go
+++ b/pkg/formatters/csv/csv.go
@@ -81,7 +81,7 @@ func NewTSVOutputFormatter(opts ...OutputFormatterOption) *OutputFormatter {
 	return f
 }
 
-func (f *OutputFormatter) Close(ctx context.Context) error {
+func (f *OutputFormatter) Close(ctx context.Context, w io.Writer) error {
 	if f.csvWriter != nil {
 		f.csvWriter.Flush()
 

--- a/pkg/formatters/excel/excel.go
+++ b/pkg/formatters/excel/excel.go
@@ -25,7 +25,7 @@ type OutputFormatter struct {
 	rowKeyToColumn map[string]string
 }
 
-func (E *OutputFormatter) Close(ctx context.Context) error {
+func (E *OutputFormatter) Close(ctx context.Context, w io.Writer) error {
 	if E.f != nil {
 		E.f.SetActiveSheet(E.sheetIndex)
 		if err := E.f.SaveAs(E.OutputFile); err != nil {

--- a/pkg/formatters/formatter.go
+++ b/pkg/formatters/formatter.go
@@ -43,7 +43,7 @@ type OutputFormatter interface {
 	// flattening the row objects before output.
 	RegisterTableMiddlewares(mw *middlewares.TableProcessor) error
 	ContentType() string
-	Close(ctx context.Context) error
+	Close(ctx context.Context, w io.Writer) error
 }
 
 // TableOutputFormatter is an output formatter that requires an entire table to be computed up

--- a/pkg/formatters/simple/simple.go
+++ b/pkg/formatters/simple/simple.go
@@ -18,7 +18,7 @@ type SingleColumnFormatter struct {
 	Separator           string
 }
 
-func (s *SingleColumnFormatter) Close(ctx context.Context) error {
+func (s *SingleColumnFormatter) Close(ctx context.Context, w io.Writer) error {
 	return nil
 }
 

--- a/pkg/formatters/table/table.go
+++ b/pkg/formatters/table/table.go
@@ -53,7 +53,7 @@ type OutputFormatter struct {
 	hasOutputHeaders    bool
 }
 
-func (tof *OutputFormatter) Close(ctx context.Context) error {
+func (tof *OutputFormatter) Close(ctx context.Context, w io.Writer) error {
 	return nil
 }
 

--- a/pkg/formatters/template/template.go
+++ b/pkg/formatters/template/template.go
@@ -20,7 +20,7 @@ type OutputFormatter struct {
 	AdditionalData      interface{}
 }
 
-func (t *OutputFormatter) Close(ctx context.Context) error {
+func (t *OutputFormatter) Close(ctx context.Context, w io.Writer) error {
 	return nil
 }
 

--- a/pkg/formatters/yaml/yaml.go
+++ b/pkg/formatters/yaml/yaml.go
@@ -18,7 +18,7 @@ type OutputFormatter struct {
 	OutputIndividualRows bool
 }
 
-func (f *OutputFormatter) Close(ctx context.Context) error {
+func (f *OutputFormatter) Close(ctx context.Context, w io.Writer) error {
 	return nil
 }
 

--- a/pkg/helpers/compare/remove_duplicates.go
+++ b/pkg/helpers/compare/remove_duplicates.go
@@ -1,0 +1,17 @@
+package compare
+
+func RemoveDuplicates[T comparable](slice []T) []T {
+	encountered := map[T]bool{}
+	result := []T{}
+
+	for _, v := range slice {
+		if encountered[v] {
+			continue
+		} else {
+			encountered[v] = true
+			result = append(result, v)
+		}
+	}
+
+	return result
+}

--- a/pkg/middlewares/row/output.go
+++ b/pkg/middlewares/row/output.go
@@ -14,7 +14,7 @@ type OutputMiddleware struct {
 }
 
 func (o OutputMiddleware) Close(ctx context.Context) error {
-	return o.formatter.Close(ctx)
+	return o.formatter.Close(ctx, o.writer)
 }
 
 func NewOutputMiddleware(formatter formatters.RowOutputFormatter, writer io.Writer) *OutputMiddleware {
@@ -41,7 +41,7 @@ type OutputChannelMiddleware[T interface{ ~string }] struct {
 }
 
 func (o *OutputChannelMiddleware[T]) Close(ctx context.Context) error {
-	return o.formatter.Close(ctx)
+	return o.formatter.Close(ctx, nil)
 }
 
 func (o *OutputChannelMiddleware[T]) Process(ctx context.Context, row types.Row) ([]types.Row, error) {

--- a/pkg/middlewares/table/output.go
+++ b/pkg/middlewares/table/output.go
@@ -14,7 +14,7 @@ type OutputMiddleware struct {
 }
 
 func (o *OutputMiddleware) Close(ctx context.Context) error {
-	return o.formatter.Close(ctx)
+	return o.formatter.Close(ctx, nil)
 }
 
 func NewOutputMiddleware(formatter formatters.TableOutputFormatter, writer io.Writer) *OutputMiddleware {
@@ -39,7 +39,7 @@ type OutputChannelMiddleware[T interface{ ~string }] struct {
 }
 
 func (o *OutputChannelMiddleware[T]) Close(ctx context.Context) error {
-	return o.formatter.Close(ctx)
+	return o.formatter.Close(ctx, nil)
 }
 
 func NewOutputChannelMiddleware[T interface{ ~string }](formatter formatters.RowOutputFormatter,


### PR DESCRIPTION
Since switching to a row output for the json formatter output,
we didn't handle outputting as a proper array, which requires us to 
output a [] by hand.
