### PR TITLE
:ambulance: Don't use defaults from viper/cobra parsing layer

### DIFF
--- a/pkg/cmds/layers/layer-impl.go
+++ b/pkg/cmds/layers/layer-impl.go
@@ -239,7 +239,9 @@ func (p *ParameterLayerImpl) ParseLayerFromCobraCommand(
 	options ...parameters.ParseStepOption,
 ) (*ParsedLayer, error) {
 	ps, err := p.ParameterDefinitions.GatherFlagsFromCobraCommand(
-		cmd, false, false, p.Prefix,
+		// TODO(manuel, 2024-01-05) We probably need to move the required check to a higher level middleware, because
+		// we are not relying on cobra so much anymore since we introduced middlewares
+		cmd, true, false, p.Prefix,
 		options...,
 	)
 	if err != nil {

--- a/pkg/cmds/middlewares/cobra.go
+++ b/pkg/cmds/middlewares/cobra.go
@@ -76,6 +76,7 @@ func GatherFlagsFromViper(options ...parameters.ParseStepOption) Middleware {
 			}
 			err = layers_.ForEachE(func(key string, l layers.ParameterLayer) error {
 				options_ := append([]parameters.ParseStepOption{
+					parameters.WithParseStepSource("viper"),
 					parameters.WithParseStepMetadata(map[string]interface{}{
 						"layer": l.GetName(),
 					}),
@@ -85,7 +86,7 @@ func GatherFlagsFromViper(options ...parameters.ParseStepOption) Middleware {
 				parameterDefinitions := l.GetParameterDefinitions()
 				prefix := l.GetPrefix()
 
-				ps, err := parameterDefinitions.GatherFlagsFromViper(false, prefix, options_...)
+				ps, err := parameterDefinitions.GatherFlagsFromViper(true, prefix, options_...)
 				if err != nil {
 					return err
 				}

--- a/pkg/helpers/cast/cast.go
+++ b/pkg/helpers/cast/cast.go
@@ -170,46 +170,6 @@ func CastInterfaceListToFloatList[To FloatNumber](list []interface{}) ([]To, boo
 
 	return ret, true
 }
-func CastStringMap[To any, From any](m map[string]From) (map[string]To, bool) {
-	ret := map[string]To{}
-
-	for k, v := range m {
-		var item interface{} = v
-		casted, ok := item.(To)
-		if !ok {
-			return ret, false
-		}
-
-		ret[k] = casted
-	}
-
-	return ret, true
-}
-
-func CastInterfaceToStringMap[To any, From any](m interface{}) (map[string]To, bool) {
-	ret := map[string]To{}
-
-	switch m := m.(type) {
-	case map[string]To:
-		return m, true
-	case map[string]interface{}:
-		return CastStringMap[To, interface{}](m)
-	case map[string]From:
-		return CastStringMap[To, From](m)
-	default:
-		return ret, false
-	}
-}
-
-func CastMapToInterfaceMap[From any](m map[string]From) map[string]interface{} {
-	ret := map[string]interface{}{}
-
-	for k, v := range m {
-		ret[k] = v
-	}
-
-	return ret
-}
 
 func CastNumberInterfaceToInt[To SignedInt | UnsignedInt](i interface{}) (To, bool) {
 	switch i := i.(type) {

--- a/pkg/helpers/cast/map.go
+++ b/pkg/helpers/cast/map.go
@@ -30,3 +30,44 @@ func ConvertMapToInterfaceMap(input interface{}) (map[string]interface{}, error)
 
 	return result, nil
 }
+
+func CastStringMap[To any, From any](m map[string]From) (map[string]To, bool) {
+	ret := map[string]To{}
+
+	for k, v := range m {
+		var item interface{} = v
+		casted, ok := item.(To)
+		if !ok {
+			return ret, false
+		}
+
+		ret[k] = casted
+	}
+
+	return ret, true
+}
+
+func CastInterfaceToStringMap[To any, From any](m interface{}) (map[string]To, bool) {
+	ret := map[string]To{}
+
+	switch m := m.(type) {
+	case map[string]To:
+		return m, true
+	case map[string]interface{}:
+		return CastStringMap[To, interface{}](m)
+	case map[string]From:
+		return CastStringMap[To, From](m)
+	default:
+		return ret, false
+	}
+}
+
+func CastMapToInterfaceMap[From any](m map[string]From) map[string]interface{} {
+	ret := map[string]interface{}{}
+
+	for k, v := range m {
+		ret[k] = v
+	}
+
+	return ret
+}


### PR DESCRIPTION
- :ambulance: Only parse provided flags from viper when using middleware
- :ambulance: Only parse provided flags from cobra when using middleware
- :sparkles: Add middleware to parse from flag list manually
