### PR TITLE
Remove single command restriction from command loader

### DIFF
--- a/pkg/cmds/loaders/loaders.go
+++ b/pkg/cmds/loaders/loaders.go
@@ -124,9 +124,6 @@ func LoadCommandsFromFS(
 					log.Debug().Err(err_).Str("file", fileName).Msg("Could not load command from file")
 					return nil, err_
 				}
-				if len(commands_) != 1 {
-					return nil, errors.New("Expected exactly one command")
-				}
 
 				return commands_, err_
 			}()


### PR DESCRIPTION
- Removes the constraint that enforces loading exactly one command per file
  in the command loader logic.
- This change allows multiple commands to be defined and loaded from a single
  file, enhancing flexibility in command organization.
- The removed lines previously threw an error if more than one command was
  found, which is no longer the case after this update.