### PR TITLE
Add helper to check for file validity when loading commands

### DIFF
--- a/pkg/cli/cobra-parser.go
+++ b/pkg/cli/cobra-parser.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
@@ -193,11 +194,13 @@ func (c *CobraParser) AddToCobraCommand(cmd *cobra.Command) error {
 		// if not, return an error
 		cobraLayer, ok := layer.(layers.CobraParameterLayer)
 		if !ok {
+			log.Error().Str("layer", layer.GetName()).Msg("Layer is not a CobraParameterLayer")
 			return errors.Errorf("layer %s is not a CobraParameterLayer", layer.GetName())
 		}
 
 		err := cobraLayer.AddLayerToCobraCommand(cmd)
 		if err != nil {
+			log.Error().Err(err).Str("layer", layer.GetName()).Msg("Could not add layer to cobra command")
 			return err
 		}
 

--- a/pkg/cli/cobra.go
+++ b/pkg/cli/cobra.go
@@ -47,10 +47,12 @@ func BuildCobraCommandFromCommandAndFunc(
 	cmd := NewCobraCommandFromCommandDescription(description)
 	cobraParser, err := NewCobraParserFromLayers(description.Layers, options...)
 	if err != nil {
+		log.Error().Err(err).Str("command", description.Name).Str("source", description.Source).Msg("Could not create cobra parser")
 		return nil, err
 	}
 	err = cobraParser.AddToCobraCommand(cmd)
 	if err != nil {
+		log.Error().Err(err).Str("command", description.Name).Str("source", description.Source).Msg("Could not add to cobra command")
 		return nil, err
 	}
 

--- a/pkg/cmds/loaders/loaders.go
+++ b/pkg/cmds/loaders/loaders.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/helpers/cast"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
 )
 
 // CommandLoader is an interface that describes the most generic loader type,
@@ -62,6 +63,33 @@ func LoadCommandOrAliasFromReader(
 
 	return cmds_, nil
 
+}
+
+// CheckYamlFileType checks if a yaml file has a specific type field value
+func CheckYamlFileType(f fs.FS, fileName string, expectedType string) bool {
+	f_, err := f.Open(fileName)
+	if err != nil {
+		return false
+	}
+	defer func(f_ fs.File) {
+		_ = f_.Close()
+	}(f_)
+
+	type commandType struct {
+		Type string `yaml:"type"`
+	}
+	var cmd commandType
+
+	content, err := io.ReadAll(f_)
+	if err != nil {
+		return false
+	}
+
+	err = yaml.Unmarshal(content, &cmd)
+	if err != nil {
+		return false
+	}
+	return cmd.Type == expectedType
 }
 
 func LoadCommandAliasFromYAML(s io.Reader, options ...alias.Option) ([]*alias.CommandAlias, error) {

--- a/pkg/cmds/parameters/cobra.go
+++ b/pkg/cmds/parameters/cobra.go
@@ -148,7 +148,7 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 
 		f := flagSet.Lookup(flagName)
 		if f != nil {
-			return errors.Errorf("Flag '%s' already exists", flagName)
+			return errors.Errorf("Flag '%s' (usage: %s) already exists", flagName, f.Usage)
 		}
 
 		helpText := parameter.Help

--- a/pkg/codegen/glazed.go
+++ b/pkg/codegen/glazed.go
@@ -22,10 +22,11 @@ func ParameterDefinitionToDict(p *parameters.ParameterDefinition) (jen.Code, err
 
 	if p.Default != nil {
 		var err error
-		ret[jen.Id("Default")], err = FlagValueToJen(p)
+		v, err := FlagValueToJen(p)
 		if err != nil {
 			return nil, err
 		}
+		ret[jen.Id("Default")] = jen.Qual("github.com/go-go-golems/glazed/pkg/helpers/cast", "InterfaceAddr").Call(v)
 	}
 	if p.Choices != nil {
 		ret[jen.Id("Choices")] = jen.Index().String().ValuesFunc(func(g *jen.Group) {

--- a/pkg/doc/topics/20-using-multi-loader.md
+++ b/pkg/doc/topics/20-using-multi-loader.md
@@ -25,7 +25,7 @@ The MultiLoader provides a flexible way to load commands from different file typ
 The MultiLoader works by first checking a file's `type` field (if present) and then dispatching to the appropriate registered loader. Here's how a typical command file with a type field looks:
 
 ```yaml
-type: sql
+type: sqleton
 name: query-users
 short: Query the users table
 flags:
@@ -110,7 +110,7 @@ commands, err := loader.LoadCommands(fs, "commands/unknown.txt", options, aliasO
 
 ### SQL Command
 ```yaml
-type: sql
+type: sqleton
 name: list-users
 short: List all users from database
 flags:


### PR DESCRIPTION
This PR adds functionality to validate command files by type before attempting 
to load them:

* Add `CheckYamlFileType` helper to verify YAML file type field
* Improve error messages for flag conflicts by including flag usage
* Fix code generation for default parameter values using `InterfaceAddr`
* Add more detailed error logging for command loading failures
* Update documentation examples to use "sqleton" instead of "sql" type

These changes improve error handling and diagnostics when loading commands, 
making it easier to identify issues with command files and flag conflicts.