### PR TITLE
Fix Markdown Code Block Output

### DIFF
--- a/cmd/glaze/cmds/markdown.go
+++ b/cmd/glaze/cmds/markdown.go
@@ -282,9 +282,27 @@ func simpleLinearize(ctx context.Context, md goldmark.Markdown, s []byte, gp mid
 	outputStack := []outputElement{}
 	err := ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
 		if entering {
+			nodeKind := node.Kind().String()
+			nodeText := string(node.Text(s))
+			if nodeKind == "FencedCodeBlock" {
+				block := node.(*ast.FencedCodeBlock)
+				language := string(block.Language(s))
+				_ = language
+				info := string(block.Info.Text(s))
+				_ = info
+				lines := node.Lines()
+				_ = lines
+				l := lines.Len()
+				var s_ strings.Builder
+				for i := 0; i < l; i++ {
+					line := lines.At(i)
+					s_.Write(line.Value(s))
+				}
+				nodeText = s_.String()
+			}
 			elt := types.NewRow(
-				types.MRP("kind", node.Kind().String()),
-				types.MRP("text", string(node.Text(s))),
+				types.MRP("kind", nodeKind),
+				types.MRP("text", nodeText),
 			)
 			parseStack = append(parseStack, elt)
 		} else {


### PR DESCRIPTION
This pull request addresses an issue with the output of code blocks in markdown files. 

Key changes:

- Added condition to check if the current node is a `FencedCodeBlock`.
- If true, the full content of the block is extracted and used as the node's text.

This change ensures the full content of code blocks is included in the output, improving markdown processing.
