### PR TITLE
:sparkles: Add command layer, add CommandWithMetadata interface

### DIFF
--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -80,44 +80,55 @@ func GetVerbsFromCobraCommand(cmd *cobra.Command) []string {
 func BuildCobraCommandFromCommandAndFunc(s cmds.Command, run CobraRunFunc) (*cobra.Command, error) {
 	description := s.Description()
 
-	glazedCommandLayer, err := layers.NewParameterLayer(
-		"glazed-command",
-		"General purpose Command options",
-		layers.WithFlags(
-			parameters.NewParameterDefinition(
-				"create-command",
-				parameters.ParameterTypeString,
-				parameters.WithHelp("Create a new command for the query, with the defaults updated"),
-			),
-			parameters.NewParameterDefinition(
-				"create-alias",
-				parameters.ParameterTypeString,
-				parameters.WithHelp("Create a CLI alias for the query"),
-			),
-			parameters.NewParameterDefinition(
-				"create-cliopatra",
-				parameters.ParameterTypeString,
-				parameters.WithHelp("Print the CLIopatra YAML for the command"),
-			),
-			parameters.NewParameterDefinition(
-				"print-yaml",
-				parameters.ParameterTypeBool,
-				parameters.WithHelp("Print the command's YAML"),
-			),
-			parameters.NewParameterDefinition(
-				"load-parameters-from-json",
-				parameters.ParameterTypeString,
-				parameters.WithHelp("Load the command's flags from JSON"),
-			),
-		),
-	)
-	if err != nil {
-		return nil, err
+	// check if we need to add the glazedCommandLayer
+	addGlazedCommandLayer := true
+	for _, layer := range description.Layers {
+		if layer.GetSlug() == "glazed-command" {
+			addGlazedCommandLayer = false
+		}
 	}
 
-	description.Layers = append([]layers.ParameterLayer{
-		glazedCommandLayer,
-	}, description.Layers...)
+	if addGlazedCommandLayer {
+
+		glazedCommandLayer, err := layers.NewParameterLayer(
+			"glazed-command",
+			"General purpose Command options",
+			layers.WithFlags(
+				parameters.NewParameterDefinition(
+					"create-command",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Create a new command for the query, with the defaults updated"),
+				),
+				parameters.NewParameterDefinition(
+					"create-alias",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Create a CLI alias for the query"),
+				),
+				parameters.NewParameterDefinition(
+					"create-cliopatra",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Print the CLIopatra YAML for the command"),
+				),
+				parameters.NewParameterDefinition(
+					"print-yaml",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("Print the command's YAML"),
+				),
+				parameters.NewParameterDefinition(
+					"load-parameters-from-json",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("Load the command's flags from JSON"),
+				),
+			),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		description.Layers = append([]layers.ParameterLayer{
+			glazedCommandLayer,
+		}, description.Layers...)
+	}
 
 	cobraParser, err := NewCobraParserFromCommandDescription(description)
 	if err != nil {

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -245,6 +245,15 @@ type Command interface {
 	ToYAML(w io.Writer) error
 }
 
+type CommandWithMetadata interface {
+	Command
+	Metadata(
+		ctx context.Context,
+		parsedLayers map[string]*layers.ParsedParameterLayer,
+		ps map[string]interface{},
+	) (map[string]interface{}, error)
+}
+
 // NOTE(manuel, 2023-03-17) Future types of commands that we could need
 // - async emitting command (just strings, for example)
 // - async emitting structured log

--- a/pkg/middlewares/processor.go
+++ b/pkg/middlewares/processor.go
@@ -18,6 +18,8 @@ type TableProcessor struct {
 	Table *types.Table
 }
 
+var _ Processor = (*TableProcessor)(nil)
+
 type TableProcessorOption func(*TableProcessor)
 
 func WithTableMiddleware(tm ...TableMiddleware) TableProcessorOption {


### PR DESCRIPTION
- Introduced `CommandWithMetadata` interface in `pkg/cmds/cmds.go`, extending `Command` interface with a `Metadata` method.
- Resolved bug in `pkg/cli/cobra.go` causing `glazedCommandLayer` to be added twice to `description.Layers`.
- Added assertion in `pkg/middlewares/processor.go` to confirm `TableProcessor` implements `Processor` interface.

