### PR TITLE
Add JSONL support and map helper functions

### DIFF
--- a/pkg/cmds/parameters/parse.go
+++ b/pkg/cmds/parameters/parse.go
@@ -632,7 +632,7 @@ func (p *ParameterDefinition) parseObjectListFromReader(
 		if err != nil {
 			return nil, err
 		}
-	} else if strings.HasSuffix(filename, ".ndjson") {
+	} else if strings.HasSuffix(filename, ".ndjson") || strings.HasSuffix(filename, ".jsonl") {
 		scanner := bufio.NewScanner(f)
 		for scanner.Scan() {
 			line := scanner.Text()


### PR DESCRIPTION
This PR adds two main features:

* Support for `.jsonl` file extension in object list parameters (in addition to
  existing `.ndjson` support)
* New map helper functions for safely accessing nested values:
  * `Get[T]()` - Generic accessor for retrieving typed values from nested maps
  * `GetString()` - Convenience function for string values
  * `GetInteger[T]()` - Accessor for integer values with type conversion support