### PR TITLE
:sparkles: Add --long-help, flag types and fix default flags display

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -10,7 +10,7 @@ const GlazedCommandSlug = "glazed-command"
 func NewGlazedCommandLayer() (layers.ParameterLayer, error) {
 	glazedCommandLayer, err := layers.NewParameterLayer(
 		GlazedCommandSlug,
-		"General purpose Command options",
+		"General purpose command options",
 		layers.WithParameterDefinitions(
 			parameters.NewParameterDefinition(
 				"create-command",

--- a/pkg/cli/cobra-parser.go
+++ b/pkg/cli/cobra-parser.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
@@ -66,6 +67,8 @@ type CobraParser struct {
 	// This hooks allows the implementor to specify additional ways of loading parameters
 	// (for example, sqleton loads the dbt and sql connection parameters from env and viper as well).
 	middlewaresFunc CobraMiddlewaresFunc
+	// List of layers to be shown in short help, empty: always show all
+	shortHelpLayers []string
 }
 
 type CobraParserOption func(*CobraParser) error
@@ -73,6 +76,13 @@ type CobraParserOption func(*CobraParser) error
 func WithCobraMiddlewaresFunc(middlewaresFunc CobraMiddlewaresFunc) CobraParserOption {
 	return func(c *CobraParser) error {
 		c.middlewaresFunc = middlewaresFunc
+		return nil
+	}
+}
+
+func WithCobraShortHelpLayers(layers ...string) CobraParserOption {
+	return func(c *CobraParser) error {
+		c.shortHelpLayers = layers
 		return nil
 	}
 }
@@ -137,6 +147,11 @@ func (c *CobraParser) AddToCobraCommand(cmd *cobra.Command) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	if len(c.shortHelpLayers) > 0 {
+		shortHelperLayer := strings.Join(c.shortHelpLayers, ",")
+		cmd.Annotations["shortHelpLayers"] = shortHelperLayer
 	}
 
 	return nil

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -62,17 +62,17 @@ func BuildCobraCommandFromCommandAndFunc(
 			os.Exit(1)
 		}
 
+		// TODO(manuel, 2023-12-28) After loading all the parameters, we potentially need to post process some Layers
+		// This is what ParseLayerFromCobraCommand is doing currently, and it seems the only place
+		// it is actually used seems to be by the FieldsFilter glazed layer.
+		// See Muji (1) sketchbook p.21
 		// get the command settings
+
 		commandSettings := &GlazedCommandSettings{}
 		if glazeCommandLayer, ok := parsedLayers.Get(GlazedCommandSlug); ok {
 			err = glazeCommandLayer.InitializeStruct(commandSettings)
 			cobra.CheckErr(err)
 		}
-
-		// TODO(manuel, 2023-12-28) After loading all the parameters, we potentially need to post process some Layers
-		// This is what ParseLayerFromCobraCommand is gdoing currently, and it seems the only place
-		// it is actually used seems to be by the FieldsFilter galzed layer.
-		// See Muji (1) sketchbook p.21
 
 		if commandSettings.PrintParsedParameters {
 			printParsedParameters(parsedLayers)

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -49,6 +49,12 @@ func WithLong(s string) CommandDescriptionOption {
 	}
 }
 
+func WithPrependLayersList(ls ...layers.ParameterLayer) CommandDescriptionOption {
+	return func(c *CommandDescription) {
+		c.Layers.PrependLayers(ls...)
+	}
+}
+
 func WithLayersList(ls ...layers.ParameterLayer) CommandDescriptionOption {
 	return func(c *CommandDescription) {
 		for _, l := range ls {
@@ -72,11 +78,15 @@ func WithFlags(
 		layer, ok := c.GetDefaultLayer()
 		var err error
 		if !ok {
-			layer, err = layers.NewParameterLayer(layers.DefaultSlug, "Default")
+			layer, err = layers.NewParameterLayer(layers.DefaultSlug, "Flags")
 			if err != nil {
 				panic(err)
 			}
 			c.Layers.Set(layer.GetSlug(), layer)
+			err = c.Layers.MoveToFront(layer.GetSlug())
+			if err != nil {
+				panic(err)
+			}
 		}
 		layer.AddFlags(flags...)
 	}
@@ -91,39 +101,21 @@ func WithArguments(
 		layer, ok := c.GetDefaultLayer()
 		var err error
 		if !ok {
-			layer, err = layers.NewParameterLayer(layers.DefaultSlug, "Default")
+			layer, err = layers.NewParameterLayer(layers.DefaultSlug, "Arguments")
 			if err != nil {
 				panic(err)
 			}
 			c.Layers.Set(layer.GetSlug(), layer)
+			err = c.Layers.MoveToFront(layer.GetSlug())
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		for _, arg := range arguments {
 			arg.IsArgument = true
 		}
 		layer.AddFlags(arguments...)
-	}
-}
-
-func WithDefaultLayer(
-	flags []*parameters.ParameterDefinition,
-	arguments []*parameters.ParameterDefinition,
-) CommandDescriptionOption {
-
-	for _, arg := range arguments {
-		arg.IsArgument = true
-	}
-	return func(c *CommandDescription) {
-		layer, err := layers.NewParameterLayer(
-			layers.DefaultSlug,
-			"Default",
-			layers.WithParameterDefinitions(flags...),
-			layers.WithParameterDefinitions(arguments...),
-		)
-		if err != nil {
-			panic(err)
-		}
-		c.Layers.Set(layer.GetSlug(), layer)
 	}
 }
 

--- a/pkg/cmds/layers/cobra_flag_groups.go
+++ b/pkg/cmds/layers/cobra_flag_groups.go
@@ -228,8 +228,6 @@ func isZeroValue(v flag.Value, defValue string) bool {
 			return false
 		}
 	}
-
-	return false
 }
 
 // getFlagUsage returns the FlagUsage for a given flag.

--- a/pkg/cmds/layers/layer.go
+++ b/pkg/cmds/layers/layer.go
@@ -2,6 +2,7 @@ package layers
 
 import (
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/helpers/list"
 	"github.com/spf13/cobra"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
@@ -92,8 +93,7 @@ func (pl *ParameterLayers) AppendLayers(layers ...ParameterLayer) {
 }
 
 func (pl *ParameterLayers) PrependLayers(layers ...ParameterLayer) {
-	// reverse layers
-	layers = append(layers[:0], layers[len(layers):]...)
+	list.Reverse[ParameterLayer](layers)
 
 	for _, l := range layers {
 		slug := l.GetSlug()

--- a/pkg/cmds/parameters/cobra.go
+++ b/pkg/cmds/parameters/cobra.go
@@ -151,6 +151,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			return errors.Errorf("Flag '%s' already exists", flagName)
 		}
 
+		helpText := parameter.Help
+		helpText = fmt.Sprintf("%s - <%s>", helpText, parameter.Type)
+
 		switch parameter.Type {
 		case ParameterTypeStringListFromFile,
 			ParameterTypeStringFromFile,
@@ -160,9 +163,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			defaultValue := ""
 
 			if parameter.ShortFlag != "" {
-				flagSet.StringP(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.StringP(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.String(flagName, defaultValue, parameter.Help)
+				flagSet.String(flagName, defaultValue, helpText)
 			}
 
 		case ParameterTypeStringListFromFiles,
@@ -172,9 +175,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			defaultValue := []string{}
 
 			if parameter.ShortFlag != "" {
-				flagSet.StringSliceP(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.StringSliceP(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.StringSlice(flagName, defaultValue, parameter.Help)
+				flagSet.StringSlice(flagName, defaultValue, helpText)
 			}
 
 		case ParameterTypeString:
@@ -188,9 +191,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			}
 
 			if parameter.ShortFlag != "" {
-				flagSet.StringP(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.StringP(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.String(flagName, defaultValue, parameter.Help)
+				flagSet.String(flagName, defaultValue, helpText)
 			}
 		case ParameterTypeInteger:
 			defaultValue := 0
@@ -203,9 +206,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			}
 
 			if parameter.ShortFlag != "" {
-				flagSet.IntP(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.IntP(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.Int(flagName, defaultValue, parameter.Help)
+				flagSet.Int(flagName, defaultValue, helpText)
 			}
 
 		case ParameterTypeFloat:
@@ -219,9 +222,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			}
 
 			if parameter.ShortFlag != "" {
-				flagSet.Float64P(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.Float64P(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.Float64(flagName, defaultValue, parameter.Help)
+				flagSet.Float64(flagName, defaultValue, helpText)
 			}
 
 		case ParameterTypeBool:
@@ -235,9 +238,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			}
 
 			if parameter.ShortFlag != "" {
-				flagSet.BoolP(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.BoolP(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.Bool(flagName, defaultValue, parameter.Help)
+				flagSet.Bool(flagName, defaultValue, helpText)
 			}
 
 		case ParameterTypeDate:
@@ -260,9 +263,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			}
 
 			if parameter.ShortFlag != "" {
-				flagSet.StringP(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.StringP(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.String(flagName, defaultValue, parameter.Help)
+				flagSet.String(flagName, defaultValue, helpText)
 			}
 
 		case ParameterTypeStringList, ParameterTypeChoiceList:
@@ -290,9 +293,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			}
 
 			if parameter.ShortFlag != "" {
-				flagSet.StringSliceP(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.StringSliceP(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.StringSlice(flagName, defaultValue, parameter.Help)
+				flagSet.StringSlice(flagName, defaultValue, helpText)
 			}
 
 		case ParameterTypeKeyValue:
@@ -326,9 +329,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			}
 
 			if parameter.ShortFlag != "" {
-				flagSet.StringSliceP(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.StringSliceP(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.StringSlice(flagName, defaultValue, parameter.Help)
+				flagSet.StringSlice(flagName, defaultValue, helpText)
 			}
 
 		case ParameterTypeIntegerList:
@@ -341,9 +344,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			}
 
 			if parameter.ShortFlag != "" {
-				flagSet.IntSliceP(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.IntSliceP(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.IntSlice(flagName, defaultValue, parameter.Help)
+				flagSet.IntSlice(flagName, defaultValue, helpText)
 			}
 
 		case ParameterTypeFloatList:
@@ -355,9 +358,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 				}
 			}
 			if parameter.ShortFlag != "" {
-				flagSet.Float64SliceP(flagName, shortFlag, defaultValue, parameter.Help)
+				flagSet.Float64SliceP(flagName, shortFlag, defaultValue, helpText)
 			} else {
-				flagSet.Float64Slice(flagName, defaultValue, parameter.Help)
+				flagSet.Float64Slice(flagName, defaultValue, helpText)
 			}
 
 		case ParameterTypeChoice:
@@ -373,9 +376,9 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 			choiceString := strings.Join(parameter.Choices, ",")
 
 			if parameter.ShortFlag != "" {
-				flagSet.StringP(flagName, shortFlag, defaultValue, fmt.Sprintf("%s (%s)", parameter.Help, choiceString))
+				flagSet.StringP(flagName, shortFlag, defaultValue, fmt.Sprintf("%s (%s)", helpText, choiceString))
 			} else {
-				flagSet.String(flagName, defaultValue, fmt.Sprintf("%s (%s)", parameter.Help, choiceString))
+				flagSet.String(flagName, defaultValue, fmt.Sprintf("%s (%s)", helpText, choiceString))
 			}
 
 		default:

--- a/pkg/help/cobra.go
+++ b/pkg/help/cobra.go
@@ -41,8 +41,6 @@ func GetCobraHelpUsageFuncs(hs *HelpSystem) (HelpFunc, UsageFunc) {
 			ShowShortTopic:  true,
 			HelpCommand:     c.Root().CommandPath() + " help",
 		}
-		// TODO(manuel, 2023-02-19) Here is where we would compute grouped flags
-		// See #59
 		return renderCommandHelpPage(c, options, hs)
 	}
 

--- a/pkg/help/help.go
+++ b/pkg/help/help.go
@@ -371,6 +371,8 @@ func (hs *HelpSystem) SetupCobraRootCommand(cmd *cobra.Command) {
 	helpFunc, usageFunc := GetCobraHelpUsageFuncs(hs)
 	helpTemplate, usageTemplate := GetCobraHelpUsageTemplates(hs)
 
+	cmd.PersistentFlags().Bool("long-help", false, "Show long help")
+
 	cmd.SetHelpFunc(helpFunc)
 	cmd.SetUsageFunc(usageFunc)
 	cmd.SetHelpTemplate(helpTemplate)

--- a/pkg/help/render.go
+++ b/pkg/help/render.go
@@ -54,6 +54,7 @@ type RenderOptions struct {
 	ShowAllSections bool
 	ShowShortTopic  bool
 	HelpCommand     string
+	LongHelp        bool
 	ListSections    bool
 }
 

--- a/pkg/help/templates/cobra-usage.tmpl
+++ b/pkg/help/templates/cobra-usage.tmpl
@@ -45,4 +45,5 @@
 ## Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   - {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
 
-Use `{{.CommandPath}} [command] --help` for more information about a command.{{end}}{{end}}
+Use `{{.CommandPath}} [command] --help` for more information about a command.{{end}}
+{{if not $.LongHelp}}Use `{{.CommandPath}} --help --long-help` for information about all flags.{{end}}{{end}}


### PR DESCRIPTION
- :ambulance: Fix broken default flags display
- :pencil: Clean up overdue comment
- :sparkles: Display flag type when glazed parameter
- :sparkles: Implement --long-help
