### PR TITLE
:sparkles: Add YAML introspection

### DIFF
--- a/cmd/glaze/cmds/csv.go
+++ b/cmd/glaze/cmds/csv.go
@@ -14,7 +14,7 @@ import (
 )
 
 type CsvCommand struct {
-	description *cmds.CommandDescription
+	*cmds.CommandDescription
 }
 
 func NewCsvCommand() (*CsvCommand, error) {
@@ -24,7 +24,7 @@ func NewCsvCommand() (*CsvCommand, error) {
 	}
 
 	return &CsvCommand{
-		description: cmds.NewCommandDescription(
+		CommandDescription: cmds.NewCommandDescription(
 			"csv",
 			cmds.WithShort("Format CSV files"),
 			cmds.WithArguments(
@@ -71,10 +71,6 @@ func NewCsvCommand() (*CsvCommand, error) {
 			),
 		),
 	}, nil
-}
-
-func (c *CsvCommand) Description() *cmds.CommandDescription {
-	return c.description
 }
 
 func (c *CsvCommand) Run(

--- a/cmd/glaze/cmds/example.go
+++ b/cmd/glaze/cmds/example.go
@@ -15,7 +15,7 @@ import (
 )
 
 type ExampleCommand struct {
-	description *cmds.CommandDescription
+	*cmds.CommandDescription
 }
 
 func NewExampleCommand() (*ExampleCommand, error) {
@@ -25,7 +25,7 @@ func NewExampleCommand() (*ExampleCommand, error) {
 	}
 
 	return &ExampleCommand{
-		description: cmds.NewCommandDescription(
+		CommandDescription: cmds.NewCommandDescription(
 			"example",
 			cmds.WithShort("Example command"),
 			cmds.WithFlags(
@@ -47,10 +47,6 @@ func NewExampleCommand() (*ExampleCommand, error) {
 			),
 		),
 	}, nil
-}
-
-func (c *ExampleCommand) Description() *cmds.CommandDescription {
-	return c.description
 }
 
 func (c *ExampleCommand) Run(

--- a/cmd/glaze/cmds/json.go
+++ b/cmd/glaze/cmds/json.go
@@ -15,7 +15,7 @@ import (
 )
 
 type JsonCommand struct {
-	description *cmds.CommandDescription
+	*cmds.CommandDescription
 }
 
 func NewJsonCommand() (*JsonCommand, error) {
@@ -25,7 +25,7 @@ func NewJsonCommand() (*JsonCommand, error) {
 	}
 
 	return &JsonCommand{
-		description: cmds.NewCommandDescription(
+		CommandDescription: cmds.NewCommandDescription(
 			"json",
 			cmds.WithShort("Format JSON data"),
 			cmds.WithFlags(
@@ -106,8 +106,4 @@ func (j *JsonCommand) Run(
 	}
 
 	return nil
-}
-
-func (j *JsonCommand) Description() *cmds.CommandDescription {
-	return j.description
 }

--- a/cmd/glaze/cmds/yaml.go
+++ b/cmd/glaze/cmds/yaml.go
@@ -19,7 +19,7 @@ import (
 )
 
 type YamlCommand struct {
-	description *cmds.CommandDescription
+	*cmds.CommandDescription
 }
 
 func NewYamlCommand() (*YamlCommand, error) {
@@ -29,7 +29,7 @@ func NewYamlCommand() (*YamlCommand, error) {
 	}
 
 	return &YamlCommand{
-		description: cmds.NewCommandDescription(
+		CommandDescription: cmds.NewCommandDescription(
 			"yaml",
 			cmds.WithShort("Format YAML data"),
 			cmds.WithFlags(
@@ -146,8 +146,4 @@ func (y *YamlCommand) Run(
 	}
 
 	return nil
-}
-
-func (y *YamlCommand) Description() *cmds.CommandDescription {
-	return y.description
 }

--- a/cmd/glaze/doc/tutorials/01-a-simple-table-cli.md
+++ b/cmd/glaze/doc/tutorials/01-a-simple-table-cli.md
@@ -30,7 +30,7 @@ type `*CommandDescription`.
 
 ```go
 type ExampleCommand struct {
-	description *cmds.CommandDescription
+	*cmds.CommandDescription
 }
 ```
 
@@ -41,7 +41,7 @@ arguments the command takes.
 ```go
 func NewExampleCommand() (*ExampleCommand, error) {
 	return &ExampleCommand{
-		description: cmds.NewCommandDescription(
+		CommandDescription: cmds.NewCommandDescription(
 			"example",
 			cmds.WithShort("Example command"),
 			cmds.WithFlags(

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -84,6 +84,7 @@ func BuildCobraCommandFromCommand(s cmds.Command, run CobraRunFunc) (*cobra.Comm
 	cmd.Flags().String("create-command", "", "Create a new command for the query, with the defaults updated")
 	cmd.Flags().String("create-alias", "", "Create a CLI alias for the query")
 	cmd.Flags().String("create-cliopatra", "", "Print the CLIopatra YAML for the command")
+	cmd.Flags().Bool("print-yaml", false, "Print the command's YAML")
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		parsedLayers, ps, err := cobraParser.Parse(args)
@@ -93,6 +94,15 @@ func BuildCobraCommandFromCommand(s cmds.Command, run CobraRunFunc) (*cobra.Comm
 			err := cmd.Help()
 			cobra.CheckErr(err)
 			os.Exit(1)
+		}
+
+		printYAML, err := cmd.Flags().GetBool("print-yaml")
+		cobra.CheckErr(err)
+
+		if printYAML {
+			err = s.ToYAML(os.Stdout)
+			cobra.CheckErr(err)
+			return
 		}
 
 		createCliopatra, err := cmd.Flags().GetString("create-cliopatra")

--- a/pkg/cmds/alias/alias.go
+++ b/pkg/cmds/alias/alias.go
@@ -152,6 +152,9 @@ func (a *CommandAlias) IsValid() bool {
 // This is necessary because they get mutated at runtime with various defaults,
 // depending on where they come from.
 func (a *CommandAlias) Description() *cmds.CommandDescription {
+	if a.AliasedCommand == nil {
+		return nil
+	}
 	s := a.AliasedCommand.Description()
 	layout_ := a.Layout
 	if layout_ == nil {

--- a/pkg/cmds/alias/alias.go
+++ b/pkg/cmds/alias/alias.go
@@ -155,7 +155,7 @@ func (a *CommandAlias) Description() *cmds.CommandDescription {
 	s := a.AliasedCommand.Description()
 	layout_ := a.Layout
 	if layout_ == nil {
-		layout_ = s.Layout.Sections
+		layout_ = s.Layout
 	}
 	ret := &cmds.CommandDescription{
 		Name:      a.Name,
@@ -163,12 +163,10 @@ func (a *CommandAlias) Description() *cmds.CommandDescription {
 		Long:      s.Long,
 		Flags:     []*parameters.ParameterDefinition{},
 		Arguments: []*parameters.ParameterDefinition{},
-		Layout: &layout.Layout{
-			Sections: layout_,
-		},
-		Layers:  s.Layers,
-		Parents: a.Parents,
-		Source:  a.Source,
+		Layout:    layout_,
+		Layers:    s.Layers,
+		Parents:   a.Parents,
+		Source:    a.Source,
 	}
 
 	for _, flag := range s.Flags {

--- a/pkg/cmds/alias/alias.go
+++ b/pkg/cmds/alias/alias.go
@@ -117,6 +117,15 @@ func (a *CommandAlias) String() string {
 		a.Name, a.AliasFor, a.Parents, a.Source)
 }
 
+func (a *CommandAlias) ToYAML(w io.Writer) error {
+	enc := yaml.NewEncoder(w)
+	defer func(enc *yaml.Encoder) {
+		_ = enc.Close()
+	}(enc)
+
+	return enc.Encode(a)
+}
+
 func (a *CommandAlias) Run(
 	ctx context.Context,
 	parsedLayers map[string]*layers.ParsedParameterLayer,

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -17,7 +17,7 @@ type CommandDescription struct {
 	Name      string                            `yaml:"name"`
 	Short     string                            `yaml:"short"`
 	Long      string                            `yaml:"long,omitempty"`
-	Layout    *layout.Layout                    `yaml:"layout,omitempty"`
+	Layout    []*layout.Section                 `yaml:"layout,omitempty"`
 	Flags     []*parameters.ParameterDefinition `yaml:"flags,omitempty"`
 	Arguments []*parameters.ParameterDefinition `yaml:"arguments,omitempty"`
 	Layers    []layers.ParameterLayer           `yaml:"layers,omitempty"`
@@ -136,7 +136,7 @@ func WithLayers(l ...layers.ParameterLayer) CommandDescriptionOption {
 
 func WithLayout(l *layout.Layout) CommandDescriptionOption {
 	return func(c *CommandDescription) {
-		c.Layout = l
+		c.Layout = l.Sections
 	}
 }
 

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/layout"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"gopkg.in/yaml.v3"
 	"io"
 )
 
@@ -217,8 +218,22 @@ func WithPrependSource(s string) CommandDescriptionOption {
 	}
 }
 
+func (cd *CommandDescription) ToYAML(w io.Writer) error {
+	enc := yaml.NewEncoder(w)
+	defer func(enc *yaml.Encoder) {
+		_ = enc.Close()
+	}(enc)
+
+	return enc.Encode(cd)
+}
+
+func (cd *CommandDescription) Description() *CommandDescription {
+	return cd
+}
+
 type Command interface {
 	Description() *CommandDescription
+	ToYAML(w io.Writer) error
 }
 
 // NOTE(manuel, 2023-03-17) Future types of commands that we could need

--- a/pkg/cmds/layers/groups.go
+++ b/pkg/cmds/layers/groups.go
@@ -77,6 +77,7 @@ type ParameterLayerImpl struct {
 	Description string                            `yaml:"description"`
 	Prefix      string                            `yaml:"prefix"`
 	Flags       []*parameters.ParameterDefinition `yaml:"flags,omitempty"`
+	ChildLayers []ParameterLayer                  `yaml:"childLayers,omitempty"`
 }
 
 func (p *ParameterLayerImpl) GetName() string {

--- a/pkg/cmds/layout/layout.go
+++ b/pkg/cmds/layout/layout.go
@@ -1,7 +1,7 @@
 package layout
 
 type Layout struct {
-	Sections []*Section
+	Sections []*Section `yaml:"sections"`
 }
 
 type Section struct {

--- a/pkg/settings/glazed_layer.go
+++ b/pkg/settings/glazed_layer.go
@@ -18,14 +18,33 @@ import (
 // Helpers for cobra commands
 
 type GlazedParameterLayers struct {
-	FieldsFiltersParameterLayer *FieldsFiltersParameterLayer
-	OutputParameterLayer        *OutputParameterLayer
-	RenameParameterLayer        *RenameParameterLayer
-	ReplaceParameterLayer       *ReplaceParameterLayer
-	SelectParameterLayer        *SelectParameterLayer
-	TemplateParameterLayer      *TemplateParameterLayer
-	JqParameterLayer            *JqParameterLayer
-	SortParameterLayer          *SortParameterLayer
+	FieldsFiltersParameterLayer *FieldsFiltersParameterLayer `yaml:"fieldsFiltersParameterLayer"`
+	OutputParameterLayer        *OutputParameterLayer        `yaml:"outputParameterLayer"`
+	RenameParameterLayer        *RenameParameterLayer        `yaml:"renameParameterLayer"`
+	ReplaceParameterLayer       *ReplaceParameterLayer       `yaml:"replaceParameterLayer"`
+	SelectParameterLayer        *SelectParameterLayer        `yaml:"selectParameterLayer"`
+	TemplateParameterLayer      *TemplateParameterLayer      `yaml:"templateParameterLayer"`
+	JqParameterLayer            *JqParameterLayer            `yaml:"jqParameterLayer"`
+	SortParameterLayer          *SortParameterLayer          `yaml:"sortParameterLayer"`
+}
+
+func (g *GlazedParameterLayers) MarshalYAML() (interface{}, error) {
+	return &layers.ParameterLayerImpl{
+		Name:        g.GetName(),
+		Slug:        g.GetSlug(),
+		Description: g.GetDescription(),
+		Prefix:      g.GetPrefix(),
+		ChildLayers: []layers.ParameterLayer{
+			g.FieldsFiltersParameterLayer,
+			g.OutputParameterLayer,
+			g.RenameParameterLayer,
+			g.ReplaceParameterLayer,
+			g.SelectParameterLayer,
+			g.TemplateParameterLayer,
+			g.JqParameterLayer,
+			g.SortParameterLayer,
+		},
+	}, nil
 }
 
 func (g *GlazedParameterLayers) GetName() string {

--- a/pkg/settings/settings_fields-filters.go
+++ b/pkg/settings/settings_fields-filters.go
@@ -22,7 +22,7 @@ type FieldsFilterFlagsDefaults struct {
 }
 
 type FieldsFiltersParameterLayer struct {
-	*layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl `yaml:",inline"`
 }
 
 type FieldsFilterSettings struct {

--- a/pkg/settings/settings_jq.go
+++ b/pkg/settings/settings_jq.go
@@ -18,7 +18,7 @@ type JqSettings struct {
 var jqFlagsYaml []byte
 
 type JqParameterLayer struct {
-	*layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl `yaml:",inline"`
 }
 
 func NewJqParameterLayer(options ...layers.ParameterLayerOptions) (*JqParameterLayer, error) {

--- a/pkg/settings/settings_output.go
+++ b/pkg/settings/settings_output.go
@@ -48,7 +48,7 @@ type OutputFormatterSettings struct {
 var outputFlagsYaml []byte
 
 type OutputParameterLayer struct {
-	*layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl `yaml:",inline"`
 }
 
 func NewOutputParameterLayer(options ...layers.ParameterLayerOptions) (*OutputParameterLayer, error) {

--- a/pkg/settings/settings_rename.go
+++ b/pkg/settings/settings_rename.go
@@ -53,7 +53,7 @@ type RenameFlagsDefaults struct {
 var renameFlagsYaml []byte
 
 type RenameParameterLayer struct {
-	*layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl `yaml:",inline"`
 }
 
 func NewRenameParameterLayer(options ...layers.ParameterLayerOptions) (*RenameParameterLayer, error) {

--- a/pkg/settings/settings_replace.go
+++ b/pkg/settings/settings_replace.go
@@ -39,7 +39,7 @@ func (rs *ReplaceSettings) AddMiddlewares(of *middlewares.TableProcessor) error 
 }
 
 type ReplaceParameterLayer struct {
-	*layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl `yaml:",inline"`
 }
 
 //go:embed "flags/replace.yaml"

--- a/pkg/settings/settings_select.go
+++ b/pkg/settings/settings_select.go
@@ -36,7 +36,7 @@ func (tf *TemplateSettings) UpdateWithSelectSettings(ss *SelectSettings) {
 }
 
 type SelectParameterLayer struct {
-	*layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl `yaml:",inline"`
 }
 
 func NewSelectParameterLayer(options ...layers.ParameterLayerOptions) (*SelectParameterLayer, error) {

--- a/pkg/settings/settings_sort.go
+++ b/pkg/settings/settings_sort.go
@@ -27,7 +27,7 @@ func NewSortSettingsFromParameters(ps map[string]interface{}) (*SortFlagsSetting
 }
 
 type SortParameterLayer struct {
-	*layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl `yaml:",inline"`
 }
 
 func NewSortParameterLayer(options ...layers.ParameterLayerOptions) (*SortParameterLayer, error) {

--- a/pkg/settings/settings_template.go
+++ b/pkg/settings/settings_template.go
@@ -43,7 +43,7 @@ func NewTemplateFlagsDefaults() *TemplateFlagsDefaults {
 }
 
 type TemplateParameterLayer struct {
-	*layers.ParameterLayerImpl
+	*layers.ParameterLayerImpl `yaml:",inline"`
 }
 
 func NewTemplateParameterLayer(options ...layers.ParameterLayerOptions) (*TemplateParameterLayer, error) {

--- a/pkg/types/mod.go
+++ b/pkg/types/mod.go
@@ -48,13 +48,20 @@ func NewRowFromMapWithColumns(hash map[FieldName]GenericCellValue, columns []Fie
 }
 
 func NewRowFromStruct(i interface{}, lowerCaseKeys bool) Row {
+	row := NewRow()
+	SetFromStruct(row, i, lowerCaseKeys)
+
+	return row
+}
+
+func SetFromStruct(row Row, i interface{}, lowerCaseKeys bool) Row {
 	val := reflect.ValueOf(i)
 	if val.Kind() == reflect.Ptr {
 		val = val.Elem()
 	}
 
 	t := val.Type()
-	row := NewRow()
+
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		name := field.Name


### PR DESCRIPTION
This adds the first building blocks to allow for commands to introspect
their flags and arguments but also provide a generic interface to provide 
access to their declarative content (if possible). It currently only handles
serializing to YAML in a single file, but this will be extended for the richer possibilities
of bundled commands like in escuse-me.

The main change here is that Command now requires the implementation of a `ToYAML()` method, 
which is provided per default for `CommandDescription` itself. However, to make the job easier,
most commands that currently had an explicit `*CommandDescription` field now embed it, so that they can reuse the default `Description()` and `ToYAML()` methods. This change has been reverberating through all the other GO GO GOLEMS modules because it actually simplifies the code. 

- :sparkles: Add introspection YAML output with --print-yaml
- :ambulance: Fix Layout definition in the normal CommandDescription
- :ambulance: Extract out Row.SetFromStruct
- :arrow_up: Adapt to new CommandDescription usage

