### PR TITLE
:ambulance: Allow parsing of strings from the environment

### DIFF
--- a/pkg/cmds/parameters/gather-parameters.go
+++ b/pkg/cmds/parameters/gather-parameters.go
@@ -51,6 +51,14 @@ func (pds *ParameterDefinitions) GatherParametersFromMap(
 				"map-value": v_,
 			}))
 
+		if s, ok := v_.(string); ok {
+			v__, err := p.ParseParameter([]string{s})
+			if err != nil {
+				return errors.Wrapf(err, "Invalid value for parameter %s", p.Name)
+			}
+			v_ = v__.Value
+		}
+
 		// TODO(manuel, 2023-12-28) We need to check if nil means remove the value or use the default or whatever that means
 		err := p.CheckValueValidity(v_)
 		if err != nil {

--- a/pkg/helpers/cast/cast.go
+++ b/pkg/helpers/cast/cast.go
@@ -3,6 +3,7 @@ package cast
 import (
 	"github.com/pkg/errors"
 	"reflect"
+	"strconv"
 )
 
 type Number interface {
@@ -197,6 +198,12 @@ func CastNumberInterfaceToInt[To SignedInt | UnsignedInt](i interface{}) (To, bo
 		return To(i), true
 	case uintptr:
 		return To(i), true
+	case string:
+		// check if string is an integer
+		if v, err := strconv.Atoi(i); err == nil {
+			return To(v), true
+		}
+		return 0, false
 	default:
 		return 0, false
 	}

--- a/pkg/helpers/cast/cast.go
+++ b/pkg/helpers/cast/cast.go
@@ -3,7 +3,6 @@ package cast
 import (
 	"github.com/pkg/errors"
 	"reflect"
-	"strconv"
 )
 
 type Number interface {
@@ -198,12 +197,6 @@ func CastNumberInterfaceToInt[To SignedInt | UnsignedInt](i interface{}) (To, bo
 		return To(i), true
 	case uintptr:
 		return To(i), true
-	case string:
-		// check if string is an integer
-		if v, err := strconv.Atoi(i); err == nil {
-			return To(v), true
-		}
-		return 0, false
 	default:
 		return 0, false
 	}


### PR DESCRIPTION
- :ambulance: Fix parsing strings when reading from map
- :fire: Remove unnecessary and confusing string to int cast
