### PR TITLE
Resolving Flag Name Clash by Renaming 'limit' and 'skip' Flags

### DIFF
--- a/pkg/doc/examples/skip-limit/01-skip-limit.md
+++ b/pkg/doc/examples/skip-limit/01-skip-limit.md
@@ -2,28 +2,28 @@
 Title: Examples of how to use the pagination flags skip and limit
 Slug: skip-limit
 Short: |
-  This document provides examples of how to use the pagination flags 'skip' and 'limit' in Glazed.
+  This document provides examples of how to use the pagination flags 'glazed-skip' and 'glazed-limit' in Glazed.
 Topics:
 - pagination
 - command line
 Flags:
-- skip
-- limit
+- glazed-skip
+- glazed-limit
 IsTopLevel: false
 ShowPerDefault: false
 SectionType: Example
 ---
 
-Glazed provides pagination options through the use of 'skip' and 'limit' flags.
+Glazed provides pagination options through the use of 'glazed-skip' and 'glazed-limit' flags.
 
 ## Skip flag
 
-The 'skip' flag allows you to skip a certain number of records. 
+The 'glazed-skip' flag allows you to skip a certain number of records. 
 
 For example, to skip the first record, you would use the following command:
 
 ``` 
-❯ glaze json misc/test-data/[123].json --skip 1
+❯ glaze json misc/test-data/[123].json --glazed-skip 1
 +-----+-----+------------+-----------+
 | a   | b   | c          | d         |
 +-----+-----+------------+-----------+
@@ -34,12 +34,12 @@ For example, to skip the first record, you would use the following command:
 
 ## Limit flag
 
-The 'limit' flag allows you to limit the number of records returned. 
+The 'glazed-limit' flag allows you to limit the number of records returned. 
 
 For example, to limit the output to the first two records, you would use the following command:
 
 ``` 
-❯ glaze json misc/test-data/[123].json --limit 2         
+❯ glaze json misc/test-data/[123].json --glazed-limit 2         
 +----+----+------------+-----------+
 | a  | b  | c          | d         |
 +----+----+------------+-----------+
@@ -53,7 +53,7 @@ For example, to limit the output to the first two records, you would use the fol
 You can also use both flags together. For example, to skip the first two records and limit the output to one record, you would use the following command:
 
 ``` 
-❯ glaze json misc/test-data/[123].json --limit 1 --skip 2
+❯ glaze json misc/test-data/[123].json --glazed-limit 1 --glazed-skip 2
 +-----+-----+-----+
 | a   | b   | c   |
 +-----+-----+-----+

--- a/pkg/settings/flags/skip-limit.yaml
+++ b/pkg/settings/flags/skip-limit.yaml
@@ -3,12 +3,12 @@ name: Glazed pagination flags
 description: |
   These are the flags used to paginate the structured data processed.
 flags:
-  - name: skip
+  - name: glazed-skip
     type: int
     help: Skip the first N rows
     default: 0
 
-  - name: limit
+  - name: glazed-limit
     type: int
     help: Limit the number of rows to N (0 = all rows)
     default: 0

--- a/pkg/settings/settings_skip_limit.go
+++ b/pkg/settings/settings_skip_limit.go
@@ -11,8 +11,8 @@ import (
 var skipLimitFlagsYaml []byte
 
 type SkipLimitSettings struct {
-	Skip  int `glazed.parameter:"skip"`
-	Limit int `glazed.parameter:"limit"`
+	Skip  int `glazed.parameter:"glazed-skip"`
+	Limit int `glazed.parameter:"glazed-limit"`
 }
 
 func NewSkipLimitSettingsFromParameters(ps map[string]interface{}) (*SkipLimitSettings, error) {


### PR DESCRIPTION
This pull request addresses a naming conflict with the 'limit' and 'skip' flags in the Glazed pagination system. The changes include:

- Renaming the 'limit' and 'skip' flags to 'glazed-limit' and 'glazed-skip' respectively. This change is reflected across the documentation, YAML settings, and the Go settings file.
- Updating all instances in the documentation where the old flag names were used. This includes command examples and flag descriptions.
- Adjusting the flag names in the settings YAML file and the Go settings file to match the new names.

These changes are necessary to avoid conflicts with other programs (such as sqleton or pinocchio) that may use 'limit' and 'skip' as flag names. By prefixing our flags with 'glazed-', we ensure uniqueness and prevent potential clashes.
