### PR TITLE
:sparkles: Add template command

### DIFF
--- a/pinocchio/glazed/create-template-command.yaml
+++ b/pinocchio/glazed/create-template-command.yaml
@@ -1,0 +1,101 @@
+name: create-template-command
+short: Convert input text template into YAML command representation.
+factories:
+  openai:
+    client:
+      timeout: 120
+    completion:
+      engine: gpt-4
+      temperature: 0.2
+      max_response_tokens: 2048
+      stop: []
+      stream: true
+flags:
+  - name: template_text
+    type: stringFromFile
+    help: Template text to convert into YAML
+    required: true
+  - name: additional_system
+    type: string
+    help: Additional system prompt
+    default: ""
+  - name: additional
+    type: string
+    help: Additional prompt
+    default: ""
+  - name: context
+    type: stringFromFiles
+    help: Additional context from files
+  - name: example
+    type: stringFromFile
+    help: Example YAML command
+    default: |
+      name: some-command-name
+      short: This command does something.
+      flags:
+        - name: yada
+          type: string
+          help: Some string flag
+        - name: numbers
+          type: intList
+          help: Some int list flag
+        - name: foobar
+          type: bool
+          help: A random bool flag
+          default: false
+        - name: color
+          type: choice
+          help: Some color
+          choices: [red, green, blue]
+      template: |
+        This is an example template that uses the above flags:
+        {{ .yada }}
+        {{ range .numbers }}
+        {{ . }}
+        {{ end }}
+        {{ if .foobar }}We are foobared!{{ end }}
+        
+        And our color is: {{ .color }}
+
+system-prompt: |
+  You are a YAML expert. Your task is to analyze the template text and generate a YAML representation that defines how the template operates. Remember to keep the original structure and content of the provided prompt intact.
+  {{ .additional_system }}
+prompt: |
+  Use the following template text to create a template command represented as a YAML file.
+  This YAML file will be parsed to expose flags as a command line application, and the value of these
+  flags will then be used to render the template.
+
+  Here is the template text, out of which you need to extract the necessary flags, and potentially 
+  add new template arguments if requested. This template text should be the `template:` value of the resulting
+  YAML.
+  
+  -- BEGIN INPUT TEXT
+  {{ .template_text }}
+  -- END INPUT TEXT
+
+  The types of parameters that can be used for flags are:
+  - ParameterTypeString: "string"
+  - ParameterTypeStringFromFile: "stringFromFile" -> string
+  - ParameterTypeObjectListFromFile: "objectListFromFile" -> []interface{}
+  - ParameterTypeObjectFromFile: "objectFromFile" -> interface{}
+  - ParameterTypeKeyValue: "keyValue" -> map[string]interface{}
+  - ParameterTypeInteger: "int"
+  - ParameterTypeFloat: "float"
+  - ParameterTypeBool: "bool"
+  - ParameterTypeDate: "date"
+  - ParameterTypeStringList: "stringList"
+  - ParameterTypeIntegerList: "intList"
+  - ParameterTypeFloatList: "floatList"
+  - ParameterTypeChoice: "choice" -> string
+  - ParameterTypeChoiceList: "choiceList" -> []string
+  
+  Here is an example YAML command. Don't copy the structure of this command, it is just there as an example
+  of the YAML structure.
+  ```yaml
+  {{ .example }}
+  ```
+
+  {{ .additional }}
+  {{ if .context }}
+  {{ .context }}
+  {{ end }}

--- a/pkg/cmds/parameters/cobra.go
+++ b/pkg/cmds/parameters/cobra.go
@@ -119,7 +119,12 @@ func GenerateUseString(cmd *cobra.Command, arguments []*ParameterDefinition) str
 //
 // Any extra arguments not defined will result in an error.
 // Parsing errors for individual arguments will also return errors.
-func GatherArguments(args []string, arguments []*ParameterDefinition, onlyProvided bool, ignoreRequired bool) (*orderedmap.OrderedMap[string, interface{}], error) {
+func GatherArguments(
+	args []string,
+	arguments []*ParameterDefinition,
+	onlyProvided bool,
+	ignoreRequired bool,
+) (*orderedmap.OrderedMap[string, interface{}], error) {
 	_ = args
 	result := orderedmap.New[string, interface{}]()
 	argsIdx := 0

--- a/pkg/cmds/template.go
+++ b/pkg/cmds/template.go
@@ -1,0 +1,113 @@
+package cmds
+
+import (
+	"context"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/layout"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"gopkg.in/yaml.v3"
+	"io"
+	"text/template"
+
+	"github.com/pkg/errors"
+)
+
+type TemplateCommand struct {
+	*CommandDescription
+	Template string
+}
+
+type TemplateCommandDescription struct {
+	Name      string                            `yaml:"name"`
+	Short     string                            `yaml:"short"`
+	Long      string                            `yaml:"long,omitempty"`
+	Layout    []*layout.Section                 `yaml:"layout,omitempty"`
+	Flags     []*parameters.ParameterDefinition `yaml:"flags,omitempty"`
+	Arguments []*parameters.ParameterDefinition `yaml:"arguments,omitempty"`
+	Layers    []layers.ParameterLayer           `yaml:"layers,omitempty"`
+	Template  string                            `yaml:"template"`
+}
+
+func (t *TemplateCommand) RunIntoWriter(
+	ctx context.Context,
+	parsedLayers map[string]*layers.ParsedParameterLayer,
+	ps map[string]interface{},
+	w io.Writer,
+) error {
+	tmpl, err := template.New("template").Parse(t.Template)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse template")
+	}
+
+	err = tmpl.Execute(w, ps)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute template")
+	}
+
+	return nil
+}
+
+func (t *TemplateCommand) IsValid() bool {
+	if t.Template == "" {
+		return false
+	}
+
+	if t.CommandDescription == nil {
+		return false
+	}
+
+	if t.CommandDescription.Name == "" || t.CommandDescription.Short == "" {
+		return false
+	}
+
+	return true
+}
+
+type TemplateCommandLoader struct{}
+
+func (tcl *TemplateCommandLoader) LoadCommandFromYAML(
+	s io.Reader,
+	options ...CommandDescriptionOption,
+) ([]Command, error) {
+	tcd := &TemplateCommandDescription{}
+	err := yaml.NewDecoder(s).Decode(tcd)
+	if err != nil {
+		return nil, err
+	}
+
+	options_ := []CommandDescriptionOption{
+		WithShort(tcd.Short),
+		WithLong(tcd.Long),
+		WithFlags(tcd.Flags...),
+		WithArguments(tcd.Arguments...),
+		WithLayers(tcd.Layers...),
+		WithLayout(&layout.Layout{
+			Sections: tcd.Layout,
+		}),
+	}
+	options_ = append(options_, options...)
+
+	tc := &TemplateCommand{
+		CommandDescription: NewCommandDescription(tcd.Name),
+		Template:           tcd.Template,
+	}
+
+	for _, option := range options_ {
+		option(tc.Description())
+	}
+
+	if !tc.IsValid() {
+		return nil, errors.New("Invalid command")
+	}
+
+	return []Command{tc}, nil
+}
+
+func (t *TemplateCommand) ToYAML(w io.Writer) error {
+	enc := yaml.NewEncoder(w)
+	defer func(enc *yaml.Encoder) {
+		_ = enc.Close()
+	}(enc)
+
+	return enc.Encode(t)
+}

--- a/pkg/doc/topics/10-template-command.md
+++ b/pkg/doc/topics/10-template-command.md
@@ -1,0 +1,124 @@
+---
+Title: TemplateCommand
+Slug: template-command
+Short: |
+  TemplateCommand is a feature that allows you to define a command that renders template text. 
+  The template text is defined in the `template` field of the YAML file, and flags/params are 
+  used to render the final template output.
+Topics:
+  - command
+  - template
+  - TemplateCommand
+IsTopLevel: false
+ShowPerDefault: false
+SectionType: GeneralTopic
+---
+
+# TemplateCommand
+
+TemplateCommand is a feature that allows you to define a command that renders template text.
+The template text is defined in the `template` field of the YAML file,
+and flags/params are used to render the final template output.
+
+## Example
+
+Here is an example of a TemplateCommand in YAML format:
+
+  ```yaml
+name: greeting
+short: Renders a greeting template
+flags:
+  - name: name
+    type: string
+    help: Name to greet
+  - name: hobbies
+    type: stringList
+    help: Hobbies
+template: |
+  Hello {{.name}}!
+
+  Your hobbies are:
+  {{ range .hobbies }}
+    - {{ . }}
+  {{ end }}
+  ```
+  
+This command will render a greeting based on the name and hobbies provided as flags.
+
+## Usage
+
+Here is an example of how to use a TemplateCommand.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+)
+
+func main() {
+	// Load the TemplateCommand from the YAML file
+	f, err := os.Open("/tmp/test.yaml")
+	if err != nil {
+		fmt.Println("Error opening file:", err)
+		return
+	}
+	defer f.Close()
+
+	tcl := &cmds.TemplateCommandLoader{}
+	commands, err := tcl.LoadCommandFromYAML(f)
+	if err != nil {
+		fmt.Println("Error loading command from YAML:", err)
+		return
+	}
+	if len(commands) != 1 {
+		fmt.Println("Expected exactly one command in the YAML file")
+		return
+	}
+	cmd, ok := commands[0].(*cmds.TemplateCommand)
+	if !ok {
+		fmt.Println("Command is not a TemplateCommand")
+		return
+	}
+
+	// Define the flags
+	flags := []string{"--flag1=value1", "--flag2=value2"}
+
+	// Run the command
+	buf := &strings.Builder{}
+	parsedLayers := map[string]*layers.ParsedParameterLayer{}
+	ps, args, err := parameters.GatherFlagsFromStringList(
+		flags, cmd.Flags,
+		false, false,
+		"")
+	if err != nil {
+		fmt.Println("Error gathering flags:", err)
+		return
+	}
+	arguments, err := parameters.GatherArguments(args, cmd.Arguments, false, false)
+	if err != nil {
+		fmt.Println("Error gathering arguments:", err)
+		return
+	}
+	for p := arguments.Oldest(); p != nil; p = p.Next() {
+		k, v := p.Key, p.Value
+		ps[k] = v
+	}
+	err = cmd.RunIntoWriter(context.Background(), parsedLayers, ps, buf)
+	if err != nil {
+		fmt.Println("Error running command:", err)
+		return
+	}
+
+	// Print the output
+	fmt.Println(buf.String())
+}
+```
+  


### PR DESCRIPTION
# Add TemplateCommand for easy templating

## Summary

This PR adds a new `TemplateCommand` type that makes it easy to define a command that renders template text. 

The template text is defined in the `template` field of the YAML file, and flags/params are used to render the template content when called.

## Motivation

We often need to quickly render some modular templated text (for example, for prompto documentation contexts). This can now be done with a simple YAML file that can be picked up (again, by prompto for example).

## Changes

- Add `TemplateCommand` as a WriterCommand
- Add loader to handle `TemplateCommand` YAML
- Update docs

## Example

```yaml
name: greeting 
short: Renders a greeting template
flags:
  - name: name
    type: string
    help: Name to greet
  - name: hobbies 
    type: stringList
    help: Hobbies
template: |
  Hello {{.name}}!

  Your hobbies are:
  {{ range .hobbies }}
    - {{ . }}
  {{ end }}

