### PR TITLE
Add choiceList type

### DIFF
--- a/pkg/cmds/cobra.go
+++ b/pkg/cmds/cobra.go
@@ -1,1 +1,0 @@
-package cmds

--- a/pkg/cmds/parameters/cobra.go
+++ b/pkg/cmds/parameters/cobra.go
@@ -165,13 +165,7 @@ func AddFlagsToCobraCommand(
 		}
 
 		switch parameter.Type {
-		case ParameterTypeStringListFromFile:
-			fallthrough
-		case ParameterTypeStringFromFile:
-			fallthrough
-		case ParameterTypeObjectFromFile:
-			fallthrough
-		case ParameterTypeObjectListFromFile:
+		case ParameterTypeStringListFromFile, ParameterTypeStringFromFile, ParameterTypeObjectFromFile, ParameterTypeObjectListFromFile:
 			defaultValue := ""
 
 			if parameter.ShortFlag != "" {
@@ -180,11 +174,7 @@ func AddFlagsToCobraCommand(
 				flagSet.String(flagName, defaultValue, parameter.Help)
 			}
 
-		case ParameterTypeStringListFromFiles:
-			fallthrough
-		case ParameterTypeStringFromFiles:
-			fallthrough
-		case ParameterTypeObjectListFromFiles:
+		case ParameterTypeStringListFromFiles, ParameterTypeStringFromFiles, ParameterTypeObjectListFromFiles:
 			defaultValue := []string{}
 
 			if parameter.ShortFlag != "" {
@@ -281,7 +271,7 @@ func AddFlagsToCobraCommand(
 				flagSet.String(flagName, defaultValue, parameter.Help)
 			}
 
-		case ParameterTypeStringList:
+		case ParameterTypeStringList, ParameterTypeChoiceList:
 			var defaultValue []string
 
 			if parameter.Default != nil {
@@ -489,19 +479,13 @@ func GatherFlagsFromCobraCommand(
 		}
 
 		switch parameter.Type {
-		case ParameterTypeObjectFromFile:
-			fallthrough
-		case ParameterTypeObjectListFromFile:
-			fallthrough
-		case ParameterTypeStringFromFile:
-			fallthrough
-		case ParameterTypeStringListFromFile:
-			fallthrough
-		case ParameterTypeString:
-			fallthrough
-		case ParameterTypeDate:
-			fallthrough
-		case ParameterTypeChoice:
+		case ParameterTypeObjectFromFile,
+			ParameterTypeObjectListFromFile,
+			ParameterTypeStringFromFile,
+			ParameterTypeStringListFromFile,
+			ParameterTypeString,
+			ParameterTypeDate,
+			ParameterTypeChoice:
 			v, err := cmd.Flags().GetString(flagName)
 			if err != nil {
 				return nil, err
@@ -533,11 +517,9 @@ func GatherFlagsFromCobraCommand(
 			}
 			ps[parameter.Name] = v
 
-		case ParameterTypeObjectListFromFiles:
-			fallthrough
-		case ParameterTypeStringFromFiles:
-			fallthrough
-		case ParameterTypeStringListFromFiles:
+		case ParameterTypeObjectListFromFiles,
+			ParameterTypeStringFromFiles,
+			ParameterTypeStringListFromFiles:
 			v, err := cmd.Flags().GetStringSlice(flagName)
 			if err != nil {
 				return nil, err
@@ -548,7 +530,8 @@ func GatherFlagsFromCobraCommand(
 			}
 			ps[parameter.Name] = v2
 
-		case ParameterTypeStringList:
+		case ParameterTypeStringList,
+			ParameterTypeChoiceList:
 			v, err := cmd.Flags().GetStringSlice(flagName)
 			if err != nil {
 				return nil, err

--- a/pkg/cmds/parameters/cobra.go
+++ b/pkg/cmds/parameters/cobra.go
@@ -57,7 +57,11 @@ func AddArgumentsToCobraCommand(cmd *cobra.Command, arguments []*ParameterDefini
 // GatherArguments parses the positional arguments passed as a list of strings into a map of
 // parsed values. If onlyProvided is true, then only arguments that are provided are returned
 // (i.e. the default values are not included).
-func GatherArguments(args []string, arguments []*ParameterDefinition, onlyProvided bool) (map[string]interface{}, error) {
+func GatherArguments(
+	args []string,
+	arguments []*ParameterDefinition,
+	onlyProvided bool,
+) (map[string]interface{}, error) {
 	_ = args
 	result := make(map[string]interface{})
 	argsIdx := 0

--- a/pkg/cmds/parameters/cobra_test.go
+++ b/pkg/cmds/parameters/cobra_test.go
@@ -43,9 +43,10 @@ func TestParseDate(t *testing.T) {
 }
 
 type DefaultTypeTestCase struct {
-	Type  ParameterType
-	Value interface{}
-	Args  []string
+	Type    ParameterType
+	Value   interface{}
+	Choices []string
+	Args    []string
 }
 
 func TestValidDefaultValue(t *testing.T) {
@@ -58,15 +59,20 @@ func TestValidDefaultValue(t *testing.T) {
 		{Type: ParameterTypeIntegerList, Value: []int{1, 2, 3}},
 		{Type: ParameterTypeStringList, Value: []string{}},
 		{Type: ParameterTypeIntegerList, Value: []int{}},
+		{Type: ParameterTypeChoice, Value: "foo", Choices: []string{"foo", "bar"}},
+		{Type: ParameterTypeChoiceList, Value: []string{"foo", "bar"}, Choices: []string{"foo", "bar"}},
 	}
 	for _, testCase := range testCases {
-		param := &ParameterDefinition{
-			Name:    "foo",
-			Default: testCase.Value,
-			Type:    testCase.Type,
-		}
-		err := param.CheckParameterDefaultValueValidity()
-		assert.Nil(t, err)
+		t.Run(string(testCase.Type), func(t *testing.T) {
+			param := &ParameterDefinition{
+				Name:    "foo",
+				Default: testCase.Value,
+				Type:    testCase.Type,
+				Choices: testCase.Choices,
+			}
+			err := param.CheckParameterDefaultValueValidity()
+			assert.Nil(t, err)
+		})
 	}
 }
 

--- a/pkg/cmds/parameters/parameters_test.go
+++ b/pkg/cmds/parameters/parameters_test.go
@@ -146,6 +146,11 @@ func TestSetValueFromDefaultFloat(t *testing.T) {
 	err = floatFlag.SetValueFromDefault(fValue)
 	require.NoError(t, err)
 	assert.Equal(t, 0.0, f)
+
+	floatFlag = testParameterDefinitions["float-flag-with-int-default"]
+	err = floatFlag.SetValueFromDefault(fValue)
+	require.NoError(t, err)
+	assert.Equal(t, 42.0, f)
 }
 
 func TestSetValueFromDefaultFloat32(t *testing.T) {
@@ -244,6 +249,60 @@ func TestSetValueFromDefaultBool(t *testing.T) {
 	assert.Equal(t, false, b)
 }
 
+func TestSetValueFromDefaultChoice(t *testing.T) {
+	choiceFlag := testParameterDefinitions["choice-flag"]
+
+	c := "foo"
+
+	// get values of testStruct.Choice
+	cValue := reflect.ValueOf(&c).Elem()
+
+	err := choiceFlag.SetValueFromDefault(cValue)
+	require.NoError(t, err)
+	assert.Equal(t, "default", c)
+
+	choiceFlag = testParameterDefinitions["choice-flag-without-default"]
+	err = choiceFlag.SetValueFromDefault(cValue)
+	require.NoError(t, err)
+	assert.Equal(t, "", c)
+
+	choiceFlag = &ParameterDefinition{
+		Name:    "choice-flag-with-invalid-default",
+		Type:    ParameterTypeChoice,
+		Default: "invalid",
+		Choices: []string{"foo", "bar"},
+	}
+	err = choiceFlag.SetValueFromDefault(cValue)
+	require.Error(t, err)
+}
+
+func TestSetValueFromDefaultChoiceList(t *testing.T) {
+	choiceListFlag := testParameterDefinitions["choice-list-flag"]
+
+	cl := []string{"foo", "bar"}
+
+	// get values of testStruct.ChoiceList
+	clValue := reflect.ValueOf(&cl).Elem()
+
+	err := choiceListFlag.SetValueFromDefault(clValue)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"default", "choice1", "choice2"}, cl)
+
+	choiceListFlag = testParameterDefinitions["choice-list-flag-without-default"]
+	err = choiceListFlag.SetValueFromDefault(clValue)
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, cl)
+
+	choiceListFlag = &ParameterDefinition{
+		Name:    "choice-list-flag-with-invalid-default",
+		Type:    ParameterTypeChoiceList,
+		Default: []string{"invalid"},
+		Choices: []string{"foo", "bar"},
+	}
+	err = choiceListFlag.SetValueFromDefault(clValue)
+	require.Error(t, err)
+}
+
 func TestSetValueFromDefaultIntList(t *testing.T) {
 	intListFlag := testParameterDefinitions["int-list-flag"]
 
@@ -307,7 +366,7 @@ func TestSetValueFromDefaultFloatList(t *testing.T) {
 
 	err := floatListFlag.SetValueFromDefault(flValue)
 	require.NoError(t, err)
-	assert.Equal(t, []float64{1.1, 2.2, 3.3}, fl)
+	assert.Equal(t, []float64{1.1, 2.2, 3.3, 4.0, 5.0}, fl)
 
 	floatListFlag = testParameterDefinitions["float-list-flag-without-default"]
 	err = floatListFlag.SetValueFromDefault(flValue)
@@ -333,7 +392,7 @@ func TestSetValueFromDefaultFloat32List(t *testing.T) {
 
 	err := floatListFlag.SetValueFromDefault(flValue)
 	require.NoError(t, err)
-	assert.Equal(t, []float32{1.1, 2.2, 3.3}, fl)
+	assert.Equal(t, []float32{1.1, 2.2, 3.3, 4, 5}, fl)
 
 	floatListFlag = testParameterDefinitions["float-list-flag-without-default"]
 	require.NotNil(t, floatListFlag)

--- a/pkg/cmds/parameters/parse.go
+++ b/pkg/cmds/parameters/parse.go
@@ -94,6 +94,22 @@ func (p *ParameterDefinition) ParseParameter(v []string) (interface{}, error) {
 		}
 		return choice, nil
 
+	case ParameterTypeChoiceList:
+		choices := make([]string, 0)
+		for _, arg := range v {
+			found := false
+			for _, c := range p.Choices {
+				if c == arg {
+					found = true
+				}
+			}
+			if !found {
+				return nil, errors.Errorf("Argument %s has invalid choice %s", p.Name, arg)
+			}
+			choices = append(choices, arg)
+		}
+		return choices, nil
+
 	case ParameterTypeDate:
 		parsedDate, err := ParseDate(v[0])
 		if err != nil {

--- a/pkg/cmds/parameters/render.go
+++ b/pkg/cmds/parameters/render.go
@@ -8,26 +8,25 @@ import (
 	"time"
 )
 
+// RenderValue renders the given value to string so that it can be parsed as a cobra command line flag.
+// TODO(manuel, 2023-09-09) Refactor rendering of values to strings that can be parsed.
+// This is only applicable to parsing using cobra, but really we now have many more ways of parsing
+// a flag out of a string, among which GET query and FORM input parameters.
 func RenderValue(type_ ParameterType, value interface{}) (string, error) {
 	switch type_ {
-	case ParameterTypeString:
-		fallthrough
-	case ParameterTypeStringFromFile:
-		fallthrough
-	case ParameterTypeStringFromFiles:
-		fallthrough
-	case ParameterTypeChoice:
+	case ParameterTypeString,
+		ParameterTypeStringFromFile,
+		ParameterTypeStringFromFiles,
+		ParameterTypeChoice:
 		s, ok := value.(string)
 		if !ok {
 			return "", errors.Errorf("expected string, got %T", value)
 		}
 		return s, nil
 
-	case ParameterTypeObjectListFromFiles:
-		fallthrough
-	case ParameterTypeObjectListFromFile:
-		fallthrough
-	case ParameterTypeObjectFromFile:
+	case ParameterTypeObjectListFromFiles,
+		ParameterTypeObjectListFromFile,
+		ParameterTypeObjectFromFile:
 		return fmt.Sprintf("%v", value), nil
 
 	case ParameterTypeDate:
@@ -75,11 +74,10 @@ func RenderValue(type_ ParameterType, value interface{}) (string, error) {
 		}
 		return "false", nil
 
-	case ParameterTypeStringListFromFiles:
-		fallthrough
-	case ParameterTypeStringListFromFile:
-		fallthrough
-	case ParameterTypeStringList:
+	case ParameterTypeStringListFromFiles,
+		ParameterTypeStringListFromFile,
+		ParameterTypeStringList,
+		ParameterTypeChoiceList:
 		l, ok := cast.CastList2[string, interface{}](value)
 		if !ok {
 			return "", errors.Errorf("expected []string, got %T", value)

--- a/pkg/cmds/parameters/test-data/parameters_test.yaml
+++ b/pkg/cmds/parameters/test-data/parameters_test.yaml
@@ -83,6 +83,11 @@
   type: float
   help: A float flag without a default value
 
+- name: float-flag-with-int-default
+  type: float
+  help: A float flag with an int default value
+  default: 42
+
 - name: float-flag-with-empty-default
   type: float
   help: A float flag with an empty default value
@@ -91,7 +96,7 @@
 - name: float-list-flag
   type: floatList
   help: A float list flag
-  default: [1.1, 2.2, 3.3]
+  default: [1.1, 2.2, 3.3, 4, 5]
 
 - name: float-list-flag-without-default
   type: floatList

--- a/pkg/cmds/parameters/test-data/parameters_test.yaml
+++ b/pkg/cmds/parameters/test-data/parameters_test.yaml
@@ -44,6 +44,7 @@
 #  ParameterTypeIntegerList ParameterType = "intList"
 #  ParameterTypeFloatList   ParameterType = "floatList"
 #  ParameterTypeChoice      ParameterType = "choice"
+#  ParameterTypeChoiceList  ParameterType = "choiceList"
 
 - name: string-list-flag
   type: stringList
@@ -195,6 +196,17 @@
 - name: choice-flag-without-default
   type: choice
   help: A choice flag without a default value
+  choices: ["choice1", "choice2"]
+
+- name: choice-list-flag
+  type: choiceList
+  help: A choice list flag
+  default: ["default", "choice1", "choice2"]
+  choices: ["default", "choice1", "choice2"]
+
+- name: choice-list-flag-without-default
+  type: choiceList
+  help: A choice list flag without a default value
   choices: ["choice1", "choice2"]
 
 - name: key-value-flag

--- a/pkg/cmds/parameters/test-data/parameters_test.yaml
+++ b/pkg/cmds/parameters/test-data/parameters_test.yaml
@@ -1,3 +1,19 @@
+#  ParameterTypeString         ParameterType = "string"
+#  ParameterTypeStringFromFile ParameterType = "stringFromFile"
+#  ParameterTypeObjectListFromFile ParameterType = "objectListFromFile"
+#  ParameterTypeObjectFromFile     ParameterType = "objectFromFile"
+#  // ParameterTypeKeyValue signals either a string with comma separate key-value options, or when beginning with @, a file with key-value options
+#  ParameterTypeKeyValue    ParameterType = "keyValue"
+#  ParameterTypeInteger     ParameterType = "int"
+#  ParameterTypeFloat       ParameterType = "float"
+#  ParameterTypeBool        ParameterType = "bool"
+#  ParameterTypeDate        ParameterType = "date"
+#  ParameterTypeStringList  ParameterType = "stringList"
+#  ParameterTypeIntegerList ParameterType = "intList"
+#  ParameterTypeFloatList   ParameterType = "floatList"
+#  ParameterTypeChoice      ParameterType = "choice"
+#  ParameterTypeChoiceList  ParameterType = "choiceList"
+
 - name: string-flag
   type: string
   help: A string flag
@@ -25,26 +41,6 @@
   type: int
   help: An int flag with an empty default value
   default: 0
-
-#  ParameterTypeString         ParameterType = "string"
-#  ParameterTypeStringFromFile ParameterType = "stringFromFile"
-#
-#  // TODO (2023-02-07) It would be great to have "list of objects from file" here
-#  // See https://github.com/go-go-golems/glazed/issues/117
-#
-#  ParameterTypeObjectListFromFile ParameterType = "objectListFromFile"
-#  ParameterTypeObjectFromFile     ParameterType = "objectFromFile"
-#  // ParameterTypeKeyValue signals either a string with comma separate key-value options, or when beginning with @, a file with key-value options
-#  ParameterTypeKeyValue    ParameterType = "keyValue"
-#  ParameterTypeInteger     ParameterType = "int"
-#  ParameterTypeFloat       ParameterType = "float"
-#  ParameterTypeBool        ParameterType = "bool"
-#  ParameterTypeDate        ParameterType = "date"
-#  ParameterTypeStringList  ParameterType = "stringList"
-#  ParameterTypeIntegerList ParameterType = "intList"
-#  ParameterTypeFloatList   ParameterType = "floatList"
-#  ParameterTypeChoice      ParameterType = "choice"
-#  ParameterTypeChoiceList  ParameterType = "choiceList"
 
 - name: string-list-flag
   type: stringList

--- a/pkg/cmds/parameters/test-data/parameters_validity_test.yaml
+++ b/pkg/cmds/parameters/test-data/parameters_validity_test.yaml
@@ -1,0 +1,352 @@
+#  ParameterTypeString         ParameterType = "string"
+#  ParameterTypeStringFromFile ParameterType = "stringFromFile"
+#  ParameterTypeObjectListFromFile ParameterType = "objectListFromFile"
+#  ParameterTypeObjectFromFile     ParameterType = "objectFromFile"
+#  // ParameterTypeKeyValue signals either a string with comma separate key-value options, or when beginning with @, a file with key-value options
+#  ParameterTypeKeyValue    ParameterType = "keyValue"
+#  ParameterTypeInteger     ParameterType = "int"
+#  ParameterTypeFloat       ParameterType = "float"
+#  ParameterTypeBool        ParameterType = "bool"
+#  ParameterTypeDate        ParameterType = "date"
+#  ParameterTypeStringList  ParameterType = "stringList"
+#  ParameterTypeIntegerList ParameterType = "intList"
+#  ParameterTypeFloatList   ParameterType = "floatList"
+#  ParameterTypeChoice      ParameterType = "choice"
+#  ParameterTypeChoiceList  ParameterType = "choiceList"
+
+- name: string-flag
+  type: string
+  value: "foo"
+  valid: true
+
+- name: string-flag-empty
+  type: string
+  value: ""
+  valid: true
+
+- name: string--int-flag
+  type: string
+  value: 1
+  valid: false
+
+- name: string--list-flag
+  type: string
+  value: ["foo", "bar"]
+  valid: false
+
+- name: string-from-file-flag
+  type: stringFromFile
+  value: "foo"
+  valid: true
+
+- name: string-from-file--int-flag
+  type: stringFromFile
+  value: 1
+  valid: false
+
+- name: string-from-file--list-flag
+  type: stringFromFile
+  value: ["foo", "bar"]
+  valid: false
+
+- name: object-list-from-file-flag
+  type: objectListFromFile
+  value:
+    - foo: bar
+  valid: true
+
+- name: object-list-from-file-flag2
+  type: objectListFromFile
+  value:
+    - foo: bar
+    - blip: bar
+  valid: true
+
+- name: object-list-from-file--string-flag
+  type: objectListFromFile
+  value: "foo"
+  valid: false
+
+- name: object-list-from-file--int-flag
+  type: objectListFromFile
+  value: 1
+  valid: false
+
+- name: object-from-file-flag
+  type: objectFromFile
+  value:
+    foo: bar
+  valid: true
+
+- name: object-from-file--string-flag
+  type: objectFromFile
+  value: "foo"
+  valid: false
+
+- name: object-from-file--int-flag
+  type: objectFromFile
+  value: 1
+  valid: false
+
+- name: object-from-file--nested-object
+  type: objectFromFile
+  value:
+      foo:
+        bar: baz
+      bla: 2
+  valid: true
+
+- name: key-value-flag
+  type: keyValue
+  value:
+    foo: bar
+  valid: true
+
+- name: key-value--string-flag
+  type: keyValue
+  value: "foo"
+  valid: false
+
+- name: key-value--int-flag
+  type: keyValue
+  value: 1
+  valid: false
+
+- name: key-value--nested-object
+  type: keyValue
+  value:
+      foo:
+          bar: baz
+      bla: 2
+  valid: false
+
+- name: int-flag
+  type: int
+  value: 1
+  valid: true
+
+- name: int-flag-zero
+  type: int
+  value: 0
+  valid: true
+
+- name: int-flag-negative
+  type: int
+  value: -1
+  valid: true
+
+- name: int-flag--string-flag
+  type: int
+  value: "foo"
+  valid: false
+
+- name: int-flag--float
+  type: int
+  value: 1.1
+  valid: false
+
+- name: int-flag--list-flag
+  type: int
+  value: ["foo", "bar"]
+  valid: false
+
+- name: float-flag
+  type: float
+  value: 1.1
+  valid: true
+
+- name: float-flag-zero
+  type: float
+  value: 0.0
+  valid: true
+
+- name: float-flag-negative
+  type: float
+  value: -1.1
+  valid: true
+
+- name: float-flag--string
+  type: float
+  value: "foo"
+  valid: false
+
+- name: float-flag--int
+  type: float
+  value: 2
+  valid: true
+
+- name: float-flag--list
+  type: float
+  value: [1.1, 2.2]
+  valid: false
+
+- name: bool-flag
+  type: bool
+  value: true
+  valid: true
+
+- name: bool-flag-false
+  type: bool
+  value: false
+  valid: true
+
+- name: bool-flag--string
+  type: bool
+  value: "foo"
+  valid: false
+
+- name: bool-flag--int
+  type: bool
+  value: 1
+  valid: false
+
+- name: date-flag
+  type: date
+  value: "2023-09-09"
+  valid: true
+
+- name: date-flag-invalid
+  type: date
+  value: "2023/09/09"
+  valid: true
+
+- name: date-time-flag
+  type: date
+  value: "2023-09-09T12:00:00Z"
+  valid: true
+
+- name: date-time-flag-natural-language
+  type: date
+  value: "today"
+  valid: true
+
+- name: stringList-flag
+  type: stringList
+  value: ["foo", "bar"]
+  valid: true
+
+- name: stringList-flag--string
+  type: stringList
+  value: "foo"
+  valid: false
+
+- name: intList-flag
+  type: intList
+  value: [1, 2, 3]
+  valid: true
+
+- name: intList-flag--int
+  type: intList
+  value: 1
+  valid: false
+
+- name: floatList-flag
+  type: floatList
+  value: [1.1, 2.2]
+  valid: true
+
+- name: floatList-flag--float
+  type: floatList
+  value: 1.1
+  valid: false
+
+- name: choice-flag
+  type: choice
+  value: "option1"
+  choices:
+    - option1
+    - option2
+  valid: true
+
+- name: choice-flag-invalid
+  type: choice
+  value: "invalidOption"
+  choices:
+      - option1
+      - option2
+  valid: false
+
+- name: choiceList-flag
+  type: choiceList
+  value: ["option1", "option2"]
+  choices:
+      - option1
+      - option2
+  valid: true
+
+- name: choiceList-flag--string
+  type: choiceList
+  value: "option1"
+  choices:
+      - option1
+      - option2
+  valid: false
+
+- name: choice-flag--no-choice-list
+  type: choice
+  value: "option1"
+  valid: false
+
+- name: choiceList-flag--duplicate-values
+  type: choiceList
+  value: ["option1", "option1"]
+  choices:
+    - option1
+    - option2
+  valid: true
+
+- name: choiceList-flag--invalid-choice
+  type: choiceList
+  value: ["option1", "invalidOption"]
+  choices:
+    - option1
+    - option2
+  valid: false
+
+- name: choiceList-flag--empty-list
+  type: choiceList
+  value: []
+  choices:
+    - option1
+    - option2
+  valid: true
+
+- name: choice-flag--int-value
+  type: choice
+  value: 1
+  choices:
+    - option1
+    - option2
+  valid: false
+
+- name: choiceList-flag--mixed-values
+  type: choiceList
+  value: ["option1", 1]
+  choices:
+    - option1
+    - option2
+  valid: false
+
+- name: choice-flag--list-value
+  type: choice
+  value: ["option1"]
+  choices:
+    - option1
+    - option2
+  valid: false
+
+- name: choiceList-flag--nested-list
+  type: choiceList
+  value: ["option1", ["option2"]]
+  choices:
+    - option1
+    - option2
+  valid: false
+
+- name: choiceList-flag--only-one-valid
+  type: choiceList
+  value: ["option1", "option3"]
+  choices:
+    - option1
+    - option2
+  valid: false

--- a/pkg/helpers/cast/cast.go
+++ b/pkg/helpers/cast/cast.go
@@ -133,7 +133,7 @@ func CastInterfaceListToFloatList[To FloatNumber](list []interface{}) ([]To, boo
 	ret := []To{}
 
 	for _, item := range list {
-		f, ok := CastFloatInterfaceToFloat[To](item)
+		f, ok := CastNumberInterfaceToFloat[To](item)
 		if !ok {
 			return ret, false
 		}

--- a/pkg/helpers/reflect/reflect.go
+++ b/pkg/helpers/reflect/reflect.go
@@ -400,7 +400,7 @@ func SetIntListReflectValue[To cast.Number](value reflect.Value, v interface{}) 
 	return fmt.Errorf("cannot set reflect.Value of type %s from %T", value.Kind(), v)
 }
 
-func SetFloatListReflectValue[To cast.Number](value reflect.Value, v interface{}) error {
+func SetFloatListReflectValue[To cast.FloatNumber](value reflect.Value, v interface{}) error {
 	if s, ok := v.([]float64); ok {
 		s2, ok := cast.CastToNumberList[To, float64](s)
 		if !ok {
@@ -420,15 +420,12 @@ func SetFloatListReflectValue[To cast.Number](value reflect.Value, v interface{}
 	}
 
 	if s, ok := v.([]interface{}); ok {
-		v2_, ok := cast.CastList[float64, interface{}](s)
+		v2_, ok := cast.CastInterfaceListToFloatList[To](s)
 		if !ok {
 			return fmt.Errorf("cannot cast %T to []%T", v, To(0))
 		}
-		v3_, ok := cast.CastToNumberList[To, float64](v2_)
-		if !ok {
-			return fmt.Errorf("cannot cast %T to []%T", v, To(0))
-		}
-		value.Set(reflect.ValueOf(v3_))
+
+		value.Set(reflect.ValueOf(v2_))
 		return nil
 	}
 


### PR DESCRIPTION
feat: Add choice list parameter type

This adds support for a new choiceList parameter type to allow multiple selections from a set of choices. 

To implement this in a clean way, the logic for parameter default value handling was refactored:

- Split out InitializeValueToEmptyValue to set empty value based on type 
- Created SetValueFromInterface to assign any value to reflect.Value
- Updated SetValueFromDefault to initialize value from default

Additional changes:

- Expanded parameter value validation tests
- Refactored parsing tests to use table-driven pattern
- Added overview documentation for ParameterDefinition

This provides a more flexible way to handle parameter default values while supporting the new choiceList type. Users can now select multiple options from a predefined choice list.

The refactor also lays groundwork for future improvements like polymorphic parsing and serialization.


Closes #346