### PR TITLE
:sparkles: Add small helper functions

### DIFF
--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -362,7 +362,11 @@ func BuildCobraCommandFromCommand(command cmds.Command) (*cobra.Command, error) 
 	return cobraCommand, nil
 }
 
-func AddCommandsToRootCommand(rootCmd *cobra.Command, commands []cmds.Command, aliases []*alias.CommandAlias) error {
+func AddCommandsToRootCommand(
+	rootCmd *cobra.Command,
+	commands []cmds.Command,
+	aliases []*alias.CommandAlias,
+) error {
 	commandsByName := map[string]cmds.Command{}
 
 	for _, command := range commands {

--- a/pkg/cmds/parameters/parameters.go
+++ b/pkg/cmds/parameters/parameters.go
@@ -488,6 +488,36 @@ func InitializeParameterDefinitionsFromStruct(
 	return nil
 }
 
+func StructToMap(s interface{}) (map[string]interface{}, error) {
+	ret := map[string]interface{}{}
+
+	// check that s is indeed a pointer to a struct
+	if reflect.TypeOf(s).Kind() != reflect.Ptr {
+		return nil, errors.Errorf("s is not a pointer")
+	}
+	// check if nil
+	if reflect.ValueOf(s).IsNil() {
+		return ret, nil
+	}
+	if reflect.TypeOf(s).Elem().Kind() != reflect.Struct {
+		return nil, errors.Errorf("s is not a pointer to a struct")
+	}
+	st := reflect.TypeOf(s).Elem()
+
+	for i := 0; i < st.NumField(); i++ {
+		field := st.Field(i)
+		parameterName, ok := field.Tag.Lookup("glazed.parameter")
+		if !ok {
+			continue
+		}
+		value := reflect.ValueOf(s).Elem().FieldByName(field.Name)
+
+		ret[parameterName] = value
+	}
+
+	return ret, nil
+}
+
 func InitializeParameterDefaultsFromParameters(
 	parameterDefinitions map[string]*ParameterDefinition,
 	ps map[string]interface{},

--- a/pkg/helpers/list/list.go
+++ b/pkg/helpers/list/list.go
@@ -1,7 +1,24 @@
 package list
 
+import (
+	"fmt"
+	"strings"
+)
+
 func Reverse[T any](s []T) {
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
 		s[i], s[j] = s[j], s[i]
 	}
+}
+
+// SliceToCSV converts a generic slice to a comma separated string.
+func SliceToCSV[T any](items []T) string {
+	var sb strings.Builder
+	for i, item := range items {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(fmt.Sprint(item))
+	}
+	return sb.String()
 }

--- a/pkg/helpers/templating/templating.go
+++ b/pkg/helpers/templating/templating.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Masterminds/sprig"
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/go-go-golems/glazed/pkg/helpers/cast"
+	"github.com/go-go-golems/glazed/pkg/helpers/list"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	html "html/template"
@@ -90,6 +91,8 @@ var TemplateFuncs = template.FuncMap{
 	"toYaml":      toYaml,
 	"indentBlock": indentBlock,
 
+	"toUrlParameter": toUrlParameter,
+
 	"styleBold": styleBold,
 }
 
@@ -103,6 +106,48 @@ func toDate(s interface{}) (string, error) {
 		return v.Format("2006-01-02"), nil
 	default:
 		return "", errors.Errorf("cannot convert %v to date", v)
+	}
+}
+
+// toUrlParameter encodes the value as a string that can be passed for url parameter decoding
+func toUrlParameter(s interface{}) (string, error) {
+	switch v := s.(type) {
+	case string:
+		return v, nil
+	case time.Time:
+		return v.Format("2006-01-02"), nil
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf("%d", v), nil
+	case float32, float64:
+		return fmt.Sprintf("%f", v), nil
+	case []string:
+		return list.SliceToCSV(v), nil
+	case []int:
+		return list.SliceToCSV(v), nil
+	case []int8:
+		return list.SliceToCSV(v), nil
+	case []int16:
+		return list.SliceToCSV(v), nil
+	case []int32:
+		return list.SliceToCSV(v), nil
+	case []int64:
+		return list.SliceToCSV(v), nil
+	case []uint:
+		return list.SliceToCSV(v), nil
+	case []uint8:
+		return list.SliceToCSV(v), nil
+	case []uint16:
+		return list.SliceToCSV(v), nil
+	case []uint32:
+		return list.SliceToCSV(v), nil
+	case []uint64:
+		return list.SliceToCSV(v), nil
+	case []float32:
+		return list.SliceToCSV(v), nil
+	case []float64:
+		return list.SliceToCSV(v), nil
+	default:
+		return fmt.Sprintf("%v", s), nil
 	}
 }
 


### PR DESCRIPTION
Related to https://github.com/go-go-golems/parka/issues/84

- :sparkles: Add StructToMap as a preparatory step for codegen of commands
- :sparkles: Add helper function to render values to valid HTTP query parameters
