### PR TITLE
:fire: Remove over-engineered LayerParameterParserFunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # glazed - Output structured data in a variety of formats
 
-
-
 ![](https://img.shields.io/github/license/go-go-golems/glazed)
 ![](https://img.shields.io/github/actions/workflow/status/go-go-golems/glazed/push.yml?branch=main)
 

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -14,13 +14,14 @@ import (
 // a command with cobra. Because a command gets registered in a verb tree,
 // a full list of Parents all the way to the root needs to be provided.
 type CommandDescription struct {
-	Name      string                            `yaml:"name"`
-	Short     string                            `yaml:"short"`
-	Long      string                            `yaml:"long,omitempty"`
-	Layout    []*layout.Section                 `yaml:"layout,omitempty"`
-	Flags     []*parameters.ParameterDefinition `yaml:"flags,omitempty"`
-	Arguments []*parameters.ParameterDefinition `yaml:"arguments,omitempty"`
-	Layers    []layers.ParameterLayer           `yaml:"layers,omitempty"`
+	Name           string                            `yaml:"name"`
+	Short          string                            `yaml:"short"`
+	Long           string                            `yaml:"long,omitempty"`
+	Layout         []*layout.Section                 `yaml:"layout,omitempty"`
+	Flags          []*parameters.ParameterDefinition `yaml:"flags,omitempty"`
+	Arguments      []*parameters.ParameterDefinition `yaml:"arguments,omitempty"`
+	Layers         []layers.ParameterLayer           `yaml:"layers,omitempty"`
+	AdditionalData map[string]interface{}            `yaml:"additionalData,omitempty"`
 
 	Parents []string `yaml:",omitempty"`
 	// Source indicates where the command was loaded from, to make debugging easier.

--- a/pkg/cmds/layers/groups.go
+++ b/pkg/cmds/layers/groups.go
@@ -52,23 +52,6 @@ func (ppl *ParsedParameterLayer) MergeParameters(other *ParsedParameterLayer) {
 	}
 }
 
-// ParameterLayerParserFunc is a type meant to represent closures capturing some "complex" process
-// by which a ParsedParameterLayer can be produced, for example parsing a layer out of a cobra.Command
-// after flags were registered (see CobraParser).
-//
-// NOTE(manuel, 2023-03-17) This seems a bit overengineered, but the thinking behind it is
-// that depending on the frontend that a function provides (cobra, another CLI framework, REST, microservices),
-// there would be a parser function that can extract the values for a specific layer. Those could
-// potentially also be overriden by middlewares to do things like validation or masking.
-// This is not really used right now (I think), and more of an experiment that will be worth revisiting.
-type ParameterLayerParserFunc func() (*ParsedParameterLayer, error)
-
-// ParameterLayerParser is a type for anything that can parse a layer. As mentioned above, this is a bit
-// experimental and might actually not be necessary as an interface.
-type ParameterLayerParser interface {
-	RegisterParameterLayer(ParameterLayer) (ParameterLayerParserFunc, error)
-}
-
 // ParameterLayerImpl is a straight forward simple implementation of ParameterLayer
 // that can easily be reused in more complex implementations.
 type ParameterLayerImpl struct {

--- a/pkg/cmds/loaders/loaders.go
+++ b/pkg/cmds/loaders/loaders.go
@@ -22,6 +22,22 @@ type YAMLCommandLoader interface {
 	LoadCommandAliasFromYAML(s io.Reader, options ...alias.Option) ([]*alias.CommandAlias, error)
 }
 
+// YAMLCommandWithFSLoader is an interface that allows an application using the glazed
+// library to loader commands from YAML files. In contrast to YAMLCommandLoader, this
+// command loader also takes a fs.FS as an argument, which can then be used to load
+// additional files from the directory the YAML file is present in.
+//
+// TODO(manuel, 2023-09-16): Implement loading additional files into a glazed command when a FS is passed.
+// This could potentially be extended to using the full prompt manager to load contexts.
+//
+// See https://github.com/go-go-golems/glazed/issues/350
+//
+// This interface is currently not implemented.
+type YAMLCommandWithFSLoader interface {
+	LoadCommandFromYAMLWithDir(s io.Reader, f fs.FS, dir string, options ...cmds.CommandDescriptionOption) ([]cmds.Command, error)
+	LoadCommandAliasFromYAMLWithDir(s io.Reader, f fs.FS, dir string, options ...alias.Option) ([]*alias.CommandAlias, error)
+}
+
 type ReaderCommandLoader interface {
 	LoadCommandsFromReader(r io.Reader, options []cmds.CommandDescriptionOption, aliasOptions []alias.Option) ([]cmds.Command, error)
 }

--- a/pkg/helpers/cast/cast.go
+++ b/pkg/helpers/cast/cast.go
@@ -1,5 +1,10 @@
 package cast
 
+import (
+	"github.com/pkg/errors"
+	"reflect"
+)
+
 type Number interface {
 	int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | uintptr | float32 | float64
 }
@@ -57,6 +62,28 @@ func CastList2[To any, From any](list interface{}) ([]To, bool) {
 	}
 
 	return ret, true
+}
+
+// CastListToInterfaceList attempts to convert the given value to a list of interface{}.
+//
+// The function checks if the provided value is a slice or an array. If so,
+// it returns a slice of interface{}, where each item in the original slice or array
+// is converted to its interface{} representation.
+func CastListToInterfaceList(value interface{}) ([]interface{}, error) {
+	val := reflect.ValueOf(value)
+
+	// Check if the value is a slice or array
+	switch val.Kind() {
+	case reflect.Slice, reflect.Array:
+		// Create an empty slice of interface{} with the appropriate length
+		result := make([]interface{}, val.Len())
+		for i := 0; i < val.Len(); i++ {
+			result[i] = val.Index(i).Interface()
+		}
+		return result, nil
+	default:
+		return nil, errors.New("the provided value is not a list")
+	}
 }
 
 // CastToNumberList casts a list of From objects to To.

--- a/pkg/helpers/cast/cast.go
+++ b/pkg/helpers/cast/cast.go
@@ -73,6 +73,7 @@ func CastListToInterfaceList(value interface{}) ([]interface{}, error) {
 	val := reflect.ValueOf(value)
 
 	// Check if the value is a slice or array
+	//exhaustive:ignore
 	switch val.Kind() {
 	case reflect.Slice, reflect.Array:
 		// Create an empty slice of interface{} with the appropriate length

--- a/prompto/glazed/definitions
+++ b/prompto/glazed/definitions
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+for i in CommandDescription ParameterDefinition ParameterLayer; do
+	oak go definitions --recurse pkg/ --name "$i" --definition-type struct,interface
+done

--- a/scripts/param-definitions.sh
+++ b/scripts/param-definitions.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-for i in CommandDescription ParameterDefinition ParameterLayer; do
-	oak go definitions --recurse pkg/ --name "$i" --definition-type struct,interface
-done


### PR DESCRIPTION
- :sparkles: Add function to cast typed lists to []interface{}
- :art: Rename promptgen to prompto
- :fire: Remove over-engineered LayerParameterParserFunc
