### PR TITLE
Enable non-glazed command layer registration in Cobra command creation

### DIFF
--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -42,12 +42,15 @@ func BuildCobraCommandFromCommandAndFunc(
 ) (*cobra.Command, error) {
 	description := s.Description()
 
-	cobraParser, err := NewCobraParserFromCommandDescription(description, options...)
+	cmd := NewCobraCommandFromCommandDescription(description)
+	cobraParser, err := NewCobraParserFromLayers(description.Layers, options...)
 	if err != nil {
 		return nil, err
 	}
-
-	cmd := cobraParser.Cmd
+	err = cobraParser.AddToCobraCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		parsedLayers, err := cobraParser.Parse(cmd, args)
@@ -66,7 +69,7 @@ func BuildCobraCommandFromCommandAndFunc(
 			cobra.CheckErr(err)
 		}
 
-		// TODO(manuel, 2023-12-28) After loading all the parameters, we potentially need to post process some layers
+		// TODO(manuel, 2023-12-28) After loading all the parameters, we potentially need to post process some Layers
 		// This is what ParseLayerFromCobraCommand is gdoing currently, and it seems the only place
 		// it is actually used seems to be by the FieldsFilter galzed layer.
 		// See Muji (1) sketchbook p.21

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -15,7 +15,7 @@ import (
 // the glazed processing layer.
 //
 // If you are more serious about using glazed, consider using the `cmds.GlazeCommand` and `parameters.ParameterDefinition`
-// abstraction to define your CLI applications, which allows you to use layers and other nice features
+// abstraction to define your CLI applications, which allows you to use Layers and other nice features
 // of the glazed ecosystem.
 //
 // If so, use SetupTableProcessor instead, and create a proper glazed.GlazeCommand for your command.

--- a/pkg/cmds/layers/layer.go
+++ b/pkg/cmds/layers/layer.go
@@ -2,6 +2,7 @@ package layers
 
 import (
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/spf13/cobra"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
@@ -131,4 +132,17 @@ func (pl *ParameterLayers) GetAllParameterDefinitions() *parameters.ParameterDef
 		})
 	})
 	return ret
+}
+
+func (pl *ParameterLayers) AddToCobraCommand(cmd *cobra.Command) error {
+	return pl.ForEachE(func(_ string, v ParameterLayer) error {
+		if v.(CobraParameterLayer) != nil {
+			err := v.(CobraParameterLayer).AddLayerToCobraCommand(cmd)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }

--- a/pkg/helpers/markdown/markdown.go
+++ b/pkg/helpers/markdown/markdown.go
@@ -113,10 +113,8 @@ func ExtractQuotedBlocks(input string, withQuotes bool) []string {
 // If there are non-code contents left at the end without a following code block, they are appended
 // as comments to the last code block.
 //
-// **Usage**:
-// Call this function with a markdown string and a boolean `withQuotes`. If `withQuotes` is set to true,
-// the output will include the enclosing ``` for each code block. Otherwise, only the inner content of
-// the code block (and the preceding comments) is returned.
+// If `withQuotes` is set to true,  the output will include the enclosing ``` for each code block.
+// Otherwise, only the inner content of the code block (and the preceding comments) is returned.
 func ExtractCodeBlocksWithComments(input string, withQuotes bool) []string {
 	blocks := ExtractAllBlocks(input)
 	var result []string


### PR DESCRIPTION
This pull request refactors the Cobra command setup to support layer
registration for non-glazed commands:

- Replaces `CobraParser`'s `Cmd` with `Layers` for parameter layer handling.
- Adds `NewCobraCommandFromCommandDescription` to create standalone `cobra.Command`.
- Introduces `NewCobraParserFromLayers` for `CobraParser` instantiation with layers.
- Implements `AddToCobraCommand` in `CobraParser` for adding layers to `cobra.Command`.
- Updates `BuildCobraCommandFromCommandAndFunc` to utilize new layer addition method.
- Enhances `ParameterLayers` with `AddToCobraCommand` for layer integration into `cobra.Command`.
- Refines comments to align with the updated layer-centric approach.