### PR TITLE
Pass command context to cancelable operations in Cobra CLI

### DIFF
--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -321,7 +321,7 @@ func BuildCobraCommandFromCommandAndFunc(s cmds.Command, run CobraRunFunc) (*cob
 			os.Exit(0)
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(cmd.Context())
 		defer cancel()
 
 		go func() {


### PR DESCRIPTION
- Updated Cobra command execution to pass the command's context to
  cancelable operations, allowing for graceful shutdowns and better
  context management.