### PR TITLE
Improve JSON parsing for struct initialization and add temporary file helper

### DIFF
--- a/pkg/cmds/parameters/initialize-struct.go
+++ b/pkg/cmds/parameters/initialize-struct.go
@@ -244,9 +244,73 @@ func (p *ParsedParameters) setWildcardValues(dst reflect.Value, pattern string, 
 	return nil
 }
 
-func (p *ParsedParameters) setTargetValue(dst reflect.Value, value interface{}, fromJson bool) error {
-	valueType := reflect.TypeOf(value)
+func (p *ParsedParameters) handleFromJSON(dst reflect.Value, value interface{}) error {
+	// The destination must be a pointer for JSON unmarshaling
+	if dst.Kind() != reflect.Ptr {
+		return errors.Errorf("from_json tag can only be used on pointer fields")
+	}
 
+	jsonData, ok := value.([]byte)
+	if !ok {
+		str, ok := value.(string)
+		if !ok {
+			// Try to marshal the value to JSON if it's not a string or []byte
+			var err error
+			jsonData, err = json.Marshal(value)
+			if err != nil {
+				return errors.Errorf("failed to marshal value of type %T to JSON: %v", value, err)
+			}
+		} else {
+			jsonData = []byte(str)
+		}
+	}
+	if err := json.Unmarshal(jsonData, dst.Interface()); err != nil {
+		return errors.Wrapf(err, "failed to unmarshal JSON")
+	}
+	return nil
+}
+
+func (p *ParsedParameters) handleFileData(dst reflect.Value, value interface{}) (bool, error) {
+	var fd *FileData
+	switch v := value.(type) {
+	case FileData:
+		fd = &v
+	case *FileData:
+		fd = v
+	default:
+		return false, nil
+	}
+
+	switch dst.Kind() {
+	case reflect.String:
+		dst.SetString(fd.Content)
+	case reflect.Slice:
+		if dst.Type().Elem().Kind() == reflect.Uint8 {
+			dst.SetBytes(fd.RawContent)
+		} else {
+			return true, errors.Errorf("cannot set FileData to slice of type %v", dst.Type().Elem().Kind())
+		}
+	default:
+		if fd.ParsedContent != nil {
+			dstVal := reflect.ValueOf(fd.ParsedContent)
+			if dstVal.Type().AssignableTo(dst.Type()) {
+				dst.Set(dstVal)
+				return true, nil
+			}
+			// Try JSON marshaling as a fallback
+			jsonData, err := json.Marshal(fd.ParsedContent)
+			if err != nil {
+				return true, errors.Wrapf(err, "failed to marshal ParsedContent to JSON")
+			}
+			if err := json.Unmarshal(jsonData, dst.Addr().Interface()); err != nil {
+				return true, errors.Wrapf(err, "failed to unmarshal ParsedContent as JSON")
+			}
+		}
+	}
+	return true, nil
+}
+
+func (p *ParsedParameters) setTargetValue(dst reflect.Value, value interface{}, fromJson bool) error {
 	// Handle pointer destination
 	wasPointer := false
 	if dst.Kind() == reflect.Ptr {
@@ -255,38 +319,32 @@ func (p *ParsedParameters) setTargetValue(dst reflect.Value, value interface{}, 
 			newValue := reflect.New(dst.Type().Elem())
 			dst.Set(newValue)
 		}
-
-		// The destination is now the value pointed to by the pointer
 		dst = dst.Elem()
 	}
 
-	// Handle JSON unmarshalling
+	// First try to handle FileData if the value is of that type
+	if handled, err := p.handleFileData(dst, value); err != nil {
+		return err
+	} else if handled {
+		return nil
+	}
+
+	// If fromJson is true, handle JSON unmarshaling
 	if fromJson {
 		if !wasPointer {
 			return errors.Errorf("from_json tag can only be used on pointer fields")
 		}
-		jsonData, ok := value.([]byte)
-		if !ok {
-			str, ok := value.(string)
-			if !ok {
-				return errors.Errorf("expected string or []byte for JSON unmarshalling, got %T", value)
-			}
-			jsonData = []byte(str)
-		}
-		if err := json.Unmarshal(jsonData, dst.Addr().Interface()); err != nil {
-			return errors.Wrapf(err, "failed to unmarshal JSON")
-		}
-		return nil
+		return p.handleFromJSON(dst.Addr(), value)
 	}
 
 	// Direct assignment if types are compatible
-	if dst.Type() == valueType {
+	if dst.Type() == reflect.TypeOf(value) {
 		dst.Set(reflect.ValueOf(value))
 		return nil
 	}
 
-	// if valueType is a pointer to a value of dst.Type(), we can assign it directly
-	if valueType.Kind() == reflect.Ptr && valueType.Elem() == dst.Type() {
+	// if value is a pointer to a value of dst.Type(), we can assign it directly
+	if reflect.TypeOf(value).Kind() == reflect.Ptr && reflect.TypeOf(value).Elem() == dst.Type() {
 		dst.Set(reflect.ValueOf(value).Elem())
 		return nil
 	}
@@ -302,6 +360,15 @@ func (p *ParsedParameters) setTargetValue(dst reflect.Value, value interface{}, 
 	}
 
 	return nil
+}
+
+func isFileData(value interface{}) bool {
+	switch value.(type) {
+	case FileData, *FileData:
+		return true
+	default:
+		return false
+	}
 }
 
 // StructToDataMap transforms a struct into a map[string]interface{} based on the `glazed.parameter` annotations.

--- a/pkg/cmds/parameters/initialize-struct.go
+++ b/pkg/cmds/parameters/initialize-struct.go
@@ -2,11 +2,12 @@ package parameters
 
 import (
 	"encoding/json"
-	reflect2 "github.com/go-go-golems/glazed/pkg/helpers/reflect"
-	"github.com/pkg/errors"
 	"path/filepath"
 	"reflect"
 	"strings"
+
+	reflect2 "github.com/go-go-golems/glazed/pkg/helpers/reflect"
+	"github.com/pkg/errors"
 )
 
 type tagOptions struct {
@@ -281,6 +282,7 @@ func (p *ParsedParameters) handleFileData(dst reflect.Value, value interface{}) 
 		return false, nil
 	}
 
+	//exhaustive:ignore
 	switch dst.Kind() {
 	case reflect.String:
 		dst.SetString(fd.Content)
@@ -360,15 +362,6 @@ func (p *ParsedParameters) setTargetValue(dst reflect.Value, value interface{}, 
 	}
 
 	return nil
-}
-
-func isFileData(value interface{}) bool {
-	switch value.(type) {
-	case FileData, *FileData:
-		return true
-	default:
-		return false
-	}
 }
 
 // StructToDataMap transforms a struct into a map[string]interface{} based on the `glazed.parameter` annotations.

--- a/pkg/cmds/parameters/initialize-struct_test.go
+++ b/pkg/cmds/parameters/initialize-struct_test.go
@@ -508,3 +508,213 @@ func TestStructToDataMapWithNonStructInput(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "input must be a struct or a pointer to a struct", err.Error())
 }
+
+// TestInitializeStructWithJSONFromStruct tests initializing a struct field from a struct value
+func TestInitializeStructWithJSONFromStruct(t *testing.T) {
+	type Config struct {
+		Host string `json:"host"`
+		Port int    `json:"port"`
+	}
+
+	type TestStructWithJSONPtr struct {
+		Config *Config `glazed.parameter:"config,from_json"`
+	}
+
+	inputConfig := Config{
+		Host: "localhost",
+		Port: 8080,
+	}
+
+	parsedParams := parameters.NewParsedParameters(
+		parameters.WithParsedParameter(
+			parameters.NewParameterDefinition(
+				"config",
+				parameters.ParameterTypeString),
+			"config",
+			inputConfig),
+	)
+
+	testStruct := &TestStructWithJSONPtr{}
+	err := parsedParams.InitializeStruct(testStruct)
+
+	require.NoError(t, err)
+	require.NotNil(t, testStruct.Config)
+	assert.Equal(t, "localhost", testStruct.Config.Host)
+	assert.Equal(t, 8080, testStruct.Config.Port)
+}
+
+// TestInitializeStructWithJSONFromMap tests initializing a struct field from a map value
+func TestInitializeStructWithJSONFromMap(t *testing.T) {
+	type Config struct {
+		Settings map[string]interface{} `json:"settings"`
+	}
+
+	type TestStructWithJSONPtr struct {
+		Config *Config `glazed.parameter:"config,from_json"`
+	}
+
+	inputMap := map[string]interface{}{
+		"settings": map[string]interface{}{
+			"debug": true,
+			"rate":  123.45,
+		},
+	}
+
+	parsedParams := parameters.NewParsedParameters(
+		parameters.WithParsedParameter(
+			parameters.NewParameterDefinition(
+				"config",
+				parameters.ParameterTypeString),
+			"config",
+			inputMap),
+	)
+
+	testStruct := &TestStructWithJSONPtr{}
+	err := parsedParams.InitializeStruct(testStruct)
+
+	require.NoError(t, err)
+	require.NotNil(t, testStruct.Config)
+	require.NotNil(t, testStruct.Config.Settings)
+	assert.Equal(t, true, testStruct.Config.Settings["debug"])
+	assert.Equal(t, 123.45, testStruct.Config.Settings["rate"])
+}
+
+// TestInitializeStructWithJSONFromUnmarshallable tests initializing a struct field from an unmarshallable value
+func TestInitializeStructWithJSONFromUnmarshallable(t *testing.T) {
+	type TestStructWithJSONPtr struct {
+		Config *struct{} `glazed.parameter:"config,from_json"`
+	}
+
+	// Create a channel which cannot be marshaled to JSON
+	ch := make(chan int)
+
+	parsedParams := parameters.NewParsedParameters(
+		parameters.WithParsedParameter(
+			parameters.NewParameterDefinition(
+				"config",
+				parameters.ParameterTypeString),
+			"config",
+			ch),
+	)
+
+	testStruct := &TestStructWithJSONPtr{}
+	err := parsedParams.InitializeStruct(testStruct)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal value of type chan int to JSON")
+}
+
+// TestInitializeStructWithFileDataToString tests initializing a string field from FileData
+func TestInitializeStructWithFileDataToString(t *testing.T) {
+	type TestStruct struct {
+		Content string `glazed.parameter:"content"`
+	}
+
+	fileData := &parameters.FileData{
+		Content: "test content",
+	}
+
+	parsedParams := parameters.NewParsedParameters(
+		parameters.WithParsedParameter(
+			parameters.NewParameterDefinition(
+				"content",
+				parameters.ParameterTypeString),
+			"content",
+			fileData),
+	)
+
+	testStruct := &TestStruct{}
+	err := parsedParams.InitializeStruct(testStruct)
+
+	require.NoError(t, err)
+	assert.Equal(t, "test content", testStruct.Content)
+}
+
+// TestInitializeStructWithFileDataToBytes tests initializing a []byte field from FileData
+func TestInitializeStructWithFileDataToBytes(t *testing.T) {
+	type TestStruct struct {
+		RawContent []byte `glazed.parameter:"raw_content"`
+	}
+
+	fileData := &parameters.FileData{
+		RawContent: []byte("test content"),
+	}
+
+	parsedParams := parameters.NewParsedParameters(
+		parameters.WithParsedParameter(
+			parameters.NewParameterDefinition(
+				"raw_content",
+				parameters.ParameterTypeString),
+			"raw_content",
+			fileData),
+	)
+
+	testStruct := &TestStruct{}
+	err := parsedParams.InitializeStruct(testStruct)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte("test content"), testStruct.RawContent)
+}
+
+// TestInitializeStructWithFileDataToParsedContent tests initializing a struct field from FileData's ParsedContent
+func TestInitializeStructWithFileDataToParsedContent(t *testing.T) {
+	type Config struct {
+		Host string `json:"host"`
+		Port int    `json:"port"`
+	}
+
+	type TestStruct struct {
+		Config Config `glazed.parameter:"config"`
+	}
+
+	parsedConfig := Config{
+		Host: "localhost",
+		Port: 8080,
+	}
+
+	fileData := &parameters.FileData{
+		ParsedContent: parsedConfig,
+	}
+
+	parsedParams := parameters.NewParsedParameters(
+		parameters.WithParsedParameter(
+			parameters.NewParameterDefinition(
+				"config",
+				parameters.ParameterTypeString),
+			"config",
+			fileData),
+	)
+
+	testStruct := &TestStruct{}
+	err := parsedParams.InitializeStruct(testStruct)
+
+	require.NoError(t, err)
+	assert.Equal(t, "localhost", testStruct.Config.Host)
+	assert.Equal(t, 8080, testStruct.Config.Port)
+}
+
+// TestInitializeStructWithFileDataToIncompatibleType tests initializing an incompatible field type from FileData
+func TestInitializeStructWithFileDataToIncompatibleType(t *testing.T) {
+	type TestStruct struct {
+		Content []int `glazed.parameter:"content"` // incompatible with FileData.RawContent
+	}
+
+	fileData := &parameters.FileData{
+		RawContent: []byte("test content"),
+	}
+
+	parsedParams := parameters.NewParsedParameters(
+		parameters.WithParsedParameter(
+			parameters.NewParameterDefinition(
+				"content",
+				parameters.ParameterTypeString),
+			"content",
+			fileData),
+	)
+
+	testStruct := &TestStruct{}
+	err := parsedParams.InitializeStruct(testStruct)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot set FileData to slice of type int")
+}

--- a/pkg/doc/topics/19-writing-yaml-commands.md
+++ b/pkg/doc/topics/19-writing-yaml-commands.md
@@ -1,0 +1,242 @@
+---
+Title: Writing YAML Command Files
+Slug: writing-yaml-commands
+Short: A comprehensive guide on writing YAML files to define glazed commands
+Topics:
+  - YAML
+  - Commands
+  - Configuration
+IsTopLevel: true
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+# Writing YAML Command Files in Glazed
+
+This guide explains how to write YAML files to define commands in the Glazed framework. YAML configuration provides a declarative way to create commands without writing Go code.
+
+## Basic Structure
+
+A basic YAML command file contains these essential elements:
+
+```yaml
+name: command-name
+short: Short description of the command
+long: |
+  A longer description that can span
+  multiple lines and provide more detail
+flags:
+  - name: flag-name
+    type: string
+    help: Description of the flag
+arguments:
+  - name: arg-name
+    type: string
+    required: true
+    help: Description of the argument
+```
+
+## Parameter Types
+
+Glazed supports these parameter types for both flags and arguments:
+
+### Basic Types
+- `string`: Text values
+- `int`: Integer values
+- `float`: Floating-point numbers
+- `bool`: Boolean true/false values
+- `date`: Date values
+- `choice`: Single selection from predefined choices
+- `choiceList`: Multiple selections from predefined choices
+
+### List Types
+- `stringList`: List of strings
+- `intList`: List of integers
+- `floatList`: List of floating-point numbers
+
+### File-Related Types
+- `file`: Single file input, provides detailed file metadata and content
+- `fileList`: List of files with metadata and content
+- `stringFromFile`: Load string content from a file (prefix with @)
+- `stringFromFiles`: Load string content from multiple files
+- `stringListFromFile`: Load list of strings from a file
+- `stringListFromFiles`: Load list of strings from multiple files
+
+### Object Types
+- `objectFromFile`: Load and parse structured data from a file
+- `objectListFromFile`: Load and parse list of objects from a file
+- `objectListFromFiles`: Load and parse lists of objects from multiple files
+
+### Key-Value Types
+- `keyValue`: Parse key-value pairs from string (comma-separated) or file (with @ prefix)
+
+## Defining Flags
+
+Flags are optional parameters that modify command behavior. Here's a comprehensive example:
+
+```yaml
+flags:
+  - name: output-format
+    shortFlag: f  # Optional short form
+    type: string
+    default: "json"
+    help: "Output format (json, yaml, or table)"
+    choices: ["json", "yaml", "table"]
+    required: false
+
+  - name: limit
+    type: int
+    default: 10
+    help: "Maximum number of items to process"
+
+  - name: tags
+    type: stringList
+    help: "List of tags to filter by"
+    default: ["default"]
+```
+
+### Flag Properties
+
+- `name`: The flag name (required)
+- `shortFlag`: Optional single-character alias
+- `type`: Parameter type (required)
+- `default`: Default value if flag is not specified
+- `help`: Help text describing the flag
+- `choices`: List of valid values
+- `required`: Whether the flag must be specified
+
+## Defining Arguments
+
+Arguments are positional parameters. They're defined similarly to flags:
+
+```yaml
+arguments:
+  - name: source
+    type: file
+    help: "Source file to process"
+    required: true
+
+  - name: destinations
+    type: stringList
+    help: "List of destination paths"
+    default: ["./output"]
+```
+
+### Argument Properties
+
+Arguments support the same properties as flags, except for `shortFlag`.
+
+## Using Layers
+
+Layers help organize related parameters. Define layers in your YAML:
+
+```yaml
+layers:
+  - name: Output Configuration
+    slug: output
+    description: "Configure output formatting"
+    prefix: "output-"
+    flags:
+      - name: format
+        type: string
+        default: "json"
+      - name: pretty
+        type: bool
+        default: true
+
+  - name: Processing Options
+    slug: processing
+    description: "Control processing behavior"
+    flags:
+      - name: threads
+        type: int
+        default: 4
+```
+
+## Best Practices
+
+1. **Naming Conventions**
+   - Use kebab-case for command and flag names
+   - Make names descriptive but concise
+   - Use consistent prefixes for related flags
+
+3. **Organization**
+   - Group related parameters using layers
+   - Use consistent parameter ordering
+   - Keep command files focused and single-purpose
+
+4. **Validation**
+   - Use `choices` to restrict valid values
+   - Set appropriate default values
+   - Mark parameters as required when necessary
+
+## Examples
+
+### Simple Query Command
+
+```yaml
+name: list-items
+short: List items from database
+flags:
+  - name: limit
+    type: int
+    default: 10
+    help: Maximum number of items to return
+
+  - name: format
+    type: string
+    default: table
+    choices: [table, json, yaml]
+    help: Output format
+```
+
+### Complex Data Processing Command
+
+```yaml
+name: process-data
+short: Process data files with multiple options
+layers:
+  - name: Input Options
+    slug: input
+    flags:
+      - name: source
+        type: file
+        required: true
+        help: Source data file
+
+      - name: format
+        type: string
+        default: csv
+        choices: [csv, json, xml]
+        help: Input file format
+
+  - name: Processing Options
+    slug: processing
+    flags:
+      - name: batch-size
+        type: int
+        default: 1000
+        help: Number of records to process at once
+
+      - name: threads
+        type: int
+        default: 4
+        help: Number of processing threads
+
+  - name: Output Options
+    slug: output
+    flags:
+      - name: destination
+        type: directory
+        required: true
+        help: Output directory
+
+      - name: compress
+        type: bool
+        default: false
+        help: Compress output files
+```
+
+## Conclusion
+
+YAML command files provide a powerful way to define Glazed commands declaratively. By following these guidelines and patterns, you can create clear, maintainable, and user-friendly command definitions that take full advantage of Glazed's capabilities.

--- a/pkg/helpers/files/files.go
+++ b/pkg/helpers/files/files.go
@@ -2,9 +2,11 @@ package files
 
 import (
 	"encoding/json"
-	"gopkg.in/yaml.v3"
+	"fmt"
 	"io"
 	"os"
+
+	"gopkg.in/yaml.v3"
 )
 
 func LoadJSONFile(path string, target interface{}) error {
@@ -46,4 +48,19 @@ func ConcatFiles(filePaths ...string) (io.Reader, error) {
 
 	// Combine all readers into a single MultiReader.
 	return io.MultiReader(readers...), nil
+}
+
+// CreateTemporaryFile creates a new temporary file with the given prefix and name.
+// The file will be created in the system's temporary directory.
+// The caller is responsible for closing the file when done.
+func CreateTemporaryFile(prefix, name string) (*os.File, error) {
+	// Ensure the temporary directory exists
+	tmpDir := os.TempDir()
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+
+	// Create a unique filename using the prefix and name
+	pattern := fmt.Sprintf("%s_%s_*.tmp", prefix, name)
+	return os.CreateTemp(tmpDir, pattern)
 }


### PR DESCRIPTION
This PR enhances JSON parsing capabilities and adds a temporary file helper:

- Improve JSON parsing when initializing structs:
  • Better handling of map[interface{}]interface{} types
  • Recursive sanitization of maps and slices for JSON compatibility
  • Enhanced error handling and reporting for JSON unmarshaling

- Add FileData handling:
  • Support for initializing struct fields from FileData
  • Handle string, []byte, and parsed content from FileData

- Implement CreateTemporaryFile helper function:
  • Creates temporary files with custom prefix and name
  • Ensures temporary directory exists

- Expand test coverage:
  • New tests for JSON parsing from various sources (structs, maps)
  • Tests for FileData handling and edge cases
  • Tests for handling map[interface{}]interface{} types

- Add comprehensive documentation on writing YAML command files:
  • Detailed guide on creating YAML-based command definitions
  • Covers parameter types, flags, arguments, layers, and best practices