### PR TITLE
Added 'from-markdown' flag to load YAMLs from markdown code snippets

### DIFF
--- a/pkg/helpers/yaml/yaml.go
+++ b/pkg/helpers/yaml/yaml.go
@@ -7,7 +7,7 @@ import (
 // Clean tries to cleanup YAML that might be invalid, for example
 // if coming out of a LLM.
 // This is quite a hacky solution, and will only work for simple YAML.
-func Clean(s string) string {
+func Clean(s string, fromMarkdown bool) string {
 	// split by lines and iterate over them
 	lines := strings.Split(s, "\n")
 	ret := []string{}
@@ -21,6 +21,10 @@ func Clean(s string) string {
 		if strings.HasPrefix(line, "```") {
 			// if it is, remove it and the next line
 			isInMarkdown = !isInMarkdown
+			continue
+		}
+
+		if fromMarkdown && !isInMarkdown {
 			continue
 		}
 

--- a/pkg/helpers/yaml/yaml_test.go
+++ b/pkg/helpers/yaml/yaml_test.go
@@ -17,7 +17,7 @@ b: 2
 c: 3
 `
 
-	actualYAML := Clean(inputYAML)
+	actualYAML := Clean(inputYAML, false)
 	assert.Equal(t, expectedYAML, actualYAML)
 }
 
@@ -32,7 +32,7 @@ a: 1
 b: 2
 c: 3`
 
-	actualYAML := Clean(inputYAML)
+	actualYAML := Clean(inputYAML, false)
 	assert.Equal(t, expectedYAML, actualYAML)
 
 	inputYAML = "```\n" + `---
@@ -40,7 +40,7 @@ a: 1
 b: 2
 c: 3` + "\n```"
 
-	actualYAML = Clean(inputYAML)
+	actualYAML = Clean(inputYAML, false)
 	assert.Equal(t, expectedYAML, actualYAML)
 }
 
@@ -57,7 +57,7 @@ b: "foobar: blabla"
 invalidRightHandSide: "&foobar"
 `
 
-	actualYAML := Clean(inputYAML)
+	actualYAML := Clean(inputYAML, false)
 	assert.Equal(t, expectedYAML, actualYAML)
 }
 
@@ -72,7 +72,7 @@ a: 1
 b: "foobar: blabla"
 `
 
-	actualYAML := Clean(inputYAML)
+	actualYAML := Clean(inputYAML, false)
 	assert.Equal(t, expectedYAML, actualYAML)
 
 	inputYAML = `---
@@ -85,7 +85,7 @@ a: 1
 b: 'foobar: blabla'
 `
 
-	actualYAML = Clean(inputYAML)
+	actualYAML = Clean(inputYAML, false)
 	assert.Equal(t, expectedYAML, actualYAML)
 
 	inputYAML = `---
@@ -100,7 +100,7 @@ b: 'foobar: blabla'
 	foobar: blabla
 `
 
-	actualYAML = Clean(inputYAML)
+	actualYAML = Clean(inputYAML, false)
 	assert.Equal(t, expectedYAML, actualYAML)
 }
 
@@ -133,7 +133,7 @@ b:
   g: 2
 `
 
-	actualYAML := Clean(inputYAML)
+	actualYAML := Clean(inputYAML, false)
 	assert.Equal(t, expectedYAML, actualYAML)
 
 }
@@ -156,7 +156,7 @@ c: |
 d: "&lkjsld"
 `
 
-	actualYAML := Clean(inputYAML)
+	actualYAML := Clean(inputYAML, false)
 	assert.Equal(t, expectedYAML, actualYAML)
 }
 
@@ -173,6 +173,6 @@ meta_title: "Buy Evergreen Trees Online - Create Year-Round Privacy and Beauty |
 meta_description: "Shop a variety of evergreen trees that stay green all year at The Tree Center. Create year-round privacy and beauty with our selection of evergreen trees. Find the perfect evergreen for your garden today!"
 `
 
-	actualYAML := Clean(inputYAML)
+	actualYAML := Clean(inputYAML, false)
 	assert.Equal(t, expectedYAML, actualYAML)
 }


### PR DESCRIPTION

This pull request introduces a new flag, 'from-markdown', to the YamlCommand in the 'yaml.go' file. This flag allows the loading of YAMLs directly from code snippets in markdown files. 

Key changes include:

- Addition of the 'from-markdown' flag to the YamlCommand parameters in 'yaml.go'.
- Modification of the 'Run' function in 'yaml.go' to handle the 'from-markdown' flag.
- Modification of the 'Clean' function in 'yaml.go' and 'yaml_test.go' to handle the 'from-markdown' flag.
- Addition of a regular expression to remove trailing whitespaces in the 'Clean' function in 'yaml.go'.
- Modification of the 'getIndentLevel' function in 'yaml.go' to return a boolean indicating if a line is whitespace.

