### PR TITLE
Implement stdin alias for file parameters

### DIFF
--- a/pkg/cmds/parameters/file.go
+++ b/pkg/cmds/parameters/file.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"github.com/rs/zerolog/log"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,6 +44,34 @@ type FileData struct {
 }
 
 func GetFileData(filename string) (*FileData, error) {
+	if filename == "-" {
+		// read from stdin
+		contentBytes, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, err
+		}
+
+		return &FileData{
+			Content:          string(contentBytes),
+			ParsedContent:    nil,
+			ParseError:       nil,
+			RawContent:       nil,
+			StringContent:    string(contentBytes),
+			IsList:           false,
+			IsObject:         false,
+			BaseName:         "stdin",
+			Extension:        "",
+			FileType:         "",
+			Path:             "stdin",
+			RelativePath:     "stdin",
+			AbsolutePath:     "stdin",
+			Size:             int64(len(contentBytes)),
+			LastModifiedTime: time.Now(),
+			Permissions:      0,
+			IsDirectory:      false,
+		}, nil
+	}
+
 	absPath, err := filepath.Abs(filename)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request introduces a change that allows the use of "-" as an alias for stdin in file parameters.

Key changes include:
- When "-" is passed as a filename, the program now reads from stdin.
- A new FileData instance is created with the content read from stdin.
- The basename, path, relative path, and absolute path are all set to "stdin".
- The size is set to the length of the content read from stdin.
- The last modified time is set to the current time.
- The permissions are set to 0, and the isDirectory flag is set to false.

