### PR TITLE
Introduction of Helper Function for Temporary File Management

### DIFF
--- a/pkg/helpers/capture-output.go
+++ b/pkg/helpers/capture-output.go
@@ -9,7 +9,6 @@ import (
 // CaptureOutput executes a provided function and captures any data
 // the function writes to standard output.
 func CaptureOutput(fn func() error) (string, error) {
-	// Create a buffer to hold the captured output
 	var buf bytes.Buffer
 
 	// Save the original stdout to restore it later

--- a/pkg/helpers/files/temp-files.go
+++ b/pkg/helpers/files/temp-files.go
@@ -1,0 +1,74 @@
+package files
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+type fileInfo struct {
+	os.FileInfo
+	path string // Full path to the file
+}
+
+type byModTime []fileInfo
+
+func (s byModTime) Len() int           { return len(s) }
+func (s byModTime) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s byModTime) Less(i, j int) bool { return s[i].ModTime().Before(s[j].ModTime()) }
+
+// GarbageCollectTemporaryFiles deletes the oldest files based on the mask, leaving only 'n' files.
+func GarbageCollectTemporaryFiles(tempDir string, mask string, n int) ([]string, error) {
+	var deletedFiles []string
+
+	// Get files that match the glob pattern in the temporary directory
+	matchingFiles, err := filepath.Glob(filepath.Join(tempDir, mask))
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if we have read access to tempDir
+	d, err := os.Stat(tempDir)
+	if err != nil {
+		return nil, err
+	}
+	if d.Mode().Perm()&0444 == 0 {
+		return nil, &os.PathError{Op: "GarbageCollectTemporaryFiles", Path: tempDir, Err: os.ErrPermission}
+	}
+
+	// Check if we have write access to tempDir
+	if d.Mode().Perm()&0222 == 0 {
+		return nil, &os.PathError{Op: "GarbageCollectTemporaryFiles", Path: tempDir, Err: os.ErrPermission}
+	}
+
+	var fileInfos []fileInfo
+	for _, fileName := range matchingFiles {
+		fi, err := os.Stat(fileName)
+		if err != nil {
+			// If we can't obtain the FileInfo, skip this file
+			continue
+		}
+
+		// Check if it's a regular file (not a directory)
+		if !fi.IsDir() {
+			fileInfos = append(fileInfos, fileInfo{FileInfo: fi, path: fileName})
+		}
+	}
+
+	// Sort the files based on modification time (oldest first)
+	sort.Sort(byModTime(fileInfos))
+
+	// Delete the oldest files, stopping when only 'n' remain
+	for i, fileInfo := range fileInfos {
+		if i >= len(fileInfos)-n {
+			break
+		}
+		err := os.Remove(fileInfo.path)
+		if err != nil {
+			return deletedFiles, err
+		}
+		deletedFiles = append(deletedFiles, fileInfo.path)
+	}
+
+	return deletedFiles, nil
+}

--- a/pkg/helpers/files/temp-files_test.go
+++ b/pkg/helpers/files/temp-files_test.go
@@ -114,8 +114,8 @@ func TestGarbageCollectTemporaryFilesWithNonExistentDirectory(t *testing.T) {
 	tempDir := "/nonexistent"
 	n := 2
 	_, err := GarbageCollectTemporaryFiles(tempDir, "file*", n)
-	if err != nil {
-		t.Fatalf("GarbageCollectTemporaryFiles failed: %v, want: %v", err, os.ErrNotExist)
+	if err == nil {
+		t.Fatalf("GarbageCollectTemporaryFiles with invalid directory should fail")
 	}
 }
 

--- a/pkg/helpers/files/temp-files_test.go
+++ b/pkg/helpers/files/temp-files_test.go
@@ -1,0 +1,166 @@
+package files
+
+import (
+	"github.com/pkg/errors"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestGarbageCollectTemporaryFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		numFiles int
+		n        int
+		want     int
+		err      error
+	}{
+		{
+			name:     "WithValidInputs",
+			numFiles: 5,
+			n:        2,
+			want:     3,
+			err:      nil,
+		},
+		{
+			name:     "WithNoMatchingFiles",
+			numFiles: 0,
+			n:        2,
+			want:     0,
+			err:      nil,
+		},
+		{
+			name:     "WithLessThanNFiles",
+			numFiles: 1,
+			n:        2,
+			want:     0,
+			err:      nil,
+		},
+		{
+			name:     "WithExactlyNFiles",
+			numFiles: 2,
+			n:        2,
+			want:     0,
+			err:      nil,
+		},
+		{
+			name:     "WithDirectories",
+			numFiles: 5,
+			n:        2,
+			want:     3,
+			err:      nil,
+		},
+		{
+			name:     "WithZeroN",
+			numFiles: 5,
+			n:        0,
+			want:     5,
+			err:      nil,
+		},
+		{
+			name:     "WithNegativeN",
+			numFiles: 5,
+			n:        -1,
+			want:     5,
+			err:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir, _, err := initTest(t, "", "temp", tt.numFiles, "file*")
+
+			defer func(path string) {
+				err := os.RemoveAll(path)
+				if err != nil {
+					log.Fatalf("Failed to remove temp directory: %v", err)
+				}
+			}(tempDir)
+			// Call GarbageCollectTemporaryFiles
+			deletedFiles, err := GarbageCollectTemporaryFiles(tempDir, "file*", tt.n)
+			if err != tt.err {
+				t.Fatalf("GarbageCollectTemporaryFiles failed: %v, want: %v", err, tt.err)
+			}
+
+			// Check the number of deleted files
+			if got := len(deletedFiles); got != tt.want {
+				t.Errorf("GarbageCollectTemporaryFiles = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func initTest(t *testing.T, dir string, pattern string, numFiles int, filePattern string) (string, []string, error) {
+	// Create a temporary directory
+	tempDir, err := os.MkdirTemp(dir, pattern)
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+
+	fileNames := []string{}
+	// Create temporary files
+	for i := 0; i < numFiles; i++ {
+		tempFile, err := os.CreateTemp(tempDir, filePattern)
+		if err != nil {
+			t.Fatalf("Failed to create temp file: %v", err)
+		}
+		_ = tempFile.Close()
+		fileNames = append(fileNames, tempFile.Name())
+	}
+	return tempDir, fileNames, err
+}
+
+func TestGarbageCollectTemporaryFilesWithNonExistentDirectory(t *testing.T) {
+	tempDir := "/nonexistent"
+	n := 2
+	_, err := GarbageCollectTemporaryFiles(tempDir, "file*", n)
+	if err != nil {
+		t.Fatalf("GarbageCollectTemporaryFiles failed: %v, want: %v", err, os.ErrNotExist)
+	}
+}
+
+func TestGarbageCollectTemporaryFilesWithInvalidMask(t *testing.T) {
+	tempDir, _, err := initTest(t, "", "temp", 5, "file*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			log.Fatalf("Failed to remove temp directory: %v", err)
+		}
+	}(tempDir)
+
+	fs, err := GarbageCollectTemporaryFiles(tempDir, "\x00", 2)
+	if err != nil {
+		t.Fatalf("GarbageCollectTemporaryFiles failed: %v, want: %v", err, os.ErrInvalid)
+	}
+	if len(fs) != 0 {
+		t.Fatalf("GarbageCollectTemporaryFiles failed: %v, want: %v", len(fs), 0)
+	}
+
+}
+
+func TestGarbageCollectTemporaryFilesWithUnreadableDirError(t *testing.T) {
+	tempDir, _, err := initTest(t, "", "temp", 5, "file*")
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			log.Fatalf("Failed to remove temp directory: %v", err)
+		}
+	}(tempDir)
+
+	n := 2
+	err = os.Chmod(tempDir, 0000)
+	if err != nil {
+		log.Fatalf("Failed to change permissions on temp directory: %v", err)
+	} // remove all permissions
+	_, err = GarbageCollectTemporaryFiles(tempDir, "file*", n)
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("GarbageCollectTemporaryFiles failed: %v, want: %v", err, os.ErrPermission)
+	}
+	err = os.Chmod(tempDir, 0755)
+	if err != nil {
+		log.Fatalf("Failed to change permissions on temp directory: %v", err)
+	} // restore permissions
+}

--- a/pkg/helpers/files/temp-files_test.go
+++ b/pkg/helpers/files/temp-files_test.go
@@ -69,6 +69,9 @@ func TestGarbageCollectTemporaryFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir, _, err := initTest(t, "", "temp", tt.numFiles, "file*")
+			if err != nil {
+				log.Fatalf("Failed to create temp directory: %v", err)
+			}
 
 			defer func(path string) {
 				err := os.RemoveAll(path)
@@ -138,11 +141,13 @@ func TestGarbageCollectTemporaryFilesWithInvalidMask(t *testing.T) {
 	if len(fs) != 0 {
 		t.Fatalf("GarbageCollectTemporaryFiles failed: %v, want: %v", len(fs), 0)
 	}
-
 }
 
 func TestGarbageCollectTemporaryFilesWithUnreadableDirError(t *testing.T) {
 	tempDir, _, err := initTest(t, "", "temp", 5, "file*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
 	defer func(path string) {
 		err := os.RemoveAll(path)
 		if err != nil {


### PR DESCRIPTION
This pull request introduces a new helper function and associated tests. The key changes include:

- Addition of a function to manage temporary files. This function deletes the oldest files in a directory based on a given mask, leaving only a specified number of the newest files. It returns a list of the paths of the deleted files. The function requires read and write permissions on the directory and will stop if it encounters a file it cannot delete, returning the files it has deleted so far along with the error.

- Inclusion of comprehensive tests for the new function. These tests cover a variety of scenarios, including valid inputs, no matching files, fewer files than specified, exactly the specified number of files, directories, zero files specified, negative file count, non-existent directory, invalid mask, and unreadable directory.
