### PR TITLE
Add regex filters for field filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,5 @@ bump-glazed:
 	go mod tidy
 
 install:
-	go build -o ./dist/glazed ./cmd/glazed && \
-		cp ./dist/glazed $(shell which glazed)
+	go build -o ./dist/glaze ./cmd/glaze && \
+		cp ./dist/glaze $(shell which glaze)

--- a/pkg/doc/examples/regex-filters/regex-filters.md
+++ b/pkg/doc/examples/regex-filters/regex-filters.md
@@ -1,0 +1,145 @@
+---
+Title: Filter fields using Regular Expressions
+Slug: regex-filters
+Short: |
+  ```
+  glaze json misc/test-data/sample.json --input-is-array --regex-fields "^name_.*" --regex-filters ".*_last$"
+  ```
+Topics:
+  - regex-filters
+  - regex-fields
+Commands:
+  - yaml
+  - json
+  - csv
+Flags:
+  - regex-fields
+  - regex-filters
+IsTemplate: false
+IsTopLevel: true
+ShowPerDefault: false
+SectionType: Example
+---
+
+You can use regular expressions to include or exclude fields from the output. This is useful when dealing with a large number of fields or fields with dynamic names.
+
+The `--regex-fields` flag allows you to specify regex patterns for fields you want to **include**.
+The `--regex-filters` flag allows you to specify regex patterns for fields you want to **exclude**.
+
+These flags can be combined with the standard `--fields` and `--filter` flags. The precedence rules are complex but generally, filters (both standard and regex) take precedence over includes. Exact matches (`--fields`, `--filter`) usually have higher priority than regex or prefix matches.
+
+Let's use the following sample data (`misc/test-data/sample.json`):
+
+```json
+[
+  {
+    "id": 1,
+    "name_first": "John",
+    "name_last": "Doe",
+    "address_street": "123 Main St",
+    "address_city": "Anytown",
+    "email": "john.doe@example.com",
+    "phone_home": "555-1234",
+    "phone_work": "555-5678"
+  },
+  {
+    "id": 2,
+    "name_first": "Jane",
+    "name_last": "Smith",
+    "address_street": "456 Oak Ave",
+    "address_city": "Otherville",
+    "email": "jane.smith@example.com",
+    "phone_home": "555-4321",
+    "phone_work": "555-8765"
+  }
+]
+```
+
+---
+
+## Examples
+
+### 1. Include fields starting with "name\_"
+
+```
+❯ glaze json misc/test-data/sample.json --input-is-array --regex-fields "^name_.*"
++------------+-----------+
+| name_first | name_last |
++------------+-----------+
+| John       | Doe       |
+| Jane       | Smith     |
++------------+-----------+
+```
+
+### 2. Include fields containing "address"
+
+```
+❯ glaze json misc/test-data/sample.json --input-is-array --regex-fields "address"
++----------------+--------------+
+| address_street | address_city |
++----------------+--------------+
+| 123 Main St    | Anytown      |
+| 456 Oak Ave    | Otherville   |
++----------------+--------------+
+```
+
+### 3. Exclude fields ending with "\_work"
+
+```
+❯ glaze json misc/test-data/sample.json --input-is-array --regex-filters "_work$"
++----+------------+-----------+----------------+--------------+------------------------+------------+
+| id | name_first | name_last | address_street | address_city | email                  | phone_home |
++----+------------+-----------+----------------+--------------+------------------------+------------+
+|  1 | John       | Doe       | 123 Main St    | Anytown      | john.doe@example.com   | 555-1234   |
+|  2 | Jane       | Smith     | 456 Oak Ave    | Otherville   | jane.smith@example.com | 555-4321   |
++----+------------+-----------+----------------+--------------+------------------------+------------+
+
+```
+
+### 4. Exclude fields related to "phone"
+
+```
+❯ glaze json misc/test-data/sample.json --input-is-array --regex-filters "^phone_.*"
++----+------------+-----------+----------------+--------------+------------------------+
+| id | name_first | name_last | address_street | address_city | email                  |
++----+------------+-----------+----------------+--------------+------------------------+
+|  1 | John       | Doe       | 123 Main St    | Anytown      | john.doe@example.com   |
+|  2 | Jane       | Smith     | 456 Oak Ave    | Otherville   | jane.smith@example.com |
++----+------------+-----------+----------------+--------------+------------------------+
+```
+
+### 5. Combine Regex Fields and Filters: Include "name\_" fields, exclude "\_last"
+
+```
+❯ glaze json misc/test-data/sample.json --input-is-array --regex-fields "^name_.*" --regex-filters "_last$"
++------------+
+| name_first |
++------------+
+| John       |
+| Jane       |
++------------+
+```
+
+### 6. Combine Regex and Standard Flags: Include "address" fields via regex, but specifically filter out "address_city"
+
+```
+❯ glaze json misc/test-data/sample.json --input-is-array --regex-fields "address" --filter address_city
++----------------+
+| address_street |
++----------------+
+| 123 Main St    |
+| 456 Oak Ave    |
++----------------+
+```
+
+### 7. Combine Regex and Standard Flags: Include "id" specifically, and all "phone" fields via regex
+
+```
+❯ glaze json misc/test-data/sample.json --input-is-array --fields id --regex-fields "^phone_.*"
++----+------------+------------+
+| id | phone_home | phone_work |
++----+------------+------------+
+|  1 | 555-1234   | 555-5678   |
+|  2 | 555-4321   | 555-8765   |
++----+------------+------------+
+```

--- a/pkg/middlewares/row/add-field_test.go
+++ b/pkg/middlewares/row/add-field_test.go
@@ -1,12 +1,11 @@
 package row
 
 import (
-	"context"
+	"testing"
+
 	assert2 "github.com/go-go-golems/glazed/pkg/helpers/assert"
-	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func createAddFieldTestRows() []types.Row {
@@ -41,19 +40,6 @@ func TestSingleAddField(t *testing.T) {
 	assert2.EqualRowValue(t, "value1", row, "field1")
 	assert2.EqualRowValue(t, "value3 blabla", row, "field2")
 	assert2.EqualRowValue(t, "value3", row, "field3")
-}
-
-func processRows(rm middlewares.RowMiddleware, rows []types.Row) ([]types.Row, error) {
-	finalRows := make([]types.Row, 0)
-	for _, row := range rows {
-		rows_, err := rm.Process(context.Background(), row)
-		if err != nil {
-			return nil, err
-		}
-		finalRows = append(finalRows, rows_...)
-	}
-
-	return finalRows, nil
 }
 
 func TestMultipleAddField(t *testing.T) {

--- a/pkg/middlewares/row/fields-filter.go
+++ b/pkg/middlewares/row/fields-filter.go
@@ -2,10 +2,12 @@ package row
 
 import (
 	"context"
+	"regexp"
+	"strings"
+
 	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
-	"strings"
 )
 
 // FieldsFilterMiddleware keeps columns that are in the fields list and removes
@@ -19,8 +21,60 @@ type FieldsFilterMiddleware struct {
 	filters       *orderedmap.OrderedMap[string, interface{}]
 	prefixFields  []string
 	prefixFilters []string
+	regexFields   []*regexp.Regexp
+	regexFilters  []*regexp.Regexp
 
 	newColumns map[types.FieldName]interface{}
+}
+
+type FieldsFilterOption func(*FieldsFilterMiddleware)
+
+// WithFields adds exact field matches to keep
+func WithFields(fields []string) FieldsFilterOption {
+	return func(ffm *FieldsFilterMiddleware) {
+		for _, field := range fields {
+			if strings.HasSuffix(field, ".") {
+				ffm.prefixFields = append(ffm.prefixFields, field)
+			} else {
+				ffm.fields.Set(field, nil)
+			}
+		}
+	}
+}
+
+// WithFilters adds exact field matches to remove
+func WithFilters(filters []string) FieldsFilterOption {
+	return func(ffm *FieldsFilterMiddleware) {
+		for _, filter := range filters {
+			if strings.HasSuffix(filter, ".") {
+				ffm.prefixFilters = append(ffm.prefixFilters, filter)
+			} else {
+				ffm.filters.Set(filter, nil)
+			}
+		}
+	}
+}
+
+// WithRegexFields adds regex patterns for fields to keep
+func WithRegexFields(patterns []string) FieldsFilterOption {
+	return func(ffm *FieldsFilterMiddleware) {
+		for _, pattern := range patterns {
+			if re, err := regexp.Compile(pattern); err == nil {
+				ffm.regexFields = append(ffm.regexFields, re)
+			}
+		}
+	}
+}
+
+// WithRegexFilters adds regex patterns for fields to remove
+func WithRegexFilters(patterns []string) FieldsFilterOption {
+	return func(ffm *FieldsFilterMiddleware) {
+		for _, pattern := range patterns {
+			if re, err := regexp.Compile(pattern); err == nil {
+				ffm.regexFilters = append(ffm.regexFilters, re)
+			}
+		}
+	}
 }
 
 var _ middlewares.RowMiddleware = (*FieldsFilterMiddleware)(nil)
@@ -29,37 +83,25 @@ func (ffm *FieldsFilterMiddleware) Close(ctx context.Context) error {
 	return nil
 }
 
-func NewFieldsFilterMiddleware(fields []string, filters []string) *FieldsFilterMiddleware {
-	fieldHash := orderedmap.New[string, interface{}]()
-	prefixFields := []string{}
-	prefixFilters := []string{}
+// NewFieldsFilterMiddleware creates a new FieldsFilterMiddleware with the given options
+func NewFieldsFilterMiddleware(options ...FieldsFilterOption) *FieldsFilterMiddleware {
+	ffm := &FieldsFilterMiddleware{
+		fields:     orderedmap.New[string, interface{}](),
+		filters:    orderedmap.New[string, interface{}](),
+		newColumns: map[types.FieldName]interface{}{},
+	}
 
-	for _, field := range fields {
-		if strings.HasSuffix(field, ".") {
-			prefixFields = append(prefixFields, field)
-		} else {
-			fieldHash.Set(field, nil)
-		}
+	for _, option := range options {
+		option(ffm)
 	}
-	filterHash := orderedmap.New[string, interface{}]()
-	for _, filter := range filters {
-		if strings.HasSuffix(filter, ".") {
-			prefixFilters = append(prefixFilters, filter)
-		} else {
-			filterHash.Set(filter, nil)
-		}
-	}
-	return &FieldsFilterMiddleware{
-		fields:        fieldHash,
-		filters:       filterHash,
-		prefixFields:  prefixFields,
-		prefixFilters: prefixFilters,
-		newColumns:    map[types.FieldName]interface{}{},
-	}
+
+	return ffm
 }
 
 func (ffm *FieldsFilterMiddleware) Process(ctx context.Context, row types.Row) ([]types.Row, error) {
-	if ffm.fields.Len() == 0 && ffm.filters.Len() == 0 {
+	if ffm.fields.Len() == 0 && ffm.filters.Len() == 0 &&
+		len(ffm.prefixFields) == 0 && len(ffm.prefixFilters) == 0 &&
+		len(ffm.regexFields) == 0 && len(ffm.regexFilters) == 0 {
 		return []types.Row{row}, nil
 	}
 
@@ -68,70 +110,105 @@ func (ffm *FieldsFilterMiddleware) Process(ctx context.Context, row types.Row) (
 	for pair := row.Oldest(); pair != nil; pair = pair.Next() {
 		rowField, value := pair.Key, pair.Value
 
-		// skip all of this if we already filtered that field
+		// skip if we already filtered that field
 		if _, ok := ffm.newColumns[rowField]; !ok {
 			exactMatchFound := false
 			prefixMatchFound := false
+			regexMatchFound := false
 
 			exactFilterMatchFound := false
 			prefixFilterMatchFound := false
+			regexFilterMatchFound := false
 
-			// go through all the fields and prefix fields and check if the current field matches
-			if ffm.fields.Len() > 0 || len(ffm.prefixFields) > 0 {
-				// first go through exact matches
+			// Check exact matches
+			if ffm.fields.Len() > 0 {
 				if _, ok := ffm.fields.Get(rowField); ok {
 					exactMatchFound = true
-				} else {
-					// else, test against all prefixes
-					for _, prefix := range ffm.prefixFields {
-						if strings.HasPrefix(rowField, prefix) {
-							prefixMatchFound = true
-							break
-						}
-					}
-				}
-
-				if !exactMatchFound && !prefixMatchFound {
-					continue
 				}
 			}
 
-			if ffm.filters.Len() > 0 || len(ffm.prefixFilters) > 0 {
-				// if an exact filter matches, move on
+			// Check prefix matches
+			if !exactMatchFound && len(ffm.prefixFields) > 0 {
+				for _, prefix := range ffm.prefixFields {
+					if strings.HasPrefix(rowField, prefix) {
+						prefixMatchFound = true
+						break
+					}
+				}
+			}
+
+			// Check regex matches
+			if !exactMatchFound && !prefixMatchFound && len(ffm.regexFields) > 0 {
+				for _, re := range ffm.regexFields {
+					if re.MatchString(rowField) {
+						regexMatchFound = true
+						break
+					}
+				}
+			}
+
+			// Check filters
+			if ffm.filters.Len() > 0 {
 				if _, ok := ffm.filters.Get(rowField); ok {
 					exactFilterMatchFound = true
-					continue
-				} else {
-					// else, test against all prefixes
-					for _, prefix := range ffm.prefixFilters {
-						if strings.HasPrefix(rowField, prefix) {
-							prefixFilterMatchFound = true
-							break
-						}
+				}
+			}
+
+			if !exactFilterMatchFound && len(ffm.prefixFilters) > 0 {
+				for _, prefix := range ffm.prefixFilters {
+					if strings.HasPrefix(rowField, prefix) {
+						prefixFilterMatchFound = true
+						break
 					}
 				}
 			}
 
+			if !exactFilterMatchFound && !prefixFilterMatchFound && len(ffm.regexFilters) > 0 {
+				for _, re := range ffm.regexFilters {
+					if re.MatchString(rowField) {
+						regexFilterMatchFound = true
+						break
+					}
+				}
+			}
+
+			// Determine if field should be included
+			shouldInclude := false
+
 			if exactMatchFound {
-				ffm.newColumns[rowField] = nil
+				shouldInclude = true
 			} else if prefixMatchFound {
 				if prefixFilterMatchFound {
-					// should we do by prefix length, nah...
-					// choose to include by default
-					ffm.newColumns[rowField] = nil
+					// Include by default when both prefix match
+					shouldInclude = true
 				} else if exactFilterMatchFound {
-					continue
+					shouldInclude = false
 				} else {
-					ffm.newColumns[rowField] = nil
+					shouldInclude = true
 				}
-			} else if exactFilterMatchFound {
-				continue
-			} else if ffm.fields.Len() == 0 {
-				ffm.newColumns[rowField] = nil
+			} else if regexMatchFound {
+				if regexFilterMatchFound {
+					// Include by default when both regex match
+					shouldInclude = true
+				} else if exactFilterMatchFound {
+					shouldInclude = false
+				} else {
+					shouldInclude = true
+				}
+			} else if exactFilterMatchFound || prefixFilterMatchFound || regexFilterMatchFound {
+				shouldInclude = false
+			} else if ffm.fields.Len() == 0 && len(ffm.prefixFields) == 0 && len(ffm.regexFields) == 0 {
+				// If no fields specified, include everything not filtered
+				shouldInclude = true
 			}
-		}
 
-		newRow.Set(rowField, value)
+			if shouldInclude {
+				ffm.newColumns[rowField] = nil
+				newRow.Set(rowField, value)
+			}
+		} else {
+			newRow.Set(rowField, value)
+		}
 	}
 
 	return []types.Row{newRow}, nil

--- a/pkg/middlewares/row/fields-filter_test.go
+++ b/pkg/middlewares/row/fields-filter_test.go
@@ -1,10 +1,13 @@
 package row
 
 import (
+	"context"
+	"testing"
+
 	assert2 "github.com/go-go-golems/glazed/pkg/helpers/assert"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func createFieldsFilterTestRows() []types.Row {
@@ -13,77 +16,166 @@ func createFieldsFilterTestRows() []types.Row {
 			types.MRP("a", 1),
 			types.MRP("b", 2),
 			types.MRP("c", 3),
+			types.MRP("test1", "value1"),
+			types.MRP("test2", "value2"),
+			types.MRP("other1", "other1"),
 		),
 		types.NewRow(
 			types.MRP("a", 4),
 			types.MRP("b", 5),
 			types.MRP("c", 6),
-		),
-		types.NewRow(
-			types.MRP("a", 7),
-			types.MRP("b", 8),
-			types.MRP("c", 9),
-			types.MRP("d", 10),
+			types.MRP("test3", "value3"),
+			types.MRP("test4", "value4"),
+			types.MRP("other2", "other2"),
 		),
 	}
 }
 
 func TestNoFieldsFilter(t *testing.T) {
-	mw := NewFieldsFilterMiddleware([]string{}, []string{})
+	mw := NewFieldsFilterMiddleware()
 
 	rows := createFieldsFilterTestRows()
 	finalRows, err := processRows(mw, rows)
 	require.NoError(t, err)
-	require.Len(t, finalRows, 3)
-	assert2.EqualRowValues(t, rows[0], map[string]interface{}{"a": 1, "b": 2, "c": 3})
-	assert2.EqualRowValues(t, rows[1], map[string]interface{}{"a": 4, "b": 5, "c": 6})
-	assert2.EqualRowValues(t, rows[2], map[string]interface{}{"a": 7, "b": 8, "c": 9, "d": 10})
+	require.Len(t, finalRows, 2)
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{
+		"a": 1, "b": 2, "c": 3,
+		"test1": "value1", "test2": "value2",
+		"other1": "other1",
+	})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{
+		"a": 4, "b": 5, "c": 6,
+		"test3": "value3", "test4": "value4",
+		"other2": "other2",
+	})
 }
 
 func TestFieldsA(t *testing.T) {
-	mw := NewFieldsFilterMiddleware([]string{"a"}, []string{})
+	mw := NewFieldsFilterMiddleware(WithFields([]string{"a"}))
 
 	rows := createFieldsFilterTestRows()
 	finalRows, err := processRows(mw, rows)
 	require.NoError(t, err)
-	require.Len(t, finalRows, 3)
+	require.Len(t, finalRows, 2)
 	assert2.EqualRowValues(t, rows[0], map[string]interface{}{"a": 1})
 	assert2.EqualRowValues(t, rows[1], map[string]interface{}{"a": 4})
-	assert2.EqualRowValues(t, rows[2], map[string]interface{}{"a": 7})
 }
 
 func TestFieldsBD(t *testing.T) {
-	mw := NewFieldsFilterMiddleware([]string{"b", "d"}, []string{})
+	mw := NewFieldsFilterMiddleware(WithFields([]string{"b", "d"}))
 
 	rows := createFieldsFilterTestRows()
 	finalRows, err := processRows(mw, rows)
 	require.NoError(t, err)
-	require.Len(t, finalRows, 3)
+	require.Len(t, finalRows, 2)
 	assert2.EqualRowValues(t, rows[0], map[string]interface{}{"b": 2})
 	assert2.EqualRowValues(t, rows[1], map[string]interface{}{"b": 5})
-	assert2.EqualRowValues(t, rows[2], map[string]interface{}{"b": 8, "d": 10})
 }
 
 func TestFilterA(t *testing.T) {
-	mw := NewFieldsFilterMiddleware([]string{}, []string{"a"})
+	mw := NewFieldsFilterMiddleware(WithFilters([]string{"a"}))
 
 	rows := createFieldsFilterTestRows()
 	finalRows, err := processRows(mw, rows)
 	require.NoError(t, err)
-	require.Len(t, finalRows, 3)
-	assert2.EqualRowValues(t, rows[0], map[string]interface{}{"b": 2, "c": 3})
-	assert2.EqualRowValues(t, rows[1], map[string]interface{}{"b": 5, "c": 6})
-	assert2.EqualRowValues(t, rows[2], map[string]interface{}{"b": 8, "c": 9, "d": 10})
+	require.Len(t, finalRows, 2)
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{
+		"b": 2, "c": 3,
+		"test1": "value1", "test2": "value2",
+		"other1": "other1",
+	})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{
+		"b": 5, "c": 6,
+		"test3": "value3", "test4": "value4",
+		"other2": "other2",
+	})
 }
 
 func TestFilterBD(t *testing.T) {
-	mw := NewFieldsFilterMiddleware([]string{}, []string{"b", "d"})
+	mw := NewFieldsFilterMiddleware(WithFilters([]string{"b", "d"}))
 
 	rows := createFieldsFilterTestRows()
 	finalRows, err := processRows(mw, rows)
 	require.NoError(t, err)
-	require.Len(t, finalRows, 3)
-	assert2.EqualRowValues(t, rows[0], map[string]interface{}{"a": 1, "c": 3})
-	assert2.EqualRowValues(t, rows[1], map[string]interface{}{"a": 4, "c": 6})
-	assert2.EqualRowValues(t, rows[2], map[string]interface{}{"a": 7, "c": 9})
+	require.Len(t, finalRows, 2)
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{
+		"a": 1, "c": 3,
+		"test1": "value1", "test2": "value2",
+		"other1": "other1",
+	})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{
+		"a": 4, "c": 6,
+		"test3": "value3", "test4": "value4",
+		"other2": "other2",
+	})
+}
+
+func TestRegexFields(t *testing.T) {
+	mw := NewFieldsFilterMiddleware(WithRegexFields([]string{"^test[0-9]+$"}))
+
+	rows := createFieldsFilterTestRows()
+	finalRows, err := processRows(mw, rows)
+	require.NoError(t, err)
+	require.Len(t, finalRows, 2)
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{
+		"test1": "value1",
+		"test2": "value2",
+	})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{
+		"test3": "value3",
+		"test4": "value4",
+	})
+}
+
+func TestRegexFilters(t *testing.T) {
+	mw := NewFieldsFilterMiddleware(WithRegexFilters([]string{"^test[0-9]+$"}))
+
+	rows := createFieldsFilterTestRows()
+	finalRows, err := processRows(mw, rows)
+	require.NoError(t, err)
+	require.Len(t, finalRows, 2)
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{
+		"a": 1, "b": 2, "c": 3,
+		"other1": "other1",
+	})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{
+		"a": 4, "b": 5, "c": 6,
+		"other2": "other2",
+	})
+}
+
+func TestCombinedFilters(t *testing.T) {
+	mw := NewFieldsFilterMiddleware(
+		WithFields([]string{"a"}),
+		WithRegexFields([]string{"^test[0-9]+$"}),
+		WithFilters([]string{"test1"}),
+		WithRegexFilters([]string{"^other[0-9]+$"}),
+	)
+
+	rows := createFieldsFilterTestRows()
+	finalRows, err := processRows(mw, rows)
+	require.NoError(t, err)
+	require.Len(t, finalRows, 2)
+	assert2.EqualRowValues(t, rows[0], map[string]interface{}{
+		"a":     1,
+		"test2": "value2",
+	})
+	assert2.EqualRowValues(t, rows[1], map[string]interface{}{
+		"a":     4,
+		"test3": "value3",
+		"test4": "value4",
+	})
+}
+
+func processRows(rm middlewares.RowMiddleware, rows []types.Row) ([]types.Row, error) {
+	finalRows := make([]types.Row, 0)
+	for _, row := range rows {
+		rows_, err := rm.Process(context.Background(), row)
+		if err != nil {
+			return nil, err
+		}
+		finalRows = append(finalRows, rows_...)
+	}
+
+	return finalRows, nil
 }

--- a/pkg/settings/flags/fields-filters.yaml
+++ b/pkg/settings/flags/fields-filters.yaml
@@ -15,6 +15,16 @@ flags:
     help: Fields to remove from output
     default: []
 
+  - name: regex-fields
+    type: stringList
+    help: Regex patterns for fields to include
+    default: []
+
+  - name: regex-filters
+    type: stringList
+    help: Regex patterns for fields to remove
+    default: []
+
   - name: sort-columns
     type: bool
     help: Sort columns alphabetically

--- a/pkg/settings/settings_fields-filters.go
+++ b/pkg/settings/settings_fields-filters.go
@@ -131,7 +131,7 @@ func NewFieldsFilterSettings(glazedLayer *layers.ParsedLayer) (*FieldsFilterSett
 }
 
 func (ffs *FieldsFilterSettings) AddMiddlewares(p_ *middlewares.TableProcessor) {
-	p_.AddRowMiddleware(row.NewFieldsFilterMiddleware(ffs.Fields, ffs.Filters))
+	p_.AddRowMiddleware(row.NewFieldsFilterMiddleware(row.WithFields(ffs.Fields), row.WithFilters(ffs.Filters)))
 	if ffs.RemoveNulls {
 		p_.AddRowMiddleware(row.NewRemoveNullsMiddleware())
 	}

--- a/pkg/settings/settings_fields-filters.go
+++ b/pkg/settings/settings_fields-filters.go
@@ -17,6 +17,8 @@ var fieldsFiltersFlagsYaml []byte
 type FieldsFilterFlagsDefaults struct {
 	Fields           []string `glazed.parameter:"fields"`
 	Filter           []string `glazed.parameter:"filter"`
+	RegexFields      []string `glazed.parameter:"regex-fields"`
+	RegexFilters     []string `glazed.parameter:"regex-filters"`
 	SortColumns      bool     `glazed.parameter:"sort-columns"`
 	RemoveNulls      bool     `glazed.parameter:"remove-nulls"`
 	RemoveDuplicates []string `glazed.parameter:"remove-duplicates"`
@@ -38,6 +40,8 @@ func (f *FieldsFiltersParameterLayer) Clone() layers.ParameterLayer {
 type FieldsFilterSettings struct {
 	Filters          []string `glazed.parameter:"filter"`
 	Fields           []string `glazed.parameter:"fields"`
+	RegexFields      []string `glazed.parameter:"regex-fields"`
+	RegexFilters     []string `glazed.parameter:"regex-filters"`
 	SortColumns      bool     `glazed.parameter:"sort-columns"`
 	RemoveNulls      bool     `glazed.parameter:"remove-nulls"`
 	RemoveDuplicates []string `glazed.parameter:"remove-duplicates"`
@@ -131,7 +135,13 @@ func NewFieldsFilterSettings(glazedLayer *layers.ParsedLayer) (*FieldsFilterSett
 }
 
 func (ffs *FieldsFilterSettings) AddMiddlewares(p_ *middlewares.TableProcessor) {
-	p_.AddRowMiddleware(row.NewFieldsFilterMiddleware(row.WithFields(ffs.Fields), row.WithFilters(ffs.Filters)))
+	opts := []row.FieldsFilterOption{
+		row.WithFields(ffs.Fields),
+		row.WithFilters(ffs.Filters),
+		row.WithRegexFields(ffs.RegexFields),
+		row.WithRegexFilters(ffs.RegexFilters),
+	}
+	p_.AddRowMiddleware(row.NewFieldsFilterMiddleware(opts...))
 	if ffs.RemoveNulls {
 		p_.AddRowMiddleware(row.NewRemoveNullsMiddleware())
 	}


### PR DESCRIPTION
This PR adds regex-based filtering capabilities to the fields filter 
middleware.

## Changes

- Add regex pattern support for field inclusion and exclusion
- Refactor `FieldsFilterMiddleware` to use functional options pattern
- Add new command line flags: `--regex-fields` and `--regex-filters`
- Improve field filtering logic to handle combinations of filters
- Add comprehensive tests for regex filtering

## Usage

Users can now filter fields using regex patterns:

```
# Include only fields that match the pattern
--regex-fields "^test[0-9]+$"

# Exclude fields that match the pattern
--regex-filters "^temp_.*$"

# Combine with existing filters
--fields id,name --regex-fields "^meta_.*$" --filter timestamp
```

The precedence rules ensure predictable behavior when combining different filter
types.