### PR TITLE
Implement skip/limit pagination functionality

### DIFF
--- a/pinocchio/glazed/create-help.yaml
+++ b/pinocchio/glazed/create-help.yaml
@@ -120,6 +120,7 @@ prompt: |
   {{ .example }}
   
   Use the provided information as information about the content of the document.
+  Replace "go run ./cmd/XXX" with "XXX".
   
   {{ if .context -}}
   {{ .context }}

--- a/pkg/doc/examples/skip-limit/01-skip-limit.md
+++ b/pkg/doc/examples/skip-limit/01-skip-limit.md
@@ -1,0 +1,62 @@
+---
+Title: Examples of how to use the pagination flags skip and limit
+Slug: skip-limit
+Short: |
+  This document provides examples of how to use the pagination flags 'skip' and 'limit' in Glazed.
+Topics:
+- pagination
+- command line
+Flags:
+- skip
+- limit
+IsTopLevel: false
+ShowPerDefault: false
+SectionType: Example
+---
+
+Glazed provides pagination options through the use of 'skip' and 'limit' flags.
+
+## Skip flag
+
+The 'skip' flag allows you to skip a certain number of records. 
+
+For example, to skip the first record, you would use the following command:
+
+``` 
+❯ glaze json misc/test-data/[123].json --skip 1
++-----+-----+------------+-----------+
+| a   | b   | c          | d         |
++-----+-----+------------+-----------+
+| 10  | 20  | 30, 40, 50 | e:60,f:70 |
+| 100 | 200 | 300        |           |
++-----+-----+------------+-----------+
+```
+
+## Limit flag
+
+The 'limit' flag allows you to limit the number of records returned. 
+
+For example, to limit the output to the first two records, you would use the following command:
+
+``` 
+❯ glaze json misc/test-data/[123].json --limit 2         
++----+----+------------+-----------+
+| a  | b  | c          | d         |
++----+----+------------+-----------+
+| 1  | 2  | 3, 4, 5    | e:6,f:7   |
+| 10 | 20 | 30, 40, 50 | e:60,f:70 |
++----+----+------------+-----------+
+```
+
+## Using both flags
+
+You can also use both flags together. For example, to skip the first two records and limit the output to one record, you would use the following command:
+
+``` 
+❯ glaze json misc/test-data/[123].json --limit 1 --skip 2
++-----+-----+-----+
+| a   | b   | c   |
++-----+-----+-----+
+| 100 | 200 | 300 |
++-----+-----+-----+
+```

--- a/pkg/middlewares/row/add-field.go
+++ b/pkg/middlewares/row/add-field.go
@@ -2,12 +2,15 @@ package row
 
 import (
 	"context"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 )
 
 type AddFieldMiddleware struct {
 	Fields map[string]string
 }
+
+var _ middlewares.RowMiddleware = (*AddFieldMiddleware)(nil)
 
 func (a *AddFieldMiddleware) Close(ctx context.Context) error {
 	return nil

--- a/pkg/middlewares/row/fields-filter.go
+++ b/pkg/middlewares/row/fields-filter.go
@@ -2,6 +2,7 @@ package row
 
 import (
 	"context"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"strings"
 )
@@ -20,6 +21,8 @@ type FieldsFilterMiddleware struct {
 
 	newColumns map[types.FieldName]interface{}
 }
+
+var _ middlewares.RowMiddleware = (*FieldsFilterMiddleware)(nil)
 
 func (ffm *FieldsFilterMiddleware) Close(ctx context.Context) error {
 	return nil

--- a/pkg/middlewares/row/flatten-object.go
+++ b/pkg/middlewares/row/flatten-object.go
@@ -3,12 +3,15 @@ package row
 import (
 	"context"
 	"fmt"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
 type FlattenObjectMiddleware struct {
 }
+
+var _ middlewares.RowMiddleware = (*FlattenObjectMiddleware)(nil)
 
 func (fom *FlattenObjectMiddleware) Close(ctx context.Context) error {
 	return nil

--- a/pkg/middlewares/row/lambda.go
+++ b/pkg/middlewares/row/lambda.go
@@ -2,12 +2,15 @@ package row
 
 import (
 	"context"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 )
 
 type LambdaMiddleware struct {
 	Function func(ctx context.Context, row types.Row) ([]types.Row, error)
 }
+
+var _ middlewares.RowMiddleware = (*LambdaMiddleware)(nil)
 
 func (l *LambdaMiddleware) Close(ctx context.Context) error {
 	return nil

--- a/pkg/middlewares/row/remove-duplicates.go
+++ b/pkg/middlewares/row/remove-duplicates.go
@@ -2,6 +2,7 @@ package row
 
 import (
 	"context"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 )
 
@@ -9,6 +10,8 @@ type RemoveDuplicatesMiddleware struct {
 	columns           []string
 	previousRowValues types.Row
 }
+
+var _ middlewares.RowMiddleware = (*RemoveDuplicatesMiddleware)(nil)
 
 func (r *RemoveDuplicatesMiddleware) Close(ctx context.Context) error {
 	return nil

--- a/pkg/middlewares/row/remove-nulls.go
+++ b/pkg/middlewares/row/remove-nulls.go
@@ -2,11 +2,14 @@ package row
 
 import (
 	"context"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 )
 
 type RemoveNullsMiddleware struct {
 }
+
+var _ middlewares.RowMiddleware = (*RemoveNullsMiddleware)(nil)
 
 func (rnm *RemoveNullsMiddleware) Close(ctx context.Context) error {
 	return nil

--- a/pkg/middlewares/row/rename-columns.go
+++ b/pkg/middlewares/row/rename-columns.go
@@ -3,6 +3,7 @@ package row
 import (
 	"context"
 	"fmt"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"gopkg.in/yaml.v3"
 	"regexp"
@@ -18,6 +19,8 @@ type RenameColumnMiddleware struct {
 	// we cache affected columns in renamedColumns.
 	renamedColumns map[types.FieldName]types.FieldName
 }
+
+var _ middlewares.RowMiddleware = (*RenameColumnMiddleware)(nil)
 
 func (r *RenameColumnMiddleware) Close(ctx context.Context) error {
 	return nil

--- a/pkg/middlewares/row/reorder-column.go
+++ b/pkg/middlewares/row/reorder-column.go
@@ -2,6 +2,7 @@ package row
 
 import (
 	"context"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"strings"
 )
@@ -9,6 +10,8 @@ import (
 type ReorderColumnOrderMiddleware struct {
 	columns []types.FieldName
 }
+
+var _ middlewares.RowMiddleware = (*ReorderColumnOrderMiddleware)(nil)
 
 func (scm *ReorderColumnOrderMiddleware) Close(ctx context.Context) error {
 	return nil

--- a/pkg/middlewares/row/replace.go
+++ b/pkg/middlewares/row/replace.go
@@ -2,6 +2,7 @@ package row
 
 import (
 	"context"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -33,6 +34,8 @@ type ReplaceMiddleware struct {
 	RegexSkips        map[types.FieldName][]*RegexpSkip
 	Skips             map[types.FieldName][]*Skip
 }
+
+var _ middlewares.RowMiddleware = (*ReplaceMiddleware)(nil)
 
 func (r *ReplaceMiddleware) Close(ctx context.Context) error {
 	return nil

--- a/pkg/middlewares/row/skip-limit.go
+++ b/pkg/middlewares/row/skip-limit.go
@@ -1,0 +1,35 @@
+package row
+
+import (
+	"context"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/types"
+)
+
+type SkipLimitMiddleware struct {
+	Skip  int
+	Limit int
+	count int
+}
+
+var _ middlewares.RowMiddleware = (*SkipLimitMiddleware)(nil)
+
+func (h *SkipLimitMiddleware) Process(ctx context.Context, row types.Row) ([]types.Row, error) {
+	defer func() { h.count++ }()
+	if h.count < h.Skip {
+
+		return nil, nil
+	}
+
+	if h.Limit > 0 {
+		if h.count >= h.Skip+h.Limit {
+			return nil, nil
+		}
+	}
+
+	return []types.Row{row}, nil
+}
+
+func (h *SkipLimitMiddleware) Close(ctx context.Context) error {
+	return nil
+}

--- a/pkg/middlewares/row/skip-limit_test.go
+++ b/pkg/middlewares/row/skip-limit_test.go
@@ -1,0 +1,181 @@
+package row
+
+import (
+	"context"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSkipLimitMiddleware_Process(t *testing.T) {
+	tests := []struct {
+		name   string
+		skip   int
+		limit  int
+		rows   []types.Row
+		expect []types.Row
+	}{
+		{
+			name:  "NoSkipNoLimit",
+			skip:  0,
+			limit: 0,
+			rows: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value1"),
+					types.MRP("field2", "value2"),
+				),
+			},
+			expect: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value1"),
+					types.MRP("field2", "value2"),
+				),
+			},
+		},
+		{
+			name:  "SkipNoLimit",
+			skip:  1,
+			limit: 0,
+			rows: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value1"),
+					types.MRP("field2", "value2"),
+				),
+				types.NewRow(
+					types.MRP("field1", "value3"),
+					types.MRP("field2", "value4"),
+				),
+			},
+			expect: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value3"),
+					types.MRP("field2", "value4"),
+				),
+			},
+		},
+		{
+			name:  "NoSkipLimit",
+			skip:  0,
+			limit: 1,
+			rows: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value1"),
+					types.MRP("field2", "value2"),
+				),
+				types.NewRow(
+					types.MRP("field1", "value3"),
+					types.MRP("field2", "value4"),
+				),
+			},
+			expect: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value1"),
+					types.MRP("field2", "value2"),
+				),
+			},
+		},
+		{
+			name:  "SkipLimit",
+			skip:  2,
+			limit: 2,
+			rows: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value1"),
+					types.MRP("field2", "value2"),
+				),
+				types.NewRow(
+					types.MRP("field1", "value3"),
+					types.MRP("field2", "value4"),
+				),
+				types.NewRow(
+					types.MRP("field1", "value5"),
+					types.MRP("field2", "value6"),
+				),
+				types.NewRow(
+					types.MRP("field1", "value7"),
+					types.MRP("field2", "value8"),
+				),
+			},
+			expect: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value5"),
+					types.MRP("field2", "value6"),
+				),
+				types.NewRow(
+					types.MRP("field1", "value7"),
+					types.MRP("field2", "value8"),
+				),
+			},
+		},
+		{
+			name:  "NegativeSkip",
+			skip:  -2,
+			limit: 0,
+			rows: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value1"),
+					types.MRP("field2", "value2"),
+				),
+				types.NewRow(
+					types.MRP("field1", "value3"),
+					types.MRP("field2", "value4"),
+				),
+			},
+			expect: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value1"),
+					types.MRP("field2", "value2"),
+				),
+				types.NewRow(
+					types.MRP("field1", "value3"),
+					types.MRP("field2", "value4"),
+				),
+			},
+		},
+		{
+			name:  "NegativeLimit",
+			skip:  0,
+			limit: -2,
+			rows: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value1"),
+					types.MRP("field2", "value2"),
+				),
+				types.NewRow(
+					types.MRP("field1", "value3"),
+					types.MRP("field2", "value4"),
+				),
+			},
+			expect: []types.Row{
+				types.NewRow(
+					types.MRP("field1", "value1"),
+					types.MRP("field2", "value2"),
+				),
+				types.NewRow(
+					types.MRP("field1", "value3"),
+					types.MRP("field2", "value4"),
+				),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skipLimitMiddleware := &SkipLimitMiddleware{Skip: tt.skip, Limit: tt.limit}
+			var got []map[string]interface{}
+			for _, row := range tt.rows {
+				rows, err := skipLimitMiddleware.Process(context.Background(), row)
+				assert.NoError(t, err)
+				for _, row_ := range rows {
+					got = append(got, types.RowToMap(row_))
+				}
+			}
+
+			var expectMaps []map[string]interface{}
+			for _, row := range tt.expect {
+				expectMaps = append(expectMaps, types.RowToMap(row))
+			}
+			assert.Equal(t, expectMaps, got)
+		})
+	}
+}

--- a/pkg/middlewares/row/sort-columns.go
+++ b/pkg/middlewares/row/sort-columns.go
@@ -2,12 +2,15 @@ package row
 
 import (
 	"context"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"sort"
 )
 
 type SortColumnsMiddleware struct {
 }
+
+var _ middlewares.RowMiddleware = (*SortColumnsMiddleware)(nil)
 
 func (scm *SortColumnsMiddleware) Close(ctx context.Context) error {
 	return nil

--- a/pkg/middlewares/row/template.go
+++ b/pkg/middlewares/row/template.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"github.com/Masterminds/sprig"
 	"github.com/go-go-golems/glazed/pkg/helpers/templating"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"strings"
 	"text/template"
@@ -20,6 +21,8 @@ type TemplateMiddleware struct {
 
 	renamedColumns map[types.FieldName]types.FieldName
 }
+
+var _ middlewares.RowMiddleware = (*TemplateMiddleware)(nil)
 
 type TemplateMiddlewareOption func(*TemplateMiddleware)
 

--- a/pkg/settings/flags/skip-limit.yaml
+++ b/pkg/settings/flags/skip-limit.yaml
@@ -1,0 +1,16 @@
+slug: glazed-pagination
+name: Glazed pagination flags
+description: |
+  These are the flags used to paginate the structured data processed.
+flags:
+  - name: skip
+    type: int
+    help: Skip the first N rows
+    default: 0
+
+  - name: limit
+    type: int
+    help: Limit the number of rows to N (0 = all rows)
+    default: 0
+
+

--- a/pkg/settings/settings_skip_limit.go
+++ b/pkg/settings/settings_skip_limit.go
@@ -1,0 +1,41 @@
+package settings
+
+import (
+	_ "embed"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/pkg/errors"
+)
+
+//go:embed "flags/skip-limit.yaml"
+var skipLimitFlagsYaml []byte
+
+type SkipLimitSettings struct {
+	Skip  int `glazed.parameter:"skip"`
+	Limit int `glazed.parameter:"limit"`
+}
+
+func NewSkipLimitSettingsFromParameters(ps map[string]interface{}) (*SkipLimitSettings, error) {
+	s := &SkipLimitSettings{}
+	err := parameters.InitializeStructFromParameters(s, ps)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to initialize skipLimit settings from parameters")
+	}
+
+	return s, nil
+}
+
+type SkipLimitParameterLayer struct {
+	*layers.ParameterLayerImpl `yaml:",inline"`
+}
+
+func NewSkipLimitParameterLayer(options ...layers.ParameterLayerOptions) (*SkipLimitParameterLayer, error) {
+	ret := &SkipLimitParameterLayer{}
+	layer, err := layers.NewParameterLayerFromYAML(skipLimitFlagsYaml, options...)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create skipLimit parameter layer")
+	}
+	ret.ParameterLayerImpl = layer
+
+	return ret, nil
+}


### PR DESCRIPTION
This pull request introduces the skip/limit pagination functionality to the Glazed application. The changes are spread across multiple files and can be summarized as follows:

- A new `SkipLimitMiddleware` has been added to the `row` package. This middleware is responsible for implementing the skip and limit functionality.
- Several existing files in the `middlewares/row` package have been updated to ensure they implement the `middlewares.RowMiddleware` interface.

- A new `SkipLimitParameterLayer` struct has been added, which includes methods for parsing skip and limit parameters from both command line flags and JSON.
- The `GlazedParameterLayers` struct in `glazed_layer.go` has been updated to include a `SkipLimitParameterLayer`.
- The `SetupTableProcessor` function in `glazed_layer.go` has been updated to add the `SkipLimitMiddleware` to the middleware pipeline if skip or limit parameters are provided.

- A new markdown file `01-skip-limit.md` provides examples of how to use the new skip and limit flags.

Closes #320
