### PR TITLE
:ambulance: Allow listing non toplevel help pages when listing explicitly

### DIFF
--- a/pkg/help/render.go
+++ b/pkg/help/render.go
@@ -56,6 +56,7 @@ type RenderOptions struct {
 	HelpCommand     string
 	LongHelp        bool
 	ListSections    bool
+	OnlyTopLevel    bool
 }
 
 func (hs *HelpSystem) ComputeRenderData(userQuery *SectionQuery) (map[string]interface{}, bool) {

--- a/pkg/helpers/strings/strings.go
+++ b/pkg/helpers/strings/strings.go
@@ -20,6 +20,9 @@ func InterfaceListToStringList(list []interface{}) []string {
 }
 
 func InterfaceToStringList(list interface{}) []string {
+	if list == nil {
+		return nil
+	}
 	return InterfaceListToStringList(list.([]interface{}))
 }
 


### PR DESCRIPTION
- :ambulance: List help that is not toplevel when asking for an explicit list
- :ambulance: Fix odd crash with glaze
