### PR TITLE
Resolved Crash During Cobra Command Alias Building

### DIFF
--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -401,7 +401,10 @@ func BuildCobraCommandAlias(alias *alias.CommandAlias) (*cobra.Command, error) {
 
 	argumentDefinitions := alias.AliasedCommand.Description().Arguments
 	minArgs := 0
-	provided, err := parameters.GatherArguments(alias.Arguments, argumentDefinitions, true, false)
+	provided, err := parameters.GatherArguments(alias.Arguments, argumentDefinitions, true, true)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, argDef := range argumentDefinitions {
 		_, ok := provided.Get(argDef.Name)


### PR DESCRIPTION
This pull request addresses a crash issue during the building of a Cobra command alias. The fix involves proper error handling and adjustments to the argument provision in the `BuildCobraCommandAlias` function.
