### PR TITLE
Add command running and loading helpers for MCP tools

### DIFF
--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -22,6 +22,7 @@ type CommandDescription struct {
 	Layout         []*layout.Section       `yaml:"layout,omitempty"`
 	Layers         *layers.ParameterLayers `yaml:"layers,omitempty"`
 	AdditionalData map[string]interface{}  `yaml:"additionalData,omitempty"`
+	Type           string                  `yaml:"type,omitempty"`
 
 	Parents []string `yaml:",omitempty"`
 	// Source indicates where the command was loaded from, to make debugging easier.
@@ -47,6 +48,12 @@ func WithShort(s string) CommandDescriptionOption {
 func WithLong(s string) CommandDescriptionOption {
 	return func(c *CommandDescription) {
 		c.Long = s
+	}
+}
+
+func WithType(t string) CommandDescriptionOption {
+	return func(c *CommandDescription) {
+		c.Type = t
 	}
 }
 

--- a/pkg/cmds/cmds.go
+++ b/pkg/cmds/cmds.go
@@ -2,13 +2,14 @@ package cmds
 
 import (
 	"context"
+	"io"
+	"strings"
+
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/layout"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"gopkg.in/yaml.v3"
-	"io"
-	"strings"
 )
 
 // CommandDescription contains the necessary information for registering
@@ -182,7 +183,7 @@ func (cd *CommandDescription) FullPath() string {
 	if len(cd.Parents) == 0 {
 		return cd.Name
 	}
-	return strings.Join(cd.Parents, " ") + " " + cd.Name
+	return strings.Join(cd.Parents, "/") + "/" + cd.Name
 }
 
 func (cd *CommandDescription) GetDefaultLayer() (layers.ParameterLayer, bool) {

--- a/pkg/cmds/loaders/multi-loader.go
+++ b/pkg/cmds/loaders/multi-loader.go
@@ -1,0 +1,130 @@
+package loaders
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/alias"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// BaseCommand represents the minimal structure needed to determine the type of a command
+type BaseCommand struct {
+	Type string `yaml:"type" json:"type"`
+}
+
+// MultiLoader implements CommandLoader and dispatches to registered loaders based on the Type field
+type MultiLoader struct {
+	loaders map[string]CommandLoader
+	// defaultLoader is used when no Type field is present
+	defaultLoader CommandLoader
+}
+
+// NewMultiLoader creates a new MultiLoader instance
+func NewMultiLoader() *MultiLoader {
+	return &MultiLoader{
+		loaders: make(map[string]CommandLoader),
+	}
+}
+
+// RegisterLoader registers a new loader for a specific type
+func (m *MultiLoader) RegisterLoader(typeName string, loader CommandLoader) {
+	m.loaders[typeName] = loader
+}
+
+// SetDefaultLoader sets the default loader to use when no Type field is present
+func (m *MultiLoader) SetDefaultLoader(loader CommandLoader) {
+	m.defaultLoader = loader
+}
+
+// findSupportedLoader tries each registered loader to find one that supports the file
+func (m *MultiLoader) findSupportedLoader(f fs.FS, fileName string) CommandLoader {
+	for _, loader := range m.loaders {
+		if loader.IsFileSupported(f, fileName) {
+			return loader
+		}
+	}
+	return nil
+}
+
+// getLoaderForFile determines which loader to use for a given file
+func (m *MultiLoader) getLoaderForFile(f fs.FS, fileName string, content []byte) (CommandLoader, error) {
+	// Try to parse as YAML to get the type
+	var base BaseCommand
+	if err := yaml.Unmarshal(content, &base); err == nil {
+		// If we have a type field, try to get the corresponding loader
+		if base.Type != "" {
+			if loader, ok := m.loaders[base.Type]; ok {
+				return loader, nil
+			}
+		}
+	}
+
+	// If we have a default loader and it supports the file, use it
+	if m.defaultLoader != nil && m.defaultLoader.IsFileSupported(f, fileName) {
+		return m.defaultLoader, nil
+	}
+
+	// Try to find a loader that supports this file
+	if loader := m.findSupportedLoader(f, fileName); loader != nil {
+		return loader, nil
+	}
+
+	// No suitable loader found
+	if base.Type != "" {
+		return nil, fmt.Errorf("no loader registered for type: %s and no loader supports the file", base.Type)
+	}
+	return nil, fmt.Errorf("no type field found in command file %s and no loader supports the file", fileName)
+}
+
+// LoadCommands implements the CommandLoader interface
+func (m *MultiLoader) LoadCommands(
+	f fs.FS,
+	entryName string,
+	options []cmds.CommandDescriptionOption,
+	aliasOptions []alias.Option,
+) ([]cmds.Command, error) {
+	// First, read the file
+	file, err := f.Open(entryName)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not open file")
+	}
+	defer file.Close()
+
+	// Read the content
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not read file")
+	}
+
+	// Get the appropriate loader
+	loader, err := m.getLoaderForFile(f, entryName, content)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the loader to load the commands
+	return loader.LoadCommands(f, entryName, options, aliasOptions)
+}
+
+// IsFileSupported implements the CommandLoader interface
+func (m *MultiLoader) IsFileSupported(f fs.FS, fileName string) bool {
+	// Try to open and read the file
+	file, err := f.Open(fileName)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return false
+	}
+
+	// Try to get a loader for this file
+	loader, err := m.getLoaderForFile(f, fileName, content)
+	return err == nil && loader != nil
+}

--- a/pkg/cmds/runner/run.go
+++ b/pkg/cmds/runner/run.go
@@ -1,0 +1,218 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	cmd_middlewares "github.com/go-go-golems/glazed/pkg/cmds/middlewares"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/settings"
+)
+
+// RunOptions contains configuration for running a command
+type RunOptions struct {
+	Writer         io.Writer
+	GlazeProcessor middlewares.Processor
+}
+
+type RunOption func(*RunOptions)
+
+// WithWriter sets the writer to use for WriterCommand output
+func WithWriter(w io.Writer) RunOption {
+	return func(o *RunOptions) {
+		o.Writer = w
+	}
+}
+
+// WithGlazeProcessor sets the processor to use for GlazeCommand output
+func WithGlazeProcessor(p middlewares.Processor) RunOption {
+	return func(o *RunOptions) {
+		o.GlazeProcessor = p
+	}
+}
+
+// RunCommand executes a Glazed command with the given parsed parameters and options
+func RunCommand(
+	ctx context.Context,
+	cmd cmds.Command,
+	parsedLayers *layers.ParsedLayers,
+	options ...RunOption,
+) error {
+	// Setup default options
+	opts := &RunOptions{
+		Writer: os.Stdout,
+	}
+
+	// Apply provided options
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	// Handle different command types
+	switch c := cmd.(type) {
+	case cmds.BareCommand:
+		return c.Run(ctx, parsedLayers)
+
+	case cmds.WriterCommand:
+		return c.RunIntoWriter(ctx, parsedLayers, opts.Writer)
+
+	case cmds.GlazeCommand:
+		// If no processor is provided, create one from glazed settings
+		if opts.GlazeProcessor == nil {
+			glazedLayer, ok := parsedLayers.Get(settings.GlazedSlug)
+			if !ok {
+				return fmt.Errorf("glazed layer not found")
+			}
+			gp, err := settings.SetupTableProcessor(glazedLayer)
+			if err != nil {
+				return fmt.Errorf("failed to setup processor: %w", err)
+			}
+			_, err = settings.SetupProcessorOutput(gp, glazedLayer, opts.Writer)
+			if err != nil {
+				return fmt.Errorf("failed to setup processor output: %w", err)
+			}
+			opts.GlazeProcessor = gp
+		}
+
+		err := c.RunIntoGlazeProcessor(ctx, parsedLayers, opts.GlazeProcessor)
+		if err != nil {
+			return err
+		}
+
+		return opts.GlazeProcessor.Close(ctx)
+
+	default:
+		return fmt.Errorf("unknown command type: %T", cmd)
+	}
+}
+
+// ParseOptions contains configuration for parameter parsing
+type ParseOptions struct {
+	ValuesForLayers       map[string]map[string]interface{}
+	EnvPrefix             string
+	AdditionalMiddlewares []cmd_middlewares.Middleware
+	UseViper              bool
+	UseEnv                bool
+}
+
+type ParseOption func(*ParseOptions)
+
+// WithValuesForLayers sets values for parameters in specified layers
+func WithValuesForLayers(values map[string]map[string]interface{}) ParseOption {
+	return func(o *ParseOptions) {
+		o.ValuesForLayers = values
+	}
+}
+
+// WithEnvPrefix sets the prefix for environment variable parsing
+func WithEnvPrefix(prefix string) ParseOption {
+	return func(o *ParseOptions) {
+		o.EnvPrefix = prefix
+	}
+}
+
+// WithAdditionalMiddlewares adds custom middlewares to the parsing chain
+func WithAdditionalMiddlewares(middlewares ...cmd_middlewares.Middleware) ParseOption {
+	return func(o *ParseOptions) {
+		o.AdditionalMiddlewares = append(o.AdditionalMiddlewares, middlewares...)
+	}
+}
+
+// WithViper enables loading parameters from Viper configuration
+func WithViper() ParseOption {
+	return func(o *ParseOptions) {
+		o.UseViper = true
+	}
+}
+
+// WithEnvMiddleware enables environment variable parsing with the given prefix
+func WithEnvMiddleware(prefix string) ParseOption {
+	return func(o *ParseOptions) {
+		o.UseEnv = true
+		o.EnvPrefix = prefix
+	}
+}
+
+// ParseCommandParameters parses parameters for a command using a configurable middleware chain
+func ParseCommandParameters(
+	cmd cmds.Command,
+	options ...ParseOption,
+) (*layers.ParsedLayers, error) {
+	opts := &ParseOptions{}
+
+	// Apply provided options
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	// Create middleware chain
+	middlewares_ := []cmd_middlewares.Middleware{}
+	middlewares_ = append(middlewares_, opts.AdditionalMiddlewares...)
+
+	// Add Viper middleware if enabled
+	if opts.UseViper {
+		middlewares_ = append(middlewares_,
+			cmd_middlewares.GatherFlagsFromViper(
+				parameters.WithParseStepSource("viper"),
+			),
+		)
+	}
+
+	// Add environment variables middleware if enabled
+	if opts.UseEnv {
+		middlewares_ = append(middlewares_,
+			cmd_middlewares.UpdateFromEnv(opts.EnvPrefix,
+				parameters.WithParseStepSource("env"),
+			),
+		)
+	}
+
+	// Add values for layers middleware if provided
+	if opts.ValuesForLayers != nil {
+		middlewares_ = append(middlewares_,
+			cmd_middlewares.UpdateFromMap(opts.ValuesForLayers,
+				parameters.WithParseStepSource("provided-values"),
+			),
+		)
+	}
+
+	// Add base defaults middleware
+	middlewares_ = append(middlewares_,
+		cmd_middlewares.SetFromDefaults(
+			parameters.WithParseStepSource(parameters.SourceDefaults),
+		),
+	)
+
+	// Create parsed layers and execute middleware chain
+	parsedLayers := layers.NewParsedLayers()
+	err := cmd_middlewares.ExecuteMiddlewares(
+		cmd.Description().Layers,
+		parsedLayers,
+		middlewares_...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse parameters: %w", err)
+	}
+
+	return parsedLayers, nil
+}
+
+// ParseAndRun combines parameter parsing and command execution into a single function
+func ParseAndRun(
+	ctx context.Context,
+	cmd cmds.Command,
+	parseOptions []ParseOption,
+	runOptions []RunOption,
+) error {
+	parsedLayers, err := ParseCommandParameters(cmd, parseOptions...)
+	if err != nil {
+		return err
+	}
+
+	return RunCommand(ctx, cmd, parsedLayers, runOptions...)
+}

--- a/pkg/doc/topics/15-using-commands.md
+++ b/pkg/doc/topics/15-using-commands.md
@@ -415,6 +415,97 @@ func runCustomCommand(cmd cmds.Command) error {
 
 This approach provides a flexible way to run Glazed commands programmatically while maintaining control over parameter parsing and command execution.
 
+## JSON Schema Generation
+
+Commands in Glazed can generate JSON Schema representations of their parameters using the `ToJsonSchema` method. This is useful for:
+
+- Documenting command parameters in a standardized format
+- Enabling client-side validation
+- Supporting auto-completion and parameter hints in tools
+- Integrating with external tools that understand JSON Schema
+
+### Using ToJsonSchema
+
+The `ToJsonSchema` method returns a `CommandJsonSchema` struct that follows the JSON Schema specification:
+
+```go
+schema, err := cmd.Description().ToJsonSchema()
+if err != nil {
+    // Handle error
+}
+
+// Pretty print the schema
+encoder := json.NewEncoder(os.Stdout)
+encoder.SetIndent("", "  ")
+if err := encoder.Encode(schema); err != nil {
+    // Handle error
+}
+```
+
+The generated schema includes:
+- Parameter types and descriptions
+- Required vs optional parameters
+- Default values
+- Enum choices for choice parameters
+- Array types for list parameters
+- Nested object structures for complex parameters
+
+### Schema Structure
+
+The generated JSON Schema follows this structure:
+
+```json
+{
+  "type": "object",
+  "description": "Command description",
+  "properties": {
+    "parameterName": {
+      "type": "string|number|boolean|array|object",
+      "description": "Parameter help text",
+      "default": "Default value if specified",
+      "enum": ["choice1", "choice2"] // For choice parameters
+    }
+  },
+  "required": ["required_parameter_names"]
+}
+```
+
+### Parameter Type Mapping
+
+Glazed parameter types are mapped to JSON Schema types as follows:
+
+Basic Types:
+- `ParameterTypeString` → `"type": "string"`
+- `ParameterTypeInteger` → `"type": "integer"`
+- `ParameterTypeFloat` → `"type": "number"`
+- `ParameterTypeBool` → `"type": "boolean"`
+- `ParameterTypeDate` → `"type": "string"` with `"format": "date"`
+
+List Types:
+- `ParameterTypeStringList` → `"type": "array"` with string items
+- `ParameterTypeIntegerList` → `"type": "array"` with integer items
+- `ParameterTypeFloatList` → `"type": "array"` with number items
+
+Choice Types:
+- `ParameterTypeChoice` → `"type": "string"` with enum values
+- `ParameterTypeChoiceList` → `"type": "array"` with string items and enum values
+
+File Types:
+- `ParameterTypeFile` → `"type": "object"` with path and content properties
+- `ParameterTypeFileList` → `"type": "array"` with file objects as items
+
+Key-Value Type:
+- `ParameterTypeKeyValue` → `"type": "object"` with key and value string properties
+
+File-Based Types:
+- `ParameterTypeStringFromFile` → `"type": "string"`
+- `ParameterTypeStringFromFiles` → `"type": "array"` with string items
+- `ParameterTypeObjectFromFile` → `"type": "object"` with additional string properties
+- `ParameterTypeObjectListFromFile` → `"type": "array"` with object items
+- `ParameterTypeObjectListFromFiles` → `"type": "array"` with object items
+- `ParameterTypeStringListFromFile` → `"type": "array"` with string items
+- `ParameterTypeStringListFromFiles` → `"type": "array"` with string items
+
 ## Summary
 
 By following this guide, you can effectively create, configure, run, and manage commands in the `glazed` framework. Whether you're building simple utilities or complex applications, `glazed` provides the tools necessary to streamline your command-line interface development.

--- a/pkg/doc/topics/20-using-multi-loader.md
+++ b/pkg/doc/topics/20-using-multi-loader.md
@@ -1,0 +1,181 @@
+---
+Title: Using the MultiLoader
+Slug: using-multi-loader
+Short: Learn how to use the MultiLoader to handle different types of command files with type-based dispatch
+Topics:
+  - Commands
+  - YAML
+  - Configuration
+  - Loaders
+Commands:
+  - LoadCommands
+Flags:
+  - none
+IsTopLevel: true
+ShowPerDefault: false
+SectionType: GeneralTopic
+---
+
+# Using the MultiLoader in Glazed
+
+The MultiLoader provides a flexible way to load commands from different file types by dispatching to appropriate loaders based on a `type` field or file content. This guide explains how to use and configure the MultiLoader for your applications.
+
+## Basic Structure
+
+The MultiLoader works by first checking a file's `type` field (if present) and then dispatching to the appropriate registered loader. Here's how a typical command file with a type field looks:
+
+```yaml
+type: sql
+name: query-users
+short: Query the users table
+flags:
+  - name: limit
+    type: int
+    help: Maximum number of users to return
+```
+
+## Setting Up the MultiLoader
+
+### Basic Setup
+
+Create and configure a MultiLoader with specific type handlers:
+
+```go
+// Create a new MultiLoader
+loader := loaders.NewMultiLoader()
+
+// Register loaders for different types
+loader.RegisterLoader("sql", sqlLoader)
+loader.RegisterLoader("http", httpLoader)
+loader.RegisterLoader("shell", shellLoader)
+
+// Set a default loader for files without a type field
+loader.SetDefaultLoader(defaultLoader)
+```
+
+### Using the MultiLoader
+
+Use the configured MultiLoader like any other CommandLoader:
+
+```go
+commands, err := loader.LoadCommands(fs, "commands/query.yaml", options, aliasOptions)
+if err != nil {
+    // Handle error
+}
+```
+
+## Loader Selection Process
+
+The MultiLoader follows this process to select the appropriate loader:
+
+1. First, attempts to parse the file as YAML and check for a `type` field
+2. If a type is found, uses the registered loader for that type
+3. If no type is found or parsing fails:
+   - Uses the default loader if one is set
+   - Tries each registered loader to find one that supports the file
+4. Returns an error if no suitable loader is found
+
+## Supported Features
+
+### Type-Based Dispatch
+
+Register loaders for specific command types:
+
+```go
+// SQL command loader
+loader.RegisterLoader("sql", &SQLCommandLoader{})
+
+// HTTP command loader
+loader.RegisterLoader("http", &HTTPCommandLoader{})
+```
+
+### Default Loader
+
+Set a fallback loader for files without a type field:
+
+```go
+loader.SetDefaultLoader(&YAMLCommandLoader{})
+```
+
+### Automatic Loader Detection
+
+The MultiLoader can automatically detect the right loader even without a type field:
+
+```go
+// Will try each registered loader's IsFileSupported method
+commands, err := loader.LoadCommands(fs, "commands/unknown.txt", options, aliasOptions)
+```
+
+## Example Command Files
+
+### SQL Command
+```yaml
+type: sql
+name: list-users
+short: List all users from database
+flags:
+  - name: order-by
+    type: string
+    help: Column to sort by
+    default: id
+```
+
+### HTTP Command
+```yaml
+type: http
+name: get-weather
+short: Get weather information
+flags:
+  - name: city
+    type: string
+    help: City name
+    required: true
+```
+
+### Default YAML Command
+```yaml
+# No type field - will use default loader
+name: simple-command
+short: A simple command
+flags:
+  - name: verbose
+    type: bool
+    help: Enable verbose output
+```
+
+## Common Patterns
+
+### Registering Multiple Loaders
+
+```go
+func RegisterLoaders(ml *loaders.MultiLoader) {
+    ml.RegisterLoader("sql", NewSQLLoader())
+    ml.RegisterLoader("http", NewHTTPLoader())
+    ml.RegisterLoader("shell", NewShellLoader())
+    
+    // Set default loader last
+    ml.SetDefaultLoader(NewYAMLLoader())
+}
+```
+
+### Conditional Loading
+
+```go
+func LoadCommandsWithMultiLoader(fs fs.FS, path string) ([]cmds.Command, error) {
+    loader := loaders.NewMultiLoader()
+    
+    // Register loaders based on configuration
+    if config.SQLEnabled {
+        loader.RegisterLoader("sql", NewSQLLoader())
+    }
+    if config.HTTPEnabled {
+        loader.RegisterLoader("http", NewHTTPLoader())
+    }
+    
+    return loader.LoadCommands(fs, path, nil, nil)
+}
+```
+
+## Conclusion
+
+The MultiLoader provides a flexible and extensible way to handle different types of command files in your application. By following these guidelines and patterns, you can create a robust command loading system that supports multiple file formats and command types while maintaining clean, maintainable code. 

--- a/pkg/doc/topics/21-cmds-middlewares.md
+++ b/pkg/doc/topics/21-cmds-middlewares.md
@@ -142,7 +142,7 @@ middleware := middlewares.ParseFromCobraCommand(cmd,
 )
 ```
 
-For positional arguments:
+For positional arguments (from command line):
 ```go
 middleware := middlewares.GatherArguments(args,
     parameters.WithParseStepSource("args"),

--- a/pkg/doc/topics/21-cmds-middlewares.md
+++ b/pkg/doc/topics/21-cmds-middlewares.md
@@ -1,3 +1,25 @@
+---
+Title: Glazed Middlewares Guide
+Slug: glazed-middlewares
+Short: Learn how to use Glazed's middleware system to load parameter values from various sources
+Topics:
+- middlewares
+- parameters
+- configuration
+Commands:
+- ExecuteMiddlewares
+- SetFromDefaults
+- UpdateFromEnv
+- LoadParametersFromFile
+- ParseFromCobraCommand
+Flags:
+- none
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
 # Glazed Middlewares Guide: Loading Parameter Values
 
 ## Overview
@@ -473,3 +495,288 @@ middlewares.WrapWithWhitelistedLayers(
     middlewares.UpdateFromEnv("APP_"),
 )
 ```
+
+## Tutorial: Practical Implementation
+
+This section provides concrete examples of implementing and using the middleware system. While the previous sections explained the architectural concepts, here we'll see how these concepts translate into working code.
+
+### 1. Basic Setup
+
+The foundation of Glazed's parameter system is the `ParameterLayer`. Before we can use middlewares, we need to define our parameter structure. This example shows how to create a layer that matches the architectural concepts discussed earlier:
+
+```go
+package main
+
+import (
+    "github.com/go-go-golems/glazed/pkg/cmds/layers"
+    "github.com/go-go-golems/glazed/pkg/cmds/parameters"
+    "github.com/go-go-golems/glazed/pkg/cmds/middlewares"
+)
+
+func main() {
+    // Create a new parameter layer
+    layer, err := layers.NewParameterLayer(
+        "config",
+        "Configuration Options",
+        layers.WithParameterDefinitions(
+            parameters.NewParameterDefinition(
+                "host",
+                parameters.ParameterTypeString,
+                parameters.WithDefault("localhost"),
+                parameters.WithHelp("Server hostname"),
+            ),
+            parameters.NewParameterDefinition(
+                "port",
+                parameters.ParameterTypeInteger,
+                parameters.WithDefault(8080),
+                parameters.WithHelp("Server port"),
+            ),
+        ),
+    )
+    if err != nil {
+        panic(err)
+    }
+
+    // Create parameter layers container
+    parameterLayers := layers.NewParameterLayers(
+        layers.WithLayers(layer),
+    )
+}
+```
+
+This setup demonstrates several key concepts:
+- Parameter definitions with types, defaults, and help text
+- Layer organization with meaningful names and descriptions
+- Error handling for layer creation
+- Container structure for managing multiple layers
+
+### 2. Using Individual Middlewares
+
+Now that we understand the middleware signature and execution order, let's see how to implement specific middlewares. These examples show how the middleware chain processes parameters in practice.
+
+#### SetFromDefaults Middleware
+
+The `SetFromDefaults` middleware demonstrates the basic middleware pattern of processing parameters after the next handler:
+
+```go
+func useDefaultsMiddleware() {
+    // Create empty parsed layers
+    parsedLayers := layers.NewParsedLayers()
+
+    // Create and execute the middleware
+    middleware := middlewares.SetFromDefaults(
+        parameters.WithParseStepSource(parameters.SourceDefaults),
+    )
+
+    err := middlewares.ExecuteMiddlewares(
+        parameterLayers,
+        parsedLayers,
+        middleware,
+    )
+    if err != nil {
+        panic(err)
+    }
+
+    // Access the parsed values
+    configLayer, _ := parsedLayers.Get("config")
+    hostValue, _ := configLayer.GetParameter("host")
+    // hostValue will be "localhost"
+}
+```
+
+This example shows:
+- Creation of empty ParsedLayers to store results
+- Source tracking using ParseStepSource
+- Middleware execution order
+- Access to parsed values
+- Error handling in middleware chains
+
+#### UpdateFromMap Middleware
+
+The `UpdateFromMap` middleware shows how to override values from an external source:
+
+```go
+func useMapMiddleware() {
+    parsedLayers := layers.NewParsedLayers()
+
+    // Define the update map
+    updateMap := map[string]map[string]interface{}{
+        "config": {
+            "host": "example.com",
+            "port": 9090,
+        },
+    }
+
+    err := middlewares.ExecuteMiddlewares(
+        parameterLayers,
+        parsedLayers,
+        middlewares.UpdateFromMap(updateMap),
+    )
+    if err != nil {
+        panic(err)
+    }
+}
+```
+
+This demonstrates:
+- Structured data input through maps
+- Layer-specific updates
+- Value override patterns
+- Integration with the middleware chain
+
+### 3. Accessing Parsed Values
+
+After middlewares process the parameters, there are several ways to access the results. These patterns align with different use cases in the architecture:
+
+```go
+func accessParsedValues(parsedLayers *layers.ParsedLayers) {
+    // 1. Direct access through layer
+    configLayer, _ := parsedLayers.Get("config")
+    hostValue, _ := configLayer.GetParameter("host")
+
+    // 2. Get all parameters as a map
+    dataMap := parsedLayers.GetDataMap()
+    host := dataMap["host"]
+
+    // 3. Initialize a struct
+    type Config struct {
+        Host string `glazed.parameter:"host"`
+        Port int    `glazed.parameter:"port"`
+    }
+    
+    var config Config
+    err := parsedLayers.InitializeStruct("config", &config)
+    if err != nil {
+        panic(err)
+    }
+}
+```
+
+These access patterns support:
+- Direct layer access for fine-grained control
+- Map-based access for dynamic parameter handling
+- Struct initialization for type-safe parameter usage
+- Integration with Go's type system through struct tags
+
+### 4. Tracking Parameter History
+
+One of the key features of Glazed's middleware system is its ability to track parameter changes. This helps debug parameter processing and understand value origins:
+
+```go
+func checkParameterHistory(parsedLayers *layers.ParsedLayers) {
+    configLayer, _ := parsedLayers.Get("config")
+    hostParam, _ := configLayer.Parameters.Get("host")
+
+    // View the parsing history
+    for _, step := range hostParam.Log {
+        fmt.Printf("Source: %s, Value: %v\n", step.Source, step.Value)
+    }
+}
+```
+
+The history tracking shows:
+- Source identification for each update
+- Value transformation tracking
+- Middleware execution order verification
+- Debugging support for parameter processing
+
+### 5. Complex Middleware Chaining
+
+This example demonstrates how multiple middlewares work together in the chain, following the execution order principles discussed earlier:
+
+```go
+func chainMiddlewares() {
+    parsedLayers := layers.NewParsedLayers()
+
+    // Define different parameter sources
+    configMap := map[string]map[string]interface{}{
+        "config": {
+            "host": "config.com",
+            "port": 5000,
+        },
+    }
+
+    defaultMap := map[string]map[string]interface{}{
+        "config": {
+            "host": "default.com",
+            "port": 8080,
+        },
+    }
+
+    // Execute middlewares in order (last middleware has highest precedence)
+    err := middlewares.ExecuteMiddlewares(
+        parameterLayers,
+        parsedLayers,
+        middlewares.UpdateFromMapAsDefault(defaultMap),  // Lowest precedence
+        middlewares.SetFromDefaults(
+            parameters.WithParseStepSource(parameters.SourceDefaults),
+        ),
+        middlewares.UpdateFromMap(configMap),  // Highest precedence
+    )
+    if err != nil {
+        panic(err)
+    }
+}
+```
+
+This complex example illustrates:
+- Priority-based middleware ordering
+- Multiple data source handling
+- Default value management
+- Value override patterns
+- Error propagation through the chain
+
+### 6. Working with Restricted Layers
+
+Layer restriction is a powerful feature that implements the modular parameter handling concept discussed in the architecture:
+
+```go
+func useRestrictedLayers() {
+    parsedLayers := layers.NewParsedLayers()
+
+    updateMap := map[string]map[string]interface{}{
+        "config": {
+            "host": "restricted.com",
+        },
+    }
+
+    // Only apply to whitelisted layers
+    whitelistedMiddleware := middlewares.WrapWithWhitelistedLayers(
+        []string{"config"},
+        middlewares.UpdateFromMap(updateMap),
+    )
+
+    // Or blacklist specific layers
+    blacklistedMiddleware := middlewares.WrapWithBlacklistedLayers(
+        []string{"other-layer"},
+        middlewares.UpdateFromMap(updateMap),
+    )
+
+    err := middlewares.ExecuteMiddlewares(
+        parameterLayers,
+        parsedLayers,
+        whitelistedMiddleware,
+        blacklistedMiddleware,
+    )
+    if err != nil {
+        panic(err)
+    }
+}
+```
+
+This demonstrates advanced concepts:
+- Selective middleware application
+- Layer isolation
+- Parameter scope control
+- Middleware composition
+- Complex configuration scenarios
+
+### Integration with Larger Systems
+
+These examples can be combined to create sophisticated parameter handling systems. For instance, a typical application might:
+
+1. Define multiple parameter layers for different concerns
+2. Set up a chain of middlewares to handle various input sources
+3. Use layer restrictions to manage parameter scope
+4. Track parameter history for debugging
+5. Access parsed values through the most appropriate pattern


### PR DESCRIPTION
Adds several helpers to support building MCP tools with glazed commands:

- New MultiLoader for type-based command loading:
  - Dispatches to registered loaders based on command type field
  - Fallback to default loader for untyped commands
  - Automatic loader detection based on file content

- New runner package for programmatic command execution:
  - ParseAndRun helper for simple command execution
  - Configurable parameter parsing with options
  - Support for environment variables, Viper config, and custom middlewares
  - Separate parse and run steps for advanced control

- Additional documentation:
  - Tutorial for using MultiLoader
  - Guide for running commands programmatically
  - Expanded middleware documentation with examples

- Other changes:
  - Added Type field to CommandDescription
  - Changed command path separator from space to forward slash
  - Added JSON Schema generation guide