### PR TITLE
Parse date flags in local timezone by default

### DIFF
--- a/pkg/cmds/parameters/cobra_test.go
+++ b/pkg/cmds/parameters/cobra_test.go
@@ -1,6 +1,7 @@
 package parameters
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -16,15 +17,15 @@ func TestParseDate(t *testing.T) {
 		Value  string
 		Result time.Time
 	}{
-		{Value: "2018-01-01", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
-		{Value: "2018/01/01", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: "2018-01-01", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.Local)},
+		{Value: "2018/01/01", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.Local)},
 		//{Value: "January First 2018", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
-		{Value: "January 1st 2018", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: "January 1st 2018", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.Local)},
 		{Value: "2018-01-01T00:00:00+00:00", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
 		{Value: "2018-01-01T00:00:00+01:00", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.FixedZone("", 3600))},
 		{Value: "2018-01-01T00:00:00-01:00", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.FixedZone("", -3600))},
-		{Value: "2018", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
-		{Value: "2018-01", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{Value: "2018", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.Local)},
+		{Value: "2018-01", Result: time.Date(2018, 1, 1, 0, 0, 0, 0, time.Local)},
 		{Value: "last year", Result: time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)},
 		{Value: "last hour", Result: time.Date(2017, 12, 31, 23, 0, 0, 0, time.UTC)},
 		{Value: "last month", Result: time.Date(2017, 12, 1, 0, 0, 0, 0, time.UTC)},
@@ -34,11 +35,14 @@ func TestParseDate(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		result, err := ParseDate(testCase.Value)
-		require.Nil(t, err)
-		if !result.Equal(testCase.Result) {
-			t.Errorf("Expected %s to parse to %s, got %s", testCase.Value, testCase.Result, result)
-		}
+		t.Run(fmt.Sprintf("ParseDate - %s", testCase.Value), func(t *testing.T) {
+
+			result, err := ParseDate(testCase.Value)
+			require.Nil(t, err)
+			if !result.Equal(testCase.Result) {
+				t.Errorf("Expected %s to parse to %s, got %s", testCase.Value, testCase.Result, result)
+			}
+		})
 	}
 }
 

--- a/pkg/cmds/parameters/parameters_test.go
+++ b/pkg/cmds/parameters/parameters_test.go
@@ -222,7 +222,8 @@ func TestSetValueFromDefaultDate(t *testing.T) {
 	// get values of testStruct.Date
 	dValue := reflect.ValueOf(&d).Elem()
 
-	parsedTime, err := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+	// get local
+	parsedTime, err := time.ParseInLocation("2006-01-02", "2021-01-01", time.Local)
 	require.NoError(t, err)
 
 	err = dateFlag.SetValueFromDefault(dValue)

--- a/pkg/cmds/parameters/parse.go
+++ b/pkg/cmds/parameters/parse.go
@@ -516,7 +516,7 @@ var refTime *time.Time
 // If both parsing attempts fail, an error is returned.
 // The reference time passed to naturaldate.Parse defaults to time.Now().
 func ParseDate(value string) (time.Time, error) {
-	parsedDate, err := dateparse.ParseAny(value)
+	parsedDate, err := dateparse.ParseLocal(value)
 	if err != nil {
 		refTime_ := time.Now()
 		if refTime != nil {

--- a/pkg/cmds/parameters/parse_test.go
+++ b/pkg/cmds/parameters/parse_test.go
@@ -24,7 +24,7 @@ type ParameterTestCase struct {
 
 func TestMain(m *testing.M) {
 	// Set default time for unit tests
-	refTime_ := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
+	refTime_ := time.Date(2018, 1, 1, 0, 0, 0, 0, time.Local)
 	refTime = &refTime_
 
 	m.Run()
@@ -86,13 +86,13 @@ func TestParameterDate(t *testing.T) {
 		{
 			Name:     "Valid full date and time input, no error expected",
 			Input:    []string{"2023-12-01 15:00"},
-			Expected: time.Date(2023, time.December, 01, 15, 00, 0, 0, time.UTC), // Adjust time zone as required
+			Expected: time.Date(2023, time.December, 01, 15, 00, 0, 0, time.Local), // Adjust time zone as required
 			WantErr:  ErrorNotExpected,
 		},
 		{
 			Name:     "Valid date only input, no error expected",
 			Input:    []string{"2023-12-01"},
-			Expected: time.Date(2023, time.December, 01, 0, 0, 0, 0, time.UTC), // Time defaults to 00:00
+			Expected: time.Date(2023, time.December, 01, 0, 0, 0, 0, time.Local), // Time defaults to 00:00
 			WantErr:  ErrorNotExpected,
 		},
 		{
@@ -104,7 +104,7 @@ func TestParameterDate(t *testing.T) {
 		{
 			Name:     "Invalid date format, error expected",
 			Input:    []string{"2023/12/01"},
-			Expected: time.Date(2023, time.December, 01, 0, 0, 0, 0, time.UTC), // Time defaults to 00:00
+			Expected: time.Date(2023, time.December, 01, 0, 0, 0, 0, time.Local), // Time defaults to 00:00
 		},
 		{
 			Name:    "Invalid non-date string, error expected",
@@ -120,13 +120,13 @@ func TestParameterDate(t *testing.T) {
 		{
 			Name:     "Valid date and time with seconds, no error expected",
 			Input:    []string{"2023-12-01 15:00:30"},
-			Expected: time.Date(2023, time.December, 01, 15, 00, 30, 0, time.UTC), // Adjust time zone as required
+			Expected: time.Date(2023, time.December, 01, 15, 00, 30, 0, time.Local), // Adjust time zone as required
 			WantErr:  ErrorNotExpected,
 		},
 		{
 			Name:     "Natural language date input with alternative format, no error expected",
 			Input:    []string{"December 1st, 2023"},
-			Expected: time.Date(2023, time.December, 01, 0, 0, 0, 0, time.UTC),
+			Expected: time.Date(2023, time.December, 01, 0, 0, 0, 0, time.Local),
 			WantErr:  ErrorNotExpected,
 		},
 		{
@@ -167,13 +167,13 @@ func TestParameterDate(t *testing.T) {
 		{
 			Name:     "Valid date and time with space separator, no error expected",
 			Input:    []string{"2023-12-01 15:00:00"},
-			Expected: time.Date(2023, time.December, 01, 15, 00, 00, 0, time.UTC),
+			Expected: time.Date(2023, time.December, 01, 15, 00, 00, 0, time.Local),
 			WantErr:  ErrorNotExpected,
 		},
 		{
 			Name:     "Date only, no error expected",
 			Input:    []string{"2023-12-01"},
-			Expected: time.Date(2023, time.December, 01, 0, 0, 0, 0, time.UTC),
+			Expected: time.Date(2023, time.December, 01, 0, 0, 0, 0, time.Local),
 			WantErr:  ErrorNotExpected,
 		},
 		{
@@ -184,7 +184,7 @@ func TestParameterDate(t *testing.T) {
 		{
 			Name:     "Valid 12-hour format date and time, no error expected",
 			Input:    []string{"December 1, 2023, 3:00 PM"},
-			Expected: time.Date(2023, time.December, 01, 15, 00, 00, 0, time.UTC),
+			Expected: time.Date(2023, time.December, 01, 15, 00, 00, 0, time.Local),
 			WantErr:  ErrorNotExpected,
 		},
 		{


### PR DESCRIPTION
This pull request updates the date parsing logic to use the local timezone
when no timezone is specified in the input. The changes ensure that date
inputs without explicit timezone information are interpreted relative to the
system's local timezone rather than defaulting to UTC.

Key changes include:
- Modification of date parsing in tests to expect local timezone results.
- Update of `ParseDate` function to use `dateparse.ParseLocal` instead of
  `dateparse.ParseAny`, which defaults to local timezone.
- Adjustment of `TestSetValueFromDefaultDate` to parse the time in the local
  timezone.
- Refactoring of test cases to use `time.Local` for expected results,
  ensuring consistency with the new parsing behavior.