### PR TITLE
Enforce stricter type checking and improve error handling for parameter values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	github.com/tj/go-naturaldate v1.3.0
 	github.com/ugorji/go/codec v1.2.11
 	github.com/wk8/go-ordered-map/v2 v2.1.8
@@ -76,7 +76,7 @@ require (
 	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.3 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
@@ -91,7 +91,7 @@ require (
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/image v0.14.0 // indirect
-	golang.org/x/mod v0.21.0 // indirect
+	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,7 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
-github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
@@ -168,8 +167,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160 h1:NSWpaDaurcAJY7PkL8Xt0PhZE7qpvbZl5ljd8r6U0bI=
@@ -213,8 +212,7 @@ golang.org/x/image v0.14.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
-golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,7 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
@@ -169,6 +170,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tj/assert v0.0.0-20190920132354-ee03d75cd160 h1:NSWpaDaurcAJY7PkL8Xt0PhZE7qpvbZl5ljd8r6U0bI=
@@ -213,6 +215,7 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
+golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/pkg/cmds/helpers/test-helpers.go
+++ b/pkg/cmds/helpers/test-helpers.go
@@ -266,7 +266,10 @@ func NewTestParsedLayer(pl layers.ParameterLayer, l TestParsedLayer) *layers.Par
 		if !ok {
 			panic("parameter definition not found")
 		}
-		params_.UpdateValue(p.Name, pd, p.Value)
+		err := params_.UpdateValue(p.Name, pd, p.Value)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	ret, err := layers.NewParsedLayer(pl, layers.WithParsedParameters(params_))

--- a/pkg/cmds/layers/layer.go
+++ b/pkg/cmds/layers/layer.go
@@ -172,7 +172,10 @@ func InitializeParameterLayerWithDefaults(
 			return err
 		}
 		if v != nil {
-			parsedLayer.Parameters.SetAsDefault(pd.Name, pd, v, options...)
+			err := parsedLayer.Parameters.SetAsDefault(pd.Name, pd, v, options...)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/pkg/cmds/middlewares/cobra.go
+++ b/pkg/cmds/middlewares/cobra.go
@@ -38,7 +38,10 @@ func ParseFromCobraCommand(cmd *cobra.Command, options ...parameters.ParseStepOp
 						return err
 					}
 
-					parsedLayer.Parameters.Merge(cobraLayer.Parameters)
+					_, err = parsedLayer.Parameters.Merge(cobraLayer.Parameters)
+					if err != nil {
+						return err
+					}
 				}
 
 				return nil
@@ -75,7 +78,10 @@ func GatherArguments(args []string, options ...parameters.ParseStepOption) Middl
 				}
 
 				parsedLayer := parsedLayers.GetOrCreate(defaultLayer)
-				parsedLayer.Parameters.Merge(ps_)
+				_, err = parsedLayer.Parameters.Merge(ps_)
+				if err != nil {
+					return err
+				}
 			}
 
 			return nil
@@ -115,7 +121,10 @@ func GatherFlagsFromViper(options ...parameters.ParseStepOption) Middleware {
 					return err
 				}
 
-				parsedLayer.Parameters.Merge(ps)
+				_, err = parsedLayer.Parameters.Merge(ps)
+				if err != nil {
+					return err
+				}
 
 				return nil
 			})
@@ -172,7 +181,10 @@ func GatherSpecificFlagsFromViper(flags []string, options ...parameters.ParseSte
 					return err
 				}
 
-				parsedLayer.Parameters.Merge(ps)
+				_, err = parsedLayer.Parameters.Merge(ps)
+				if err != nil {
+					return err
+				}
 
 				return nil
 			})

--- a/pkg/cmds/middlewares/layers.go
+++ b/pkg/cmds/middlewares/layers.go
@@ -95,7 +95,10 @@ func MergeParsedLayer(layerSlug string, layerToMerge *layers.ParsedLayer) Middle
 				return nil
 			}
 
-			targetLayer.MergeParameters(layerToMerge)
+			err = targetLayer.MergeParameters(layerToMerge)
+			if err != nil {
+				return err
+			}
 			return nil
 		}
 	}
@@ -116,7 +119,10 @@ func MergeParsedLayers(layersToMerge *layers.ParsedLayers) Middleware {
 				return errors.New("cannot merge nil layers")
 			}
 
-			parsedLayers.Merge(layersToMerge)
+			err = parsedLayers.Merge(layersToMerge)
+			if err != nil {
+				return err
+			}
 			return nil
 		}
 	}
@@ -144,7 +150,10 @@ func MergeParsedLayersSelective(layersToMerge *layers.ParsedLayers, slugs []stri
 					if !exists {
 						parsedLayers.Set(slug, layer.Clone())
 					} else {
-						targetLayer.MergeParameters(layer)
+						err = targetLayer.MergeParameters(layer)
+						if err != nil {
+							return err
+						}
 					}
 				}
 			}

--- a/pkg/cmds/middlewares/tests/multi-update-from-map.yaml
+++ b/pkg/cmds/middlewares/tests/multi-update-from-map.yaml
@@ -43,7 +43,7 @@
       - name: "layer1"
         parameters:
           - name: param1
-            value: "initial"
+            value: ["initial"]
     expectedLayers:
       - name: "layer1"
         values:
@@ -61,12 +61,16 @@
         definitions:
           - name: "param1"
             type: "objectFromFile"
-            default: "original"
+            default: 
+              original:
+                param2: "original"
     parsedLayers:
       - name: "layer1"
         parameters:
           - name: param1
-            value: "initial"
+            value:
+              original:
+                param2: "initial"
     expectedLayers:
       - name: "layer1"
         values:
@@ -84,12 +88,18 @@
         definitions:
           - name: "param1"
             type: "objectListFromFile"
-            default: "original"
+            default:
+              - original:
+                  param2: "original"
+              - original:
+                  param2: "original2"
     parsedLayers:
       - name: "layer1"
         parameters:
           - name: param1
-            value: "initial"
+            value:
+              - original:
+                  param2: "initial"
     expectedLayers:
       - name: "layer1"
         values:

--- a/pkg/cmds/middlewares/update.go
+++ b/pkg/cmds/middlewares/update.go
@@ -107,7 +107,10 @@ func updateFromMap(
 		if err != nil {
 			return err
 		}
-		parsedLayer.Parameters.Merge(ps)
+		_, err = parsedLayer.Parameters.Merge(ps)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -128,7 +131,10 @@ func updateFromMapAsDefault(
 		if err != nil {
 			return err
 		}
-		parsedLayer.Parameters.MergeAsDefault(ps)
+		_, err = parsedLayer.Parameters.MergeAsDefault(ps)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -139,10 +145,10 @@ func updateFromEnv(
 	prefix string,
 	options ...parameters.ParseStepOption,
 ) error {
-	layers_.ForEach(func(key string, l layers.ParameterLayer) {
+	err := layers_.ForEachE(func(key string, l layers.ParameterLayer) error {
 		parsedLayer := parsedLayers.GetOrCreate(l)
 		pds := l.GetParameterDefinitions()
-		pds.ForEach(func(p *parameters.ParameterDefinition) {
+		err := pds.ForEachE(func(p *parameters.ParameterDefinition) error {
 			name := p.Name
 			if prefix != "" {
 				name = prefix + "_" + name
@@ -150,12 +156,20 @@ func updateFromEnv(
 			name = strings.ToUpper(name)
 
 			if v, ok := os.LookupEnv(name); ok {
-				parsedLayer.Parameters.UpdateValue(name, p, v, options...)
+				err := parsedLayer.Parameters.UpdateValue(name, p, v, options...)
+				if err != nil {
+					return err
+				}
 			}
+			return nil
 		})
+		if err != nil {
+			return err
+		}
+		return nil
 	})
 
-	return nil
+	return err
 }
 
 func UpdateFromEnv(prefix string, options ...parameters.ParseStepOption) Middleware {
@@ -180,14 +194,20 @@ func updateFromStringList(layers_ *layers.ParameterLayers, parsedLayers *layers.
 			return err
 		}
 
-		parsedLayer.Parameters.Merge(ps)
+		_, err = parsedLayer.Parameters.Merge(ps)
+		if err != nil {
+			return err
+		}
 
 		ps, err = pds.GatherArguments(remainingArgs, true, true, options...)
 		if err != nil {
 			return err
 		}
 
-		parsedLayer.Parameters.Merge(ps)
+		_, err = parsedLayer.Parameters.Merge(ps)
+		if err != nil {
+			return err
+		}
 
 		return nil
 	})

--- a/pkg/cmds/parameters/cobra.go
+++ b/pkg/cmds/parameters/cobra.go
@@ -288,9 +288,6 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 
 				defaultValue = stringList
 			}
-			if err != nil {
-				return errors.Wrapf(err, "Could not convert default value for parameter %s to string list: %v", parameter.Name, *parameter.Default)
-			}
 
 			if parameter.ShortFlag != "" {
 				flagSet.StringSliceP(flagName, shortFlag, defaultValue, helpText)
@@ -478,7 +475,10 @@ func (pds *ParameterDefinitions) GatherFlagsFromCobraCommand(
 			if err != nil {
 				return err
 			}
-			p.Update(v, options...)
+			err = p.Update(v, options...)
+			if err != nil {
+				return err
+			}
 			ps.Set(pd.Name, p)
 
 		case ParameterTypeInteger:
@@ -486,7 +486,10 @@ func (pds *ParameterDefinitions) GatherFlagsFromCobraCommand(
 			if err != nil {
 				return err
 			}
-			p.Update(v, options...)
+			err = p.Update(v, options...)
+			if err != nil {
+				return err
+			}
 			ps.Set(pd.Name, p)
 
 		case ParameterTypeBool:
@@ -494,7 +497,10 @@ func (pds *ParameterDefinitions) GatherFlagsFromCobraCommand(
 			if err != nil {
 				return err
 			}
-			p.Update(v, options...)
+			err = p.Update(v, options...)
+			if err != nil {
+				return err
+			}
 			ps.Set(pd.Name, p)
 
 		case ParameterTypeObjectListFromFiles,
@@ -517,7 +523,10 @@ func (pds *ParameterDefinitions) GatherFlagsFromCobraCommand(
 			if err != nil {
 				return err
 			}
-			p.Update(v, options...)
+			err = p.Update(v, options...)
+			if err != nil {
+				return err
+			}
 			ps.Set(pd.Name, p)
 
 		case ParameterTypeKeyValue:
@@ -533,7 +542,10 @@ func (pds *ParameterDefinitions) GatherFlagsFromCobraCommand(
 						"flag":      flagName,
 						"emptyFlag": true,
 					}))
-				p.Update(map[string]string{}, options_...)
+				err = p.Update(map[string]string{}, options_...)
+				if err != nil {
+					return err
+				}
 				ps.Set(pd.Name, p)
 			} else {
 				v2, err := pd.ParseParameter(v, options...)
@@ -549,7 +561,10 @@ func (pds *ParameterDefinitions) GatherFlagsFromCobraCommand(
 			if err != nil {
 				return err
 			}
-			p.Update(v, options...)
+			err = p.Update(v, options...)
+			if err != nil {
+				return err
+			}
 			ps.Set(pd.Name, p)
 
 		case ParameterTypeFloatList:
@@ -558,7 +573,10 @@ func (pds *ParameterDefinitions) GatherFlagsFromCobraCommand(
 			if err != nil {
 				return err
 			}
-			p.Update(v, options...)
+			err = p.Update(v, options...)
+			if err != nil {
+				return err
+			}
 			ps.Set(pd.Name, p)
 		}
 

--- a/pkg/cmds/parameters/gather-arguments.go
+++ b/pkg/cmds/parameters/gather-arguments.go
@@ -49,7 +49,10 @@ func (pds *ParameterDefinitions) GatherArguments(
 				if argument.Default != nil && !onlyProvided {
 					parseOptions_ := append(parseOptions, WithParseStepSource("default"))
 
-					p.Update(*argument.Default, parseOptions_...)
+					err := p.Update(*argument.Default, parseOptions_...)
+					if err != nil {
+						return err
+					}
 					result.Set(argument.Name, p)
 				}
 				return nil

--- a/pkg/cmds/parameters/gather-parameters.go
+++ b/pkg/cmds/parameters/gather-parameters.go
@@ -40,7 +40,10 @@ func (pds *ParameterDefinitions) GatherParametersFromMap(
 			}
 			if !ok {
 				if p.Default != nil {
-					parsed.Update(*p.Default)
+					err := parsed.Update(*p.Default)
+					if err != nil {
+						return err
+					}
 					ret.Set(p.Name, parsed)
 					return nil
 				}
@@ -70,7 +73,10 @@ func (pds *ParameterDefinitions) GatherParametersFromMap(
 		}
 
 		// NOTE(manuel, 2023-12-22) We might want to pass in that name instead of just saying from-map
-		parsed.Update(v2, options_...)
+		err = parsed.Update(v2, options_...)
+		if err != nil {
+			return err
+		}
 		ret.Set(p.Name, parsed)
 		return nil
 	})

--- a/pkg/cmds/parameters/strings.go
+++ b/pkg/cmds/parameters/strings.go
@@ -144,7 +144,10 @@ func (pds *ParameterDefinitions) GatherFlagsFromStringList(
 				parseOptions_ := append(parseOptions, WithParseStepMetadata(map[string]interface{}{
 					"default": true,
 				}), WithParseStepSource("default"))
-				p.Update(*param.Default, parseOptions_...)
+				err := p.Update(*param.Default, parseOptions_...)
+				if err != nil {
+					return err
+				}
 				result.Set(param.Name, p)
 			}
 		}

--- a/pkg/cmds/parameters/strings_test.go
+++ b/pkg/cmds/parameters/strings_test.go
@@ -1,9 +1,10 @@
 package parameters
 
 import (
-	"github.com/go-go-golems/glazed/pkg/helpers/cast"
 	"reflect"
 	"testing"
+
+	"github.com/go-go-golems/glazed/pkg/helpers/cast"
 )
 
 // TestGatherFlagsFromStringList_ValidArgumentsAndParameters tests the function with valid arguments and parameters.
@@ -295,7 +296,7 @@ func TestGatherFlagsFromStringList_ValidArgumentsAndParameters(t *testing.T) {
 				{Name: "key-value", ShortFlag: "kv", Type: ParameterTypeKeyValue},
 			})),
 			want: map[string]interface{}{
-				"key-value": map[string]interface{}{
+				"key-value": map[string]string{
 					"key1": "value1",
 					"key2": "value2",
 				},

--- a/pkg/cmds/parameters/viper.go
+++ b/pkg/cmds/parameters/viper.go
@@ -27,7 +27,10 @@ func (pds *ParameterDefinitions) GatherFlagsFromViper(
 			if p.Default != nil {
 				options_ := append(options, WithParseStepSource("default"))
 
-				parsed.Update(*p.Default, options_...)
+				err := parsed.Update(*p.Default, options_...)
+				if err != nil {
+					return nil, err
+				}
 				ret.Set(p.Name, parsed)
 			}
 			continue
@@ -43,29 +46,62 @@ func (pds *ParameterDefinitions) GatherFlagsFromViper(
 		//exhaustive:ignore
 		switch p.Type {
 		case ParameterTypeString:
-			parsed.Update(viper.GetString(flagName), options...)
+			err := parsed.Update(viper.GetString(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 		case ParameterTypeInteger:
-			parsed.Update(viper.GetInt(flagName), options...)
+			err := parsed.Update(viper.GetInt(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 		case ParameterTypeFloat:
-			parsed.Update(viper.GetFloat64(flagName), options...)
+			err := parsed.Update(viper.GetFloat64(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 		case ParameterTypeBool:
-			parsed.Update(viper.GetBool(flagName), options...)
+			err := parsed.Update(viper.GetBool(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 		case ParameterTypeStringList:
-			parsed.Update(viper.GetStringSlice(flagName), options...)
+			err := parsed.Update(viper.GetStringSlice(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 		case ParameterTypeIntegerList:
-			parsed.Update(viper.GetIntSlice(flagName), options...)
+			err := parsed.Update(viper.GetIntSlice(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 		case ParameterTypeKeyValue:
-			parsed.Update(viper.GetStringMapString(flagName), options...)
+			err := parsed.Update(viper.GetStringMapString(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 		case ParameterTypeStringListFromFile:
-			parsed.Update(viper.GetStringSlice(flagName), options...)
+			err := parsed.Update(viper.GetStringSlice(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 		case ParameterTypeStringFromFile:
 			// not sure if this is the best here, maybe it should be the filename?
-			parsed.Update(viper.GetString(flagName), options...)
+			err := parsed.Update(viper.GetString(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 		case ParameterTypeChoice:
 			// probably should do some checking here
-			parsed.Update(viper.GetString(flagName), options...)
+			err := parsed.Update(viper.GetString(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 		case ParameterTypeObjectFromFile:
-			parsed.Update(viper.GetStringMap(flagName), options...)
+			err := parsed.Update(viper.GetStringMap(flagName), options...)
+			if err != nil {
+				return nil, err
+			}
 			// TODO(manuel, 2023-09-19) Add more of the newer types here too
 		default:
 			return nil, errors.Errorf("Unknown parameter type %s for flag %s", p.Type, p.Name)

--- a/pkg/helpers/reflect/reflect.go
+++ b/pkg/helpers/reflect/reflect.go
@@ -556,3 +556,56 @@ func StripInterface(v reflect.Value) reflect.Type {
 
 	return v.Type()
 }
+
+// StripInterfaceFromValue takes a reflect.Value and returns the underlying value by recursively
+// stripping off interface{} and pointer types.
+//
+// For example:
+// - string -> string value
+// - interface{}(string) -> string value
+// - *string -> string value
+// - interface{}(*string) -> string value
+// - *interface{}(string) -> string value
+// - interface{}(*interface{}(string)) -> string value
+//
+// If the value is invalid or nil, returns an invalid reflect.Value.
+func StripInterfaceFromValue(v reflect.Value) reflect.Value {
+	if !v.IsValid() {
+		return v
+	}
+
+	// Keep stripping until we hit a non-interface, non-pointer type
+	for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+		// Handle nil interface or pointer
+		if v.IsNil() {
+			return reflect.Value{}
+		}
+		v = v.Elem()
+	}
+
+	return v
+}
+
+// StripInterfaceValue takes an interface{} and returns the underlying value by recursively
+// stripping off interface{} and pointer types.
+//
+// For example:
+// - string -> string value
+// - interface{}(string) -> string value
+// - *string -> string value
+// - interface{}(*string) -> string value
+// - *interface{}(string) -> string value
+// - interface{}(*interface{}(string)) -> string value
+//
+// If the value is nil, returns nil.
+func StripInterfaceValue(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+
+	value := StripInterfaceFromValue(reflect.ValueOf(v))
+	if !value.IsValid() {
+		return nil
+	}
+	return value.Interface()
+}

--- a/pkg/helpers/reflect/reflect.go
+++ b/pkg/helpers/reflect/reflect.go
@@ -1,10 +1,11 @@
 package reflect
 
 import (
-	"github.com/go-go-golems/glazed/pkg/helpers/cast"
-	"github.com/pkg/errors"
 	"reflect"
 	"strconv"
+
+	"github.com/go-go-golems/glazed/pkg/helpers/cast"
+	"github.com/pkg/errors"
 )
 
 // NOTE(manuel, 2024-07-03) This is quite a mess of a function and I'm not even entirely sure
@@ -525,4 +526,33 @@ func SetStringMapListReflectValue[To interface{}](mapSlice reflect.Value, v inte
 		return nil
 	}
 	return errors.Errorf("cannot set reflect.Value of type %s from %T", keyKind, v)
+}
+
+// StripInterface takes a reflect.Value and returns the underlying type by recursively
+// stripping off interface{} and pointer types.
+//
+// For example:
+// - string -> string
+// - interface{}(string) -> string
+// - *string -> string
+// - interface{}(*string) -> string
+// - *interface{}(string) -> string
+// - interface{}(*interface{}(string)) -> string
+//
+// If the value is invalid or nil, returns nil.
+func StripInterface(v reflect.Value) reflect.Type {
+	if !v.IsValid() {
+		return nil
+	}
+
+	// Keep stripping until we hit a non-interface, non-pointer type
+	for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+		// Handle nil interface or pointer
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	return v.Type()
 }

--- a/pkg/helpers/reflect/reflect_test.go
+++ b/pkg/helpers/reflect/reflect_test.go
@@ -827,3 +827,285 @@ func TestStripInterface(t *testing.T) {
 		})
 	}
 }
+
+func TestStripInterfaceFromValue(t *testing.T) {
+	type CustomString string
+	type CustomInt int
+	type Wrapper struct {
+		Value interface{}
+	}
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+	}{
+		{
+			name:     "plain string",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "pointer to string",
+			input:    func() interface{} { s := "hello"; return &s }(),
+			expected: "hello",
+		},
+		{
+			name:     "empty interface",
+			input:    interface{}(nil),
+			expected: nil,
+		},
+		{
+			name:     "interface containing string",
+			input:    interface{}("hello"),
+			expected: "hello",
+		},
+		{
+			name: "nested interfaces and pointers",
+			input: func() interface{} {
+				s := interface{}("test")
+				return &s
+			}(),
+			expected: "test",
+		},
+		{
+			name:     "custom string type",
+			input:    CustomString("hello"),
+			expected: CustomString("hello"),
+		},
+		{
+			name:     "interface containing custom string",
+			input:    interface{}(CustomString("hello")),
+			expected: CustomString("hello"),
+		},
+		{
+			name: "pointer to interface containing custom string",
+			input: func() interface{} {
+				i := interface{}(CustomString("hello"))
+				return &i
+			}(),
+			expected: CustomString("hello"),
+		},
+		{
+			name:     "int",
+			input:    42,
+			expected: 42,
+		},
+		{
+			name:     "custom int",
+			input:    CustomInt(42),
+			expected: CustomInt(42),
+		},
+		{
+			name: "deeply nested interfaces",
+			input: func() interface{} {
+				s := "test"
+				i1 := interface{}(s)
+				i2 := interface{}(&i1)
+				i3 := interface{}(&i2)
+				return &i3
+			}(),
+			expected: "test",
+		},
+		{
+			name: "struct containing interface",
+			input: Wrapper{
+				Value: "hello",
+			},
+			expected: Wrapper{Value: "hello"},
+		},
+		{
+			name:     "nil pointer to string",
+			input:    (*string)(nil),
+			expected: nil,
+		},
+		{
+			name: "interface containing nil pointer",
+			input: func() interface{} {
+				var s *string
+				return s
+			}(),
+			expected: nil,
+		},
+		{
+			name:     "slice of strings",
+			input:    []string{"hello", "world"},
+			expected: []string{"hello", "world"},
+		},
+		{
+			name:     "interface containing slice",
+			input:    interface{}([]string{"hello", "world"}),
+			expected: []string{"hello", "world"},
+		},
+		{
+			name:     "map of strings",
+			input:    map[string]string{"hello": "world"},
+			expected: map[string]string{"hello": "world"},
+		},
+		{
+			name: "interface containing map",
+			input: interface{}(map[string]string{
+				"hello": "world",
+			}),
+			expected: map[string]string{"hello": "world"},
+		},
+		{
+			name: "interface containing interface containing string",
+			input: func() interface{} {
+				s := interface{}("hello")
+				return interface{}(s)
+			}(),
+			expected: "hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := StripInterfaceFromValue(reflect.ValueOf(tt.input))
+			if tt.expected == nil {
+				assert.False(t, result.IsValid())
+			} else {
+				assert.Equal(t, tt.expected, result.Interface())
+			}
+		})
+	}
+}
+
+func TestStripInterfaceValue(t *testing.T) {
+	type CustomString string
+	type CustomInt int
+	type Wrapper struct {
+		Value interface{}
+	}
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+	}{
+		{
+			name:     "plain string",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "pointer to string",
+			input:    func() interface{} { s := "hello"; return &s }(),
+			expected: "hello",
+		},
+		{
+			name:     "empty interface",
+			input:    interface{}(nil),
+			expected: nil,
+		},
+		{
+			name:     "interface containing string",
+			input:    interface{}("hello"),
+			expected: "hello",
+		},
+		{
+			name: "nested interfaces and pointers",
+			input: func() interface{} {
+				s := interface{}("test")
+				return &s
+			}(),
+			expected: "test",
+		},
+		{
+			name:     "custom string type",
+			input:    CustomString("hello"),
+			expected: CustomString("hello"),
+		},
+		{
+			name:     "interface containing custom string",
+			input:    interface{}(CustomString("hello")),
+			expected: CustomString("hello"),
+		},
+		{
+			name: "pointer to interface containing custom string",
+			input: func() interface{} {
+				i := interface{}(CustomString("hello"))
+				return &i
+			}(),
+			expected: CustomString("hello"),
+		},
+		{
+			name:     "int",
+			input:    42,
+			expected: 42,
+		},
+		{
+			name:     "custom int",
+			input:    CustomInt(42),
+			expected: CustomInt(42),
+		},
+		{
+			name: "deeply nested interfaces",
+			input: func() interface{} {
+				s := "test"
+				i1 := interface{}(s)
+				i2 := interface{}(&i1)
+				i3 := interface{}(&i2)
+				return &i3
+			}(),
+			expected: "test",
+		},
+		{
+			name: "struct containing interface",
+			input: Wrapper{
+				Value: "hello",
+			},
+			expected: Wrapper{Value: "hello"},
+		},
+		{
+			name:     "nil pointer to string",
+			input:    (*string)(nil),
+			expected: nil,
+		},
+		{
+			name: "interface containing nil pointer",
+			input: func() interface{} {
+				var s *string
+				return s
+			}(),
+			expected: nil,
+		},
+		{
+			name:     "slice of strings",
+			input:    []string{"hello", "world"},
+			expected: []string{"hello", "world"},
+		},
+		{
+			name:     "interface containing slice",
+			input:    interface{}([]string{"hello", "world"}),
+			expected: []string{"hello", "world"},
+		},
+		{
+			name:     "map of strings",
+			input:    map[string]string{"hello": "world"},
+			expected: map[string]string{"hello": "world"},
+		},
+		{
+			name: "interface containing map",
+			input: interface{}(map[string]string{
+				"hello": "world",
+			}),
+			expected: map[string]string{"hello": "world"},
+		},
+		{
+			name: "interface containing interface containing string",
+			input: func() interface{} {
+				s := interface{}("hello")
+				return interface{}(s)
+			}(),
+			expected: "hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := StripInterfaceValue(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/lua/lua.go
+++ b/pkg/lua/lua.go
@@ -96,7 +96,11 @@ func ParseLuaTableMiddleware(L *lua.LState, luaTable *lua.LTable, layerName stri
 				return err
 			}
 
-			parsedLayers.GetOrCreate(layer).MergeParameters(parsedLayer)
+			err = parsedLayers.GetOrCreate(layer).MergeParameters(parsedLayer)
+			if err != nil {
+				return err
+			}
+
 			return next(layers_, parsedLayers)
 		}
 	}
@@ -112,7 +116,10 @@ func ParseNestedLuaTableMiddleware(L *lua.LState, luaTable *lua.LTable) middlewa
 			}
 
 			// Merge the new parsed layers with the existing ones
-			parsedLayers.Merge(newParsedLayers)
+			err = parsedLayers.Merge(newParsedLayers)
+			if err != nil {
+				return err
+			}
 
 			return next(layers_, parsedLayers)
 		}

--- a/pkg/settings/glazed_layer.go
+++ b/pkg/settings/glazed_layer.go
@@ -104,43 +104,23 @@ func (g *GlazedParameterLayers) GetParameterDefinitions() *parameters.ParameterD
 }
 
 func (g *GlazedParameterLayers) AddLayerToCobraCommand(cmd *cobra.Command) error {
-	err := g.OutputParameterLayer.AddLayerToCobraCommand(cmd)
-	if err != nil {
-		return err
-	}
-	err = g.FieldsFiltersParameterLayer.AddLayerToCobraCommand(cmd)
-	if err != nil {
-		return err
-	}
-	err = g.SelectParameterLayer.AddLayerToCobraCommand(cmd)
-	if err != nil {
-		return err
-	}
-	err = g.TemplateParameterLayer.AddLayerToCobraCommand(cmd)
-	if err != nil {
-		return err
-	}
-	err = g.RenameParameterLayer.AddLayerToCobraCommand(cmd)
-	if err != nil {
-		return err
-	}
-	err = g.ReplaceParameterLayer.AddLayerToCobraCommand(cmd)
-	if err != nil {
-		return err
-	}
-	err = g.JqParameterLayer.AddLayerToCobraCommand(cmd)
-	if err != nil {
-		return err
-	}
-	err = g.SortParameterLayer.AddLayerToCobraCommand(cmd)
-	if err != nil {
-		return err
-	}
-	err = g.SkipLimitParameterLayer.AddLayerToCobraCommand(cmd)
-	if err != nil {
-		return err
+	layers := []layers.CobraParameterLayer{
+		g.OutputParameterLayer,
+		g.FieldsFiltersParameterLayer,
+		g.SelectParameterLayer,
+		g.TemplateParameterLayer,
+		g.RenameParameterLayer,
+		g.ReplaceParameterLayer,
+		g.JqParameterLayer,
+		g.SortParameterLayer,
+		g.SkipLimitParameterLayer,
 	}
 
+	for _, layer := range layers {
+		if err := layer.AddLayerToCobraCommand(cmd); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -152,54 +132,30 @@ func (g *GlazedParameterLayers) ParseLayerFromCobraCommand(
 		Layer: g,
 	}
 	ps := parameters.NewParsedParameters()
-	l, err := g.OutputParameterLayer.ParseLayerFromCobraCommand(cmd, options...)
-	if err != nil {
-		return nil, err
+
+	layers := []layers.CobraParameterLayer{
+		g.OutputParameterLayer,
+		g.SelectParameterLayer,
+		g.RenameParameterLayer,
+		g.TemplateParameterLayer,
+		g.FieldsFiltersParameterLayer,
+		g.ReplaceParameterLayer,
+		g.JqParameterLayer,
+		g.SortParameterLayer,
+		g.SkipLimitParameterLayer,
 	}
-	ps.Merge(l.Parameters)
-	l, err = g.SelectParameterLayer.ParseLayerFromCobraCommand(cmd, options...)
-	if err != nil {
-		return nil, err
+
+	for _, layer := range layers {
+		l, err := layer.ParseLayerFromCobraCommand(cmd, options...)
+		if err != nil {
+			return nil, err
+		}
+		if _, err = ps.Merge(l.Parameters); err != nil {
+			return nil, err
+		}
 	}
-	ps.Merge(l.Parameters)
-	l, err = g.RenameParameterLayer.ParseLayerFromCobraCommand(cmd, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(l.Parameters)
-	l, err = g.TemplateParameterLayer.ParseLayerFromCobraCommand(cmd, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(l.Parameters)
-	l, err = g.FieldsFiltersParameterLayer.ParseLayerFromCobraCommand(cmd, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(l.Parameters)
-	l, err = g.ReplaceParameterLayer.ParseLayerFromCobraCommand(cmd, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(l.Parameters)
-	l, err = g.JqParameterLayer.ParseLayerFromCobraCommand(cmd, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(l.Parameters)
-	l, err = g.SortParameterLayer.ParseLayerFromCobraCommand(cmd, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(l.Parameters)
-	l, err = g.SkipLimitParameterLayer.ParseLayerFromCobraCommand(cmd, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(l.Parameters)
 
 	res.Parameters = ps
-
 	return res, nil
 }
 
@@ -207,92 +163,50 @@ func (g *GlazedParameterLayers) GatherParametersFromMap(
 	m map[string]interface{}, onlyProvided bool,
 	options ...parameters.ParseStepOption,
 ) (*parameters.ParsedParameters, error) {
-	ps, err := g.OutputParameterLayer.GatherParametersFromMap(m, onlyProvided, options...)
-	if err != nil {
-		return nil, err
+	ps := parameters.NewParsedParameters()
+
+	layers := []layers.ParameterLayer{
+		g.OutputParameterLayer,
+		g.SelectParameterLayer,
+		g.RenameParameterLayer,
+		g.TemplateParameterLayer,
+		g.FieldsFiltersParameterLayer,
+		g.ReplaceParameterLayer,
+		g.JqParameterLayer,
+		g.SortParameterLayer,
+		g.SkipLimitParameterLayer,
 	}
-	ps_, err := g.SelectParameterLayer.GatherParametersFromMap(m, onlyProvided, options...)
-	if err != nil {
-		return nil, err
+
+	for _, layer := range layers {
+		ps_, err := layer.GetParameterDefinitions().GatherParametersFromMap(m, onlyProvided, options...)
+		if err != nil {
+			return nil, err
+		}
+		if _, err = ps.Merge(ps_); err != nil {
+			return nil, err
+		}
 	}
-	ps.Merge(ps_)
-	ps_, err = g.RenameParameterLayer.GatherParametersFromMap(m, onlyProvided, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(ps_)
-	ps_, err = g.TemplateParameterLayer.GatherParametersFromMap(m, onlyProvided, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(ps_)
-	ps_, err = g.FieldsFiltersParameterLayer.GatherParametersFromMap(m, onlyProvided, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(ps_)
-	ps_, err = g.ReplaceParameterLayer.GatherParametersFromMap(m, onlyProvided, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(ps_)
-	ps_, err = g.JqParameterLayer.GatherParametersFromMap(m, onlyProvided, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(ps_)
-	ps_, err = g.SortParameterLayer.GatherParametersFromMap(m, onlyProvided, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(ps_)
-	ps_, err = g.SkipLimitParameterLayer.GatherParametersFromMap(m, onlyProvided, options...)
-	if err != nil {
-		return nil, err
-	}
-	ps.Merge(ps_)
 
 	return ps, nil
-
 }
 
 func (g *GlazedParameterLayers) InitializeParameterDefaultsFromStruct(s interface{}) error {
-	err := g.OutputParameterLayer.InitializeParameterDefaultsFromStruct(s)
-	if err != nil {
-		return err
-	}
-	err = g.FieldsFiltersParameterLayer.InitializeParameterDefaultsFromStruct(s)
-	if err != nil {
-		return err
+	layers := []layers.ParameterLayer{
+		g.OutputParameterLayer,
+		g.FieldsFiltersParameterLayer,
+		g.SelectParameterLayer,
+		g.TemplateParameterLayer,
+		g.RenameParameterLayer,
+		g.ReplaceParameterLayer,
+		g.JqParameterLayer,
+		g.SortParameterLayer,
+		g.SkipLimitParameterLayer,
 	}
 
-	err = g.SelectParameterLayer.InitializeParameterDefaultsFromStruct(s)
-	if err != nil {
-		return err
-	}
-	err = g.TemplateParameterLayer.InitializeParameterDefaultsFromStruct(s)
-	if err != nil {
-		return err
-	}
-	err = g.RenameParameterLayer.InitializeParameterDefaultsFromStruct(s)
-	if err != nil {
-		return err
-	}
-	err = g.ReplaceParameterLayer.InitializeParameterDefaultsFromStruct(s)
-	if err != nil {
-		return err
-	}
-	err = g.JqParameterLayer.InitializeParameterDefaultsFromStruct(s)
-	if err != nil {
-		return err
-	}
-	err = g.SortParameterLayer.InitializeParameterDefaultsFromStruct(s)
-	if err != nil {
-		return err
-	}
-	err = g.SkipLimitParameterLayer.InitializeParameterDefaultsFromStruct(s)
-	if err != nil {
-		return err
+	for _, layer := range layers {
+		if err := layer.InitializeParameterDefaultsFromStruct(s); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/settings/settings_fields-filters.go
+++ b/pkg/settings/settings_fields-filters.go
@@ -97,10 +97,16 @@ func (f *FieldsFiltersParameterLayer) ParseLayerFromCobraCommand(
 			p := &parameters.ParsedParameter{
 				ParameterDefinition: pd,
 			}
-			p.Update([]string{}, options_...)
+			err := p.Update([]string{}, options_...)
+			if err != nil {
+				return nil, errors.Wrap(err, "Failed to update filter parameter")
+			}
 			l.Parameters.Set("filter", p)
 		} else {
-			parsedFilter.Update([]string{}, options_...)
+			err := parsedFilter.Update([]string{}, options_...)
+			if err != nil {
+				return nil, errors.Wrap(err, "Failed to update filter parameter")
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR improves type safety and error handling around parameter value parsing and 
validation:

Key Changes:
- Add strict type checking when updating parameter values to ensure values match
  declared parameter types
- Propagate errors through parameter update/merge operations instead of silently
  failing
- Make map[string]string the concrete type for key-value parameters instead of
  map[string]interface{}
- Add helper functions to safely handle interface{} type stripping and validation
- Clean up redundant code in glazed layer implementations using loops over layer
  slices
- Add extensive tests for interface stripping and type conversion edge cases

Type Checking:
- Parameter values are now validated against their declared type before being set
- Invalid type conversions result in errors rather than silent failures
- Key-value parameters enforce string values

Error Handling:
- Parameter update operations now return errors
- Layer merges propagate errors up the call stack
- Consistent error wrapping and handling throughout

Test Coverage:
- Added comprehensive tests for interface type stripping
- Expanded tests for parameter type validation
- Added tests for error cases in parameter updates