### PR TITLE
Add --log-to-stdout flag for simultaneous file and stdout logging

### DIFF
--- a/pkg/cmds/logging/init.go
+++ b/pkg/cmds/logging/init.go
@@ -46,10 +46,13 @@ func InitLoggerFromSettings(settings *LoggingSettings) error {
 				TimeFormat: time.RFC3339Nano,
 			}
 		}
-		// TODO(manuel, 2024-07-05) We used to support logging to file *and* stderr, but disabling that for now
-		// because it makes logging in UI apps tricky.
-		// logWriter = io.MultiWriter(logWriter, writer)
-		logWriter = writer
+
+		// If LogToStdout is enabled, log to both file and stdout
+		if settings.LogToStdout {
+			logWriter = io.MultiWriter(logWriter, writer)
+		} else {
+			logWriter = writer
+		}
 	}
 
 	// Configure Logstash logging if enabled
@@ -103,6 +106,7 @@ func InitLoggerFromSettings(settings *LoggingSettings) error {
 	log.Logger.Debug().Str("format", settings.LogFormat).
 		Str("level", settings.LogLevel).
 		Str("file", settings.LogFile).
+		Bool("logToStdout", settings.LogToStdout).
 		Bool("logstash", settings.LogstashEnabled).
 		Msg("Logger initialized")
 
@@ -116,6 +120,7 @@ func InitLoggerFromViper() error {
 		LogFile:             viper.GetString("log-file"),
 		LogFormat:           viper.GetString("log-format"),
 		WithCaller:          viper.GetBool("with-caller"),
+		LogToStdout:         viper.GetBool("log-to-stdout"),
 		LogstashEnabled:     viper.GetBool("logstash-enabled"),
 		LogstashHost:        viper.GetString("logstash-host"),
 		LogstashPort:        viper.GetInt("logstash-port"),

--- a/pkg/cmds/logging/layer.go
+++ b/pkg/cmds/logging/layer.go
@@ -13,6 +13,7 @@ type LoggingSettings struct {
 	LogLevel            string `glazed.parameter:"log-level"`
 	LogFormat           string `glazed.parameter:"log-format"`
 	LogFile             string `glazed.parameter:"log-file"`
+	LogToStdout         bool   `glazed.parameter:"log-to-stdout"`
 	LogstashEnabled     bool   `glazed.parameter:"logstash-enabled"`
 	LogstashHost        string `glazed.parameter:"logstash-host"`
 	LogstashPort        int    `glazed.parameter:"logstash-port"`
@@ -54,6 +55,12 @@ func NewLoggingLayer() (layers.ParameterLayer, error) {
 				parameters.ParameterTypeString,
 				parameters.WithHelp("Log file (default: stderr)"),
 				parameters.WithDefault(""),
+			),
+			parameters.NewParameterDefinition(
+				"log-to-stdout",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Log to stdout even when log-file is set"),
+				parameters.WithDefault(false),
 			),
 			parameters.NewParameterDefinition(
 				"logstash-enabled",
@@ -128,6 +135,7 @@ func AddLoggingLayerToRootCommand(rootCmd *cobra.Command, appName string) error 
 	rootCmd.PersistentFlags().String("log-file", "", "Log file (default: stderr)")
 	rootCmd.PersistentFlags().String("log-format", "text", "Log format (json, text)")
 	rootCmd.PersistentFlags().Bool("with-caller", false, "Log caller information")
+	rootCmd.PersistentFlags().Bool("log-to-stdout", false, "Log to stdout even when log-file is set")
 
 	// Add logstash flags
 	rootCmd.PersistentFlags().Bool("logstash-enabled", false, "Enable logging to Logstash")


### PR DESCRIPTION
This PR adds a new `--log-to-stdout` flag that enables logging to both a file and 
stdout simultaneously when a log file is specified.