### PR TITLE
Add secret parameter type with masked display

### DIFF
--- a/cmd/examples/parameter-types/README.md
+++ b/cmd/examples/parameter-types/README.md
@@ -1,0 +1,96 @@
+# Parameter Types Example
+
+This example demonstrates all parameter types available in the glazed framework.
+
+## Usage
+
+```bash
+# Build the example
+go build -o parameter-types .
+
+# Show help to see all available parameters
+./parameter-types --help
+
+# Run with default values
+./parameter-types
+
+# Test basic types
+./parameter-types \
+  --string-param "hello world" \
+  --secret-param "my-secret" \
+  --integer-param 100 \
+  --float-param 2.71828 \
+  --bool-param=false \
+  --date-param "2024-12-25" \
+  --choice-param option2
+
+# Test list types
+./parameter-types \
+  --string-list-param item1,item2,item3 \
+  --integer-list-param 10,20,30 \
+  --float-list-param 1.1,2.2,3.3 \
+  --choice-list-param red,green
+
+# Test file types
+./parameter-types \
+  --file-param sample.json \
+  --file-list-param sample.json,sample.yaml \
+  --string-from-file-param sample-text.txt \
+  --string-list-from-file-param sample-lines.txt \
+  --object-from-file-param sample.json \
+  --object-list-from-file-param sample-list.json
+
+# Test key-value type
+./parameter-types \
+  --key-value-param key1:value1,key2:value2
+
+# Load key-value from file
+./parameter-types \
+  --key-value-param @config.yaml
+```
+
+## Parameter Types Demonstrated
+
+### Basic Types
+- **string**: Simple text values
+- **secret**: Text values that are masked when displayed (***) 
+- **integer**: Whole numbers
+- **float**: Decimal numbers
+- **bool**: Boolean true/false values
+- **date**: Date/time values (RFC3339 or natural language)
+- **choice**: Single value from predefined options
+
+### List Types  
+- **string-list**: Multiple text values
+- **integer-list**: Multiple integers
+- **float-list**: Multiple decimal numbers
+- **choice-list**: Multiple values from predefined options
+
+### File Types
+- **file**: Load file with metadata (path, size, type, etc.)
+- **file-list**: Load multiple files with metadata
+- **string-from-file**: Load file content as a single string
+- **string-from-files**: Load and concatenate multiple files as string
+- **string-list-from-file**: Load file lines as string list
+- **string-list-from-files**: Load lines from multiple files as string list
+- **object-from-file**: Parse JSON/YAML file as object
+- **object-list-from-file**: Parse JSON/YAML file as object list  
+- **object-list-from-files**: Parse multiple files and merge object lists
+
+### Key-Value Type
+- **key-value**: Map of key-value pairs (key:value format or @file)
+
+## Sample Files
+
+- `sample.json` - JSON object for testing object parameters
+- `sample.yaml` - YAML data for testing YAML parsing
+- `sample-list.json` - JSON array for testing list parameters
+- `sample-text.txt` - Multi-line text for string parameters
+- `sample-lines.txt` - Line-by-line text for list parameters
+- `config.yaml` - Configuration file for key-value parameters
+
+## Output
+
+The program displays all parsed parameter values in a structured format, demonstrating how each type is processed and what the final values look like.
+
+Note that secret parameters will show as `***` in the output to protect sensitive data.

--- a/cmd/examples/parameter-types/config.yaml
+++ b/cmd/examples/parameter-types/config.yaml
@@ -1,0 +1,10 @@
+database:
+  host: localhost
+  port: 5432
+  username: admin
+  password: secret
+
+server:
+  host: 0.0.0.0
+  port: 8080
+  debug: true

--- a/cmd/examples/parameter-types/main.go
+++ b/cmd/examples/parameter-types/main.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/help"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type ParameterTypesSettings struct {
+	// Basic types
+	StringParam  string    `glazed.parameter:"string-param"`
+	SecretParam  string    `glazed.parameter:"secret-param"`
+	IntegerParam int       `glazed.parameter:"integer-param"`
+	FloatParam   float64   `glazed.parameter:"float-param"`
+	BoolParam    bool      `glazed.parameter:"bool-param"`
+	DateParam    time.Time `glazed.parameter:"date-param"`
+	ChoiceParam  string    `glazed.parameter:"choice-param"`
+
+	// List types
+	StringListParam  []string  `glazed.parameter:"string-list-param"`
+	IntegerListParam []int     `glazed.parameter:"integer-list-param"`
+	FloatListParam   []float64 `glazed.parameter:"float-list-param"`
+	ChoiceListParam  []string  `glazed.parameter:"choice-list-param"`
+
+	// File types
+	FileParam                *parameters.FileData     `glazed.parameter:"file-param"`
+	FileListParam            []*parameters.FileData   `glazed.parameter:"file-list-param"`
+	StringFromFileParam      string                   `glazed.parameter:"string-from-file-param"`
+	StringFromFilesParam     string                   `glazed.parameter:"string-from-files-param"`
+	StringListFromFileParam  []string                 `glazed.parameter:"string-list-from-file-param"`
+	StringListFromFilesParam []string                 `glazed.parameter:"string-list-from-files-param"`
+	ObjectFromFileParam      map[string]interface{}   `glazed.parameter:"object-from-file-param"`
+	ObjectListFromFileParam  []map[string]interface{} `glazed.parameter:"object-list-from-file-param"`
+	ObjectListFromFilesParam []map[string]interface{} `glazed.parameter:"object-list-from-files-param"`
+
+	// Key-value type
+	KeyValueParam map[string]string `glazed.parameter:"key-value-param"`
+}
+
+type ParameterTypesCommand struct {
+	*cmds.CommandDescription
+}
+
+var _ cmds.GlazeCommand = (*ParameterTypesCommand)(nil)
+
+func NewParameterTypesCommand() (*ParameterTypesCommand, error) {
+	glazedParameterLayer, err := settings.NewGlazedParameterLayers()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create Glazed parameter layer")
+	}
+
+	return &ParameterTypesCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"parameter-types",
+			cmds.WithShort("Showcase all parameter types available in glazed"),
+			cmds.WithLong(`This command demonstrates all the different parameter types available in the glazed framework.
+It shows how to define and use each type, and displays the parsed values.
+
+Parameter types demonstrated:
+- Basic types: string, secret, integer, float, bool, date, choice
+- List types: string-list, integer-list, float-list, choice-list  
+- File types: file, file-list, string-from-file, object-from-file, etc.
+- Key-value type: key-value mappings
+
+Use --help to see all available parameters and their descriptions.`),
+			cmds.WithFlags(
+				// Basic types
+				parameters.NewParameterDefinition(
+					"string-param",
+					parameters.ParameterTypeString,
+					parameters.WithHelp("A simple string parameter"),
+					parameters.WithDefault("default-string"),
+				),
+				parameters.NewParameterDefinition(
+					"secret-param",
+					parameters.ParameterTypeSecret,
+					parameters.WithHelp("A secret parameter (will be masked when displayed)"),
+					parameters.WithDefault("secret-value"),
+				),
+				parameters.NewParameterDefinition(
+					"integer-param",
+					parameters.ParameterTypeInteger,
+					parameters.WithHelp("An integer parameter"),
+					parameters.WithDefault(42),
+				),
+				parameters.NewParameterDefinition(
+					"float-param",
+					parameters.ParameterTypeFloat,
+					parameters.WithHelp("A floating point parameter"),
+					parameters.WithDefault(3.14),
+				),
+				parameters.NewParameterDefinition(
+					"bool-param",
+					parameters.ParameterTypeBool,
+					parameters.WithHelp("A boolean parameter"),
+					parameters.WithDefault(true),
+				),
+				parameters.NewParameterDefinition(
+					"date-param",
+					parameters.ParameterTypeDate,
+					parameters.WithHelp("A date parameter (RFC3339 format or natural language)"),
+					parameters.WithDefault("2024-01-01T00:00:00Z"),
+				),
+				parameters.NewParameterDefinition(
+					"choice-param",
+					parameters.ParameterTypeChoice,
+					parameters.WithHelp("A choice parameter with predefined options"),
+					parameters.WithChoices("option1", "option2", "option3"),
+					parameters.WithDefault("option1"),
+				),
+
+				// List types
+				parameters.NewParameterDefinition(
+					"string-list-param",
+					parameters.ParameterTypeStringList,
+					parameters.WithHelp("A list of strings"),
+					parameters.WithDefault([]string{"item1", "item2"}),
+				),
+				parameters.NewParameterDefinition(
+					"integer-list-param",
+					parameters.ParameterTypeIntegerList,
+					parameters.WithHelp("A list of integers"),
+					parameters.WithDefault([]int{1, 2, 3}),
+				),
+				parameters.NewParameterDefinition(
+					"float-list-param",
+					parameters.ParameterTypeFloatList,
+					parameters.WithHelp("A list of floating point numbers"),
+					parameters.WithDefault([]float64{1.1, 2.2, 3.3}),
+				),
+				parameters.NewParameterDefinition(
+					"choice-list-param",
+					parameters.ParameterTypeChoiceList,
+					parameters.WithHelp("A list of choices from predefined options"),
+					parameters.WithChoices("red", "green", "blue"),
+					parameters.WithDefault([]string{"red", "blue"}),
+				),
+
+				// File types
+				parameters.NewParameterDefinition(
+					"file-param",
+					parameters.ParameterTypeFile,
+					parameters.WithHelp("A file parameter that loads file metadata"),
+				),
+				parameters.NewParameterDefinition(
+					"file-list-param",
+					parameters.ParameterTypeFileList,
+					parameters.WithHelp("A list of files with metadata"),
+				),
+				parameters.NewParameterDefinition(
+					"string-from-file-param",
+					parameters.ParameterTypeStringFromFile,
+					parameters.WithHelp("Load string content from a file"),
+				),
+				parameters.NewParameterDefinition(
+					"string-from-files-param",
+					parameters.ParameterTypeStringFromFiles,
+					parameters.WithHelp("Load and concatenate string content from multiple files"),
+				),
+				parameters.NewParameterDefinition(
+					"string-list-from-file-param",
+					parameters.ParameterTypeStringListFromFile,
+					parameters.WithHelp("Load lines from a file as a string list"),
+				),
+				parameters.NewParameterDefinition(
+					"string-list-from-files-param",
+					parameters.ParameterTypeStringListFromFiles,
+					parameters.WithHelp("Load lines from multiple files as a string list"),
+				),
+				parameters.NewParameterDefinition(
+					"object-from-file-param",
+					parameters.ParameterTypeObjectFromFile,
+					parameters.WithHelp("Load a JSON/YAML object from a file"),
+				),
+				parameters.NewParameterDefinition(
+					"object-list-from-file-param",
+					parameters.ParameterTypeObjectListFromFile,
+					parameters.WithHelp("Load a list of objects from a file"),
+				),
+				parameters.NewParameterDefinition(
+					"object-list-from-files-param",
+					parameters.ParameterTypeObjectListFromFiles,
+					parameters.WithHelp("Load and merge object lists from multiple files"),
+				),
+
+				// Key-value type
+				parameters.NewParameterDefinition(
+					"key-value-param",
+					parameters.ParameterTypeKeyValue,
+					parameters.WithHelp("Key-value pairs (format: key:value or @filename for JSON/YAML file)"),
+					parameters.WithDefault(map[string]string{"default-key": "default-value"}),
+				),
+			),
+			cmds.WithLayersList(
+				glazedParameterLayer,
+			),
+		),
+	}, nil
+}
+
+func (c *ParameterTypesCommand) RunIntoGlazeProcessor(
+	ctx context.Context,
+	parsedLayers *layers.ParsedLayers,
+	gp middlewares.Processor,
+) error {
+	s := &ParameterTypesSettings{}
+	err := parsedLayers.InitializeStruct(layers.DefaultSlug, s)
+	if err != nil {
+		return errors.Wrap(err, "Failed to initialize settings from parameters")
+	}
+
+	// We'll use hardcoded metadata since layer access is complex
+
+	// Create a result row for each parameter
+	parameterData := []struct {
+		name         string
+		paramType    parameters.ParameterType
+		realValue    interface{}
+		help         string
+		required     bool
+		choices      []string
+		defaultValue interface{}
+	}{
+		{"string-param", parameters.ParameterTypeString, s.StringParam, "A simple string parameter", false, nil, "default-string"},
+		{"secret-param", parameters.ParameterTypeSecret, s.SecretParam, "A secret parameter (will be masked when displayed)", false, nil, "secret-value"},
+		{"integer-param", parameters.ParameterTypeInteger, s.IntegerParam, "An integer parameter", false, nil, 42},
+		{"float-param", parameters.ParameterTypeFloat, s.FloatParam, "A floating point parameter", false, nil, 3.14},
+		{"bool-param", parameters.ParameterTypeBool, s.BoolParam, "A boolean parameter", false, nil, true},
+		{"date-param", parameters.ParameterTypeDate, s.DateParam, "A date parameter (RFC3339 format or natural language)", false, nil, "2024-01-01T00:00:00Z"},
+		{"choice-param", parameters.ParameterTypeChoice, s.ChoiceParam, "A choice parameter with predefined options", false, []string{"option1", "option2", "option3"}, "option1"},
+		{"string-list-param", parameters.ParameterTypeStringList, s.StringListParam, "A list of strings", false, nil, []string{"item1", "item2"}},
+		{"integer-list-param", parameters.ParameterTypeIntegerList, s.IntegerListParam, "A list of integers", false, nil, []int{1, 2, 3}},
+		{"float-list-param", parameters.ParameterTypeFloatList, s.FloatListParam, "A list of floating point numbers", false, nil, []float64{1.1, 2.2, 3.3}},
+		{"choice-list-param", parameters.ParameterTypeChoiceList, s.ChoiceListParam, "A list of choices from predefined options", false, []string{"red", "green", "blue"}, []string{"red", "blue"}},
+		{"file-param", parameters.ParameterTypeFile, s.FileParam, "A file parameter that loads file metadata", false, nil, nil},
+		{"file-list-param", parameters.ParameterTypeFileList, s.FileListParam, "A list of files with metadata", false, nil, nil},
+		{"string-from-file-param", parameters.ParameterTypeStringFromFile, s.StringFromFileParam, "Load string content from a file", false, nil, nil},
+		{"string-from-files-param", parameters.ParameterTypeStringFromFiles, s.StringFromFilesParam, "Load and concatenate string content from multiple files", false, nil, nil},
+		{"string-list-from-file-param", parameters.ParameterTypeStringListFromFile, s.StringListFromFileParam, "Load lines from a file as a string list", false, nil, nil},
+		{"string-list-from-files-param", parameters.ParameterTypeStringListFromFiles, s.StringListFromFilesParam, "Load lines from multiple files as a string list", false, nil, nil},
+		{"object-from-file-param", parameters.ParameterTypeObjectFromFile, s.ObjectFromFileParam, "Load a JSON/YAML object from a file", false, nil, nil},
+		{"object-list-from-file-param", parameters.ParameterTypeObjectListFromFile, s.ObjectListFromFileParam, "Load a list of objects from a file", false, nil, nil},
+		{"object-list-from-files-param", parameters.ParameterTypeObjectListFromFiles, s.ObjectListFromFilesParam, "Load and merge object lists from multiple files", false, nil, nil},
+		{"key-value-param", parameters.ParameterTypeKeyValue, s.KeyValueParam, "Key-value pairs (format: key:value or @filename for JSON/YAML file)", false, nil, map[string]string{"default-key": "default-value"}},
+	}
+
+	for _, param := range parameterData {
+		// Get rendered value (what would be displayed to user)
+		renderedValue := "<nil>"
+		if param.realValue != nil {
+			// Check for nil pointers using reflection
+			v := reflect.ValueOf(param.realValue)
+			isNil := false
+			if v.Kind() == reflect.Ptr || v.Kind() == reflect.Slice || v.Kind() == reflect.Map {
+				isNil = v.IsNil()
+			}
+
+			if !isNil {
+				var err error
+				renderedValue, err = parameters.RenderValue(param.paramType, param.realValue)
+				if err != nil {
+					renderedValue = fmt.Sprintf("ERROR: %v", err)
+				}
+			}
+		}
+
+		// Format real value for display
+		realValueStr := fmt.Sprintf("%v", param.realValue)
+		if param.realValue == nil {
+			realValueStr = "<nil>"
+		}
+
+		// Format default value
+		defaultValueStr := fmt.Sprintf("%v", param.defaultValue)
+		if param.defaultValue == nil {
+			defaultValueStr = "<nil>"
+		}
+
+		// Format choices
+		choicesStr := ""
+		if len(param.choices) > 0 {
+			choicesStr = fmt.Sprintf("[%s]", strings.Join(param.choices, ", "))
+		}
+
+		result := types.NewRow(
+			types.MRP("parameter_name", param.name),
+			types.MRP("parameter_type", string(param.paramType)),
+			types.MRP("real_value", realValueStr),
+			types.MRP("rendered_value", renderedValue),
+			types.MRP("default_value", defaultValueStr),
+			types.MRP("required", param.required),
+			types.MRP("choices", choicesStr),
+			types.MRP("help", param.help),
+		)
+
+		err = gp.AddRow(ctx, result)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	helpSystem := help.NewHelpSystem()
+
+	cmd, err := NewParameterTypesCommand()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create command: %v\n", err)
+		os.Exit(1)
+	}
+
+	rootCmd := &cobra.Command{
+		Use:   "parameter-types",
+		Short: "Showcase all glazed parameter types",
+	}
+
+	cobraCommand, err := cli.BuildCobraCommandFromGlazeCommand(cmd)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to build cobra command: %v\n", err)
+		os.Exit(1)
+	}
+
+	rootCmd.AddCommand(cobraCommand)
+	helpSystem.SetupCobraRootCommand(rootCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/examples/parameter-types/sample-lines.txt
+++ b/cmd/examples/parameter-types/sample-lines.txt
@@ -1,0 +1,5 @@
+line1
+line2
+line3
+line4
+line5

--- a/cmd/examples/parameter-types/sample-list.json
+++ b/cmd/examples/parameter-types/sample-list.json
@@ -1,0 +1,5 @@
+[
+  {"id": 1, "name": "Item 1", "category": "electronics"},
+  {"id": 2, "name": "Item 2", "category": "books"},
+  {"id": 3, "name": "Item 3", "category": "clothing"}
+]

--- a/cmd/examples/parameter-types/sample-text.txt
+++ b/cmd/examples/parameter-types/sample-text.txt
@@ -1,0 +1,4 @@
+This is a sample text file.
+It contains multiple lines.
+Each line will be part of the string content.
+Perfect for testing string-from-file parameters.

--- a/cmd/examples/parameter-types/sample.json
+++ b/cmd/examples/parameter-types/sample.json
@@ -1,0 +1,6 @@
+{
+  "name": "John Doe",
+  "age": 30,
+  "city": "New York",
+  "active": true
+}

--- a/cmd/examples/parameter-types/sample.yaml
+++ b/cmd/examples/parameter-types/sample.yaml
@@ -1,0 +1,11 @@
+users:
+  - name: Alice
+    role: admin
+    permissions:
+      - read
+      - write
+      - delete
+  - name: Bob
+    role: user
+    permissions:
+      - read

--- a/cmd/examples/parameter-types/simple-config.yaml
+++ b/cmd/examples/parameter-types/simple-config.yaml
@@ -1,0 +1,3 @@
+key1: value1
+key2: value2
+key3: value3

--- a/pkg/cmds/json-schema.go
+++ b/pkg/cmds/json-schema.go
@@ -39,7 +39,7 @@ func parameterTypeToJsonSchema(param *parameters.ParameterDefinition) (*JsonSche
 
 	switch param.Type {
 	// Basic types
-	case parameters.ParameterTypeString:
+	case parameters.ParameterTypeString, parameters.ParameterTypeSecret:
 		prop.Type = "string"
 
 	case parameters.ParameterTypeInteger:

--- a/pkg/cmds/parameters/cobra.go
+++ b/pkg/cmds/parameters/cobra.go
@@ -180,7 +180,7 @@ func (pds *ParameterDefinitions) AddParametersToCobraCommand(
 				flagSet.StringSlice(flagName, defaultValue, helpText)
 			}
 
-		case ParameterTypeString:
+		case ParameterTypeString, ParameterTypeSecret:
 			defaultValue := ""
 
 			if parameter.Default != nil {
@@ -457,6 +457,7 @@ func (pds *ParameterDefinitions) GatherFlagsFromCobraCommand(
 			ParameterTypeStringFromFile,
 			ParameterTypeStringListFromFile,
 			ParameterTypeString,
+			ParameterTypeSecret,
 			ParameterTypeFile,
 			ParameterTypeDate,
 			ParameterTypeChoice:

--- a/pkg/cmds/parameters/parameter-type.go
+++ b/pkg/cmds/parameters/parameter-type.go
@@ -6,6 +6,7 @@ type ParameterType string
 
 const (
 	ParameterTypeString ParameterType = "string"
+	ParameterTypeSecret ParameterType = "secret"
 
 	// TODO(2023-02-13, manuel) Should the "default" of a stringFromFile be the filename, or the string?
 	//

--- a/pkg/cmds/parameters/parameters.go
+++ b/pkg/cmds/parameters/parameters.go
@@ -151,7 +151,7 @@ func (p *ParameterDefinition) SetValueFromDefault(value reflect.Value) error {
 // InitializeValueToEmptyValue initializes the given value to the empty value of the type of the parameter.
 func (p *ParameterDefinition) InitializeValueToEmptyValue(value reflect.Value) error {
 	switch p.Type {
-	case ParameterTypeString, ParameterTypeChoice, ParameterTypeStringFromFiles, ParameterTypeStringFromFile:
+	case ParameterTypeString, ParameterTypeSecret, ParameterTypeChoice, ParameterTypeStringFromFiles, ParameterTypeStringFromFile:
 		value.SetString("")
 	case ParameterTypeBool:
 		value.SetBool(false)
@@ -194,7 +194,7 @@ func (p *ParameterDefinition) SetValueFromInterface(value reflect.Value, v inter
 	}
 
 	switch p.Type {
-	case ParameterTypeString, ParameterTypeChoice, ParameterTypeStringFromFiles, ParameterTypeStringFromFile:
+	case ParameterTypeString, ParameterTypeSecret, ParameterTypeChoice, ParameterTypeStringFromFiles, ParameterTypeStringFromFile:
 		strVal, ok := v.(string)
 		if !ok {
 			return errors.Errorf("expected string value for parameter %s, got %T", p.Name, v)
@@ -437,6 +437,8 @@ func (p *ParameterDefinition) CheckValueValidity(v interface{}) (interface{}, er
 	case ParameterTypeStringFromFiles:
 		fallthrough
 	case ParameterTypeString:
+		fallthrough
+	case ParameterTypeSecret:
 		s, err := cast.ToString(v)
 		if err != nil {
 			return nil, errors.Errorf("Value for parameter %s is not a string: %v", p.Name, v)
@@ -774,7 +776,7 @@ func (p *ParameterDefinition) setReflectValue(v reflect.Value, value interface{}
 	}
 
 	switch p.Type {
-	case ParameterTypeString, ParameterTypeChoice, ParameterTypeStringFromFiles, ParameterTypeStringFromFile:
+	case ParameterTypeString, ParameterTypeSecret, ParameterTypeChoice, ParameterTypeStringFromFiles, ParameterTypeStringFromFile:
 		strVal, ok := value.(string)
 		if !ok {
 			return errors.Errorf("expected string value for parameter %s, got %T", p.Name, value)

--- a/pkg/cmds/parameters/parse.go
+++ b/pkg/cmds/parameters/parse.go
@@ -106,6 +106,11 @@ func (p *ParameterDefinition) ParseParameter(v []string, options ...ParseStepOpt
 			return nil, errors.Errorf("Argument %s must be a single string", p.Name)
 		}
 		v_ = v[0]
+	case ParameterTypeSecret:
+		if len(v) > 1 {
+			return nil, errors.Errorf("Argument %s must be a single secret", p.Name)
+		}
+		v_ = v[0]
 	case ParameterTypeInteger:
 		if len(v) > 1 {
 			return nil, errors.Errorf("Argument %s must be a single integer", p.Name)

--- a/pkg/cmds/parameters/render.go
+++ b/pkg/cmds/parameters/render.go
@@ -25,7 +25,18 @@ func RenderValue(type_ ParameterType, value interface{}) (string, error) {
 		return s, nil
 
 	case ParameterTypeSecret:
-		return "***", nil
+		s, ok := value.(string)
+		if !ok {
+			return "", errors.Errorf("expected string, got %T", value)
+		}
+
+		// For very short strings, just return ***
+		if len(s) <= 6 {
+			return "***", nil
+		}
+
+		// For longer strings, show first 2 chars, ***, and last 2 chars
+		return s[:2] + "***" + s[len(s)-2:], nil
 
 	case ParameterTypeObjectListFromFiles,
 		ParameterTypeObjectListFromFile,

--- a/pkg/cmds/parameters/render.go
+++ b/pkg/cmds/parameters/render.go
@@ -24,6 +24,9 @@ func RenderValue(type_ ParameterType, value interface{}) (string, error) {
 		}
 		return s, nil
 
+	case ParameterTypeSecret:
+		return "***", nil
+
 	case ParameterTypeObjectListFromFiles,
 		ParameterTypeObjectListFromFile,
 		ParameterTypeObjectFromFile:

--- a/pkg/cmds/parameters/viper.go
+++ b/pkg/cmds/parameters/viper.go
@@ -45,7 +45,7 @@ func (pds *ParameterDefinitions) GatherFlagsFromViper(
 		}, options...)
 		//exhaustive:ignore
 		switch p.Type {
-		case ParameterTypeString:
+		case ParameterTypeString, ParameterTypeSecret:
 			err := parsed.Update(viper.GetString(flagName), options...)
 			if err != nil {
 				return nil, err

--- a/pkg/codegen/glazed.go
+++ b/pkg/codegen/glazed.go
@@ -65,7 +65,8 @@ func FlagTypeToGoType(s *jen.Statement, parameterType parameters.ParameterType) 
 	case parameters.ParameterTypeStringFromFile,
 		parameters.ParameterTypeStringFromFiles,
 		parameters.ParameterTypeChoice,
-		parameters.ParameterTypeString:
+		parameters.ParameterTypeString,
+		parameters.ParameterTypeSecret:
 		return s.Id("string")
 	case parameters.ParameterTypeStringList,
 		parameters.ParameterTypeStringListFromFile,

--- a/pkg/doc/topics/15-using-commands.md
+++ b/pkg/doc/topics/15-using-commands.md
@@ -267,11 +267,13 @@ Parameters are the inputs to your command and are defined using `parameters.Para
 
 Glazed supports various parameter types, each affecting how values are parsed and validated:
 
-- Basic types: `ParameterTypeString`, `ParameterTypeInteger`, `ParameterTypeBool`, `ParameterTypeFloat`, `ParameterTypeDate`
+- Basic types: `ParameterTypeString`, `ParameterTypeSecret`, `ParameterTypeInteger`, `ParameterTypeBool`, `ParameterTypeFloat`, `ParameterTypeDate`
 - Lists: `ParameterTypeStringList`, `ParameterTypeIntegerList`, `ParameterTypeFloatList`
 - Choice-based: `ParameterTypeChoice`, `ParameterTypeChoiceList` (with predefined options)
 - File-based: `ParameterTypeFile`, `ParameterTypeFileList`, `ParameterTypeStringFromFile`, etc.
 - Key-value: `ParameterTypeKeyValue` (for map-like inputs)
+
+**Note**: `ParameterTypeSecret` behaves like a string but masks sensitive values when displayed (e.g., `my***rd` for `"my-secret-password"`), protecting passwords, API keys, and other confidential data.
 
 ### Creating Parameter Definitions
 
@@ -286,6 +288,15 @@ paramDef := parameters.NewParameterDefinition(
     parameters.WithDefault("guest"),  // Default value
     parameters.WithRequired(false),   // Is it required?
     parameters.WithShortFlag("n"),    // Short flag (-n)
+)
+
+// Example of a secret parameter for sensitive data
+apiKeyParam := parameters.NewParameterDefinition(
+    "api-key",
+    parameters.ParameterTypeSecret,  // Masks value when displayed
+    parameters.WithHelp("API key for authentication"),
+    parameters.WithRequired(true),
+    parameters.WithShortFlag("k"),
 )
 ```
 

--- a/pkg/doc/topics/16-adding-parameter-types.md
+++ b/pkg/doc/topics/16-adding-parameter-types.md
@@ -1,0 +1,578 @@
+---
+Title: Adding New Parameter Types to Glazed
+Slug: adding-parameter-types
+Short: Comprehensive guide on implementing new parameter types in the Glazed framework.
+Topics:
+- parameters
+- types
+- parsing
+- validation
+- development
+- extension
+IsTemplate: false
+IsTopLevel: true
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+# Adding New Parameter Types to Glazed
+
+## Overview
+
+Parameter types in glazed are defined in the [`glazed/pkg/cmds/parameters`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters) package. Each parameter type requires modifications to several files to handle:
+
+1. Type definition and metadata
+2. Parsing logic
+3. Validation
+4. Value initialization and assignment
+5. Cobra CLI integration
+6. Viper configuration support
+7. Rendering for display
+
+This guide explains how to add a new parameter type to the glazed command line framework. We'll use the example of adding a `credentials` parameter type to demonstrate the process.
+
+## Files to Modify
+
+When adding a new parameter type, you need to modify these files:
+
+### Core Parameter Files
+1. [`parameter-type.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/parameter-type.go) - Define the type constant and metadata methods
+2. [`parse.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/parse.go) - Add parsing logic
+3. [`parameters.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/parameters.go) - Add validation and value assignment
+4. [`cobra.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/cobra.go) - Add CLI flag support
+5. [`viper.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/viper.go) - Add configuration file support
+6. [`render.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/render.go) - Add display formatting
+
+### Additional Files with Exhaustive Switches
+7. [`json-schema.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/json-schema.go) - Add JSON schema type mapping
+8. [`glazed.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/codegen/glazed.go) - Add Go type mapping for code generation
+9. [`lua.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/lua/lua.go) - Add Lua value parsing support
+
+**Note**: The linter will help you find any additional files with exhaustive switch statements that need updating by running `make lint` or `golangci-lint run`.
+
+## Step 1: Define the Parameter Type
+
+In [`parameter-type.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/parameter-type.go), add your new type constant:
+
+```go
+const (
+    // ... existing types ...
+    ParameterTypeCredentials ParameterType = "credentials"
+)
+```
+
+Add your type to the relevant metadata methods. For example, if credentials should be treated as a list:
+
+```go
+func (p ParameterType) IsList() bool {
+    switch p {
+    case ParameterTypeCredentials:
+        return true
+    // ... existing cases ...
+    }
+}
+```
+
+Add other metadata methods as needed:
+- `NeedsFileContent()` - if type can load from files
+- `NeedsMultipleFileContent()` - if type loads from multiple files
+- `IsFile()` - if type represents file data
+- `IsObject()` - if type represents structured objects
+- `IsKeyValue()` - if type represents key-value maps
+
+## Step 2: Add Parsing Logic
+
+In [`parse.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/parse.go), add a case to the `ParseParameter` method:
+
+```go
+func (p *ParameterDefinition) ParseParameter(v []string, options ...ParseStepOption) (*ParsedParameter, error) {
+    // ... existing code ...
+    
+    switch p.Type {
+    // ... existing cases ...
+    
+    case ParameterTypeCredentials:
+        // Parse credentials from command line arguments
+        // Example: expect format "username:password" or load from file with @
+        if len(v) == 1 && strings.HasPrefix(v[0], "@") {
+            // Load from file
+            credFile := v[0][1:]
+            content, err := os.ReadFile(credFile)
+            if err != nil {
+                return nil, errors.Wrapf(err, "Could not read credentials file %s", credFile)
+            }
+            // Parse JSON/YAML credentials file
+            var creds map[string]string
+            if strings.HasSuffix(credFile, ".json") {
+                err = json.Unmarshal(content, &creds)
+            } else {
+                err = yaml.Unmarshal(content, &creds)
+            }
+            if err != nil {
+                return nil, errors.Wrapf(err, "Could not parse credentials file %s", credFile)
+            }
+            v_ = creds
+        } else {
+            // Parse from command line
+            creds := make(map[string]string)
+            for _, arg := range v {
+                parts := strings.SplitN(arg, ":", 2)
+                if len(parts) != 2 {
+                    return nil, errors.Errorf("Invalid credentials format: %s (expected username:password)", arg)
+                }
+                creds[parts[0]] = parts[1]
+            }
+            v_ = creds
+        }
+    }
+    
+    // ... rest of method ...
+}
+```
+
+If your type supports file loading, add cases to `ParseFromReader`:
+
+```go
+func (p *ParameterDefinition) ParseFromReader(f io.Reader, filename string, options ...ParseStepOption) (*ParsedParameter, error) {
+    // ... existing code ...
+    
+    switch p.Type {
+    // ... existing cases ...
+    
+    case ParameterTypeCredentials:
+        var creds map[string]string
+        if strings.HasSuffix(filename, ".json") {
+            err = json.NewDecoder(f).Decode(&creds)
+        } else {
+            err = yaml.NewDecoder(f).Decode(&creds)
+        }
+        if err != nil {
+            return nil, err
+        }
+        err = ret.Update(creds, options...)
+        return ret, err
+    }
+}
+```
+
+## Step 3: Add Validation and Value Assignment
+
+In [`parameters.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/parameters.go), add validation to `CheckValueValidity`:
+
+```go
+func (p *ParameterDefinition) CheckValueValidity(v interface{}) (interface{}, error) {
+    // ... existing code ...
+    
+    switch p.Type {
+    // ... existing cases ...
+    
+    case ParameterTypeCredentials:
+        creds, ok := v.(map[string]string)
+        if !ok {
+            // Try to convert from map[string]interface{}
+            credsIface, ok := v.(map[string]interface{})
+            if !ok {
+                return nil, errors.Errorf("Value for parameter %s is not credentials (expected map[string]string): %v", p.Name, v)
+            }
+            creds = make(map[string]string)
+            for k, v := range credsIface {
+                str, ok := v.(string)
+                if !ok {
+                    return nil, errors.Errorf("Credentials value for key %s is not a string: %v", k, v)
+                }
+                creds[k] = str
+            }
+        }
+        
+        // Validate required fields
+        if _, ok := creds["username"]; !ok {
+            return nil, errors.Errorf("Credentials missing required 'username' field")
+        }
+        if _, ok := creds["password"]; !ok {
+            return nil, errors.Errorf("Credentials missing required 'password' field")
+        }
+        
+        return creds, nil
+    }
+}
+```
+
+Add empty value initialization to `InitializeValueToEmptyValue`:
+
+```go
+func (p *ParameterDefinition) InitializeValueToEmptyValue(value reflect.Value) error {
+    switch p.Type {
+    // ... existing cases ...
+    
+    case ParameterTypeCredentials:
+        value.Set(reflect.ValueOf(map[string]string{}))
+    }
+}
+```
+
+Add value assignment to `SetValueFromInterface`:
+
+```go
+func (p *ParameterDefinition) SetValueFromInterface(value reflect.Value, v interface{}) error {
+    // ... validation ...
+    
+    switch p.Type {
+    // ... existing cases ...
+    
+    case ParameterTypeCredentials:
+        creds, ok := v.(map[string]string)
+        if !ok {
+            return errors.Errorf("expected credentials for parameter %s, got %T", p.Name, v)
+        }
+        value.Set(reflect.ValueOf(creds))
+    }
+}
+```
+
+## Step 4: Add Cobra CLI Integration
+
+In [`cobra.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/cobra.go), add flag creation logic:
+
+```go
+func (ps *ParameterDefinitions) AddToCobraCommand(cmd *cobra.Command) error {
+    // ... existing code ...
+    
+    switch parameter.Type {
+    // ... existing cases ...
+    
+    case ParameterTypeCredentials:
+        defaultValue := []string{}
+        if parameter.Default != nil {
+            if creds, ok := (*parameter.Default).(map[string]string); ok {
+                for k, v := range creds {
+                    defaultValue = append(defaultValue, k+":"+v)
+                }
+            }
+        }
+        cmd.Flags().StringSliceVarP(&ps.cobraParameterValues[parameter.Name], 
+            parameter.Name, parameter.ShortFlag, defaultValue, parameter.Help)
+    }
+}
+```
+
+Add completion logic if needed:
+
+```go
+func (ps *ParameterDefinitions) SetupCobraCompletions(cmd *cobra.Command) error {
+    // ... existing code ...
+    
+    switch parameter.Type {
+    case ParameterTypeCredentials:
+        err = cmd.RegisterFlagCompletionFunc(parameter.Name, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+            return []string{"username:", "token:", "api_key:"}, cobra.ShellCompDirectiveNoSpace
+        })
+    }
+}
+```
+
+## Step 5: Add Viper Configuration Support
+
+In [`viper.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/viper.go), add configuration parsing:
+
+```go
+func (ps *ParameterDefinitions) LoadFromViper(v *viper.Viper, overrides map[string]interface{}) (*ParsedParameters, error) {
+    // ... existing code ...
+    
+    switch parameter.Type {
+    // ... existing cases ...
+    
+    case ParameterTypeCredentials:
+        if v.IsSet(key) {
+            credsConfig := v.Get(key)
+            var creds map[string]string
+            
+            // Handle different config formats
+            switch c := credsConfig.(type) {
+            case map[string]interface{}:
+                creds = make(map[string]string)
+                for k, v := range c {
+                    if str, ok := v.(string); ok {
+                        creds[k] = str
+                    }
+                }
+            case map[string]string:
+                creds = c
+            case string:
+                // Parse as file path
+                if strings.HasPrefix(c, "@") {
+                    // Load from file
+                    // ... file loading logic ...
+                } else {
+                    // Parse as single credential
+                    parts := strings.SplitN(c, ":", 2)
+                    if len(parts) == 2 {
+                        creds = map[string]string{parts[0]: parts[1]}
+                    }
+                }
+            }
+            
+            if creds != nil {
+                err = parsedParameters.UpdateValue(parameter.Name, parameter, creds, options...)
+            }
+        }
+    }
+}
+```
+
+## Step 6: Add Rendering Support
+
+In [`render.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/pkg/cmds/parameters/render.go), add display formatting:
+
+```go
+func RenderValue(parameterType ParameterType, value interface{}) (string, error) {
+    switch parameterType {
+    // ... existing cases ...
+    
+    case ParameterTypeCredentials:
+        if creds, ok := value.(map[string]string); ok {
+            // Mask sensitive data for display
+            rendered := make([]string, 0, len(creds))
+            for k, v := range creds {
+                if strings.Contains(strings.ToLower(k), "password") || 
+                   strings.Contains(strings.ToLower(k), "secret") ||
+                   strings.Contains(strings.ToLower(k), "token") {
+                    rendered = append(rendered, k+":***")
+                } else {
+                    rendered = append(rendered, k+":"+v)
+                }
+            }
+            return strings.Join(rendered, ", "), nil
+        }
+        return "", errors.Errorf("Invalid credentials value: %v", value)
+    }
+}
+```
+
+## Step 7: Update Additional Files with Exhaustive Switches
+
+After implementing the core parameter functionality, you may need to update additional files that have exhaustive switch statements on parameter types:
+
+### JSON Schema Support (`json-schema.go`)
+```go
+switch param.Type {
+// ... existing cases ...
+case parameters.ParameterTypeCredentials:
+    prop.Type = "object"
+    prop.Properties = map[string]*JSONSchemaProperty{
+        "username": {Type: "string"},
+        "password": {Type: "string"},
+    }
+}
+```
+
+### Code Generation Support (`codegen/glazed.go`)
+```go
+func FlagTypeToGoType(s *jen.Statement, parameterType parameters.ParameterType) *jen.Statement {
+    switch parameterType {
+    // ... existing cases ...
+    case parameters.ParameterTypeCredentials:
+        return s.Map(jen.Id("string")).Id("string")
+    }
+}
+```
+
+### Lua Integration Support (`lua/lua.go`)
+```go
+func ParseParameterFromLua(L *lua.LState, value lua.LValue, paramDef *parameters.ParameterDefinition) (interface{}, error) {
+    switch paramDef.Type {
+    // ... existing cases ...
+    case parameters.ParameterTypeCredentials:
+        if table, ok := value.(*lua.LTable); ok {
+            creds := make(map[string]string)
+            table.ForEach(func(k, v lua.LValue) {
+                if keyStr, ok := k.(lua.LString); ok {
+                    if valStr, ok := v.(lua.LString); ok {
+                        creds[string(keyStr)] = string(valStr)
+                    }
+                }
+            })
+            return creds, nil
+        }
+        return nil, fmt.Errorf("invalid type for credentials parameter '%s': expected table, got %s", paramDef.Name, value.Type())
+    }
+}
+```
+
+**Pro Tip**: Run `make lint` or `golangci-lint run` after adding your parameter type to discover any additional files with exhaustive switches that need updating.
+
+## Step 8: Update Parameter Types Example
+
+Update the parameter types example command in [`cmd/examples/parameter-types/main.go`](file:///home/manuel/workspaces/2025-06-09/add-geppetto-js/glazed/cmd/examples/parameter-types/main.go) to showcase your new parameter type.
+
+### Add to Parameter Definitions
+Add your parameter to the `cmds.WithFlags()` section:
+
+```go
+parameters.NewParameterDefinition(
+    "credentials-param",
+    parameters.ParameterTypeCredentials,
+    parameters.WithHelp("A credentials parameter for username/password pairs"),
+    parameters.WithDefault(map[string]string{"username": "admin", "password": "secret"}),
+),
+```
+
+### Add to Settings Struct
+Add a field to the `ParameterTypesSettings` struct:
+
+```go
+type ParameterTypesSettings struct {
+    // ... existing fields ...
+    CredentialsParam map[string]string `glazed.parameter:"credentials-param"`
+}
+```
+
+### Add to Parameter Data Array
+Add an entry to the `parameterData` slice in `RunIntoGlazeProcessor`:
+
+```go
+{"credentials-param", parameters.ParameterTypeCredentials, s.CredentialsParam, "A credentials parameter for username/password pairs", false, nil, map[string]string{"username": "admin", "password": "secret"}},
+```
+
+This ensures that developers and users can easily test and understand how your new parameter type works in practice.
+
+## Step 9: Test the Example
+
+After updating the example, test it to ensure your new parameter type works correctly:
+
+```bash
+cd cmd/examples/parameter-types
+go build -o parameter-types .
+
+# Test with default values
+./parameter-types parameter-types
+
+# Test with custom values for your new type
+./parameter-types parameter-types --credentials-param username:admin,password:secret
+
+# Test parameter parsing (useful for debugging)
+./parameter-types parameter-types --credentials-param username:test,password:demo --print-parsed-parameters
+```
+
+Verify that:
+- Your parameter appears in the help output (`--help`)
+- Default values work correctly
+- Custom values parse and display properly
+- The rendered value shows what users should see (e.g., secrets are masked)
+- The real value contains the actual parsed data
+
+## Step 10: Add Tests
+
+Create comprehensive tests for your new parameter type:
+
+```go
+func TestCredentialsParameter(t *testing.T) {
+    tests := []struct {
+        name     string
+        input    []string
+        expected map[string]string
+        wantErr  bool
+    }{
+        {
+            name:     "single credential",
+            input:    []string{"user:pass"},
+            expected: map[string]string{"user": "pass"},
+        },
+        {
+            name:     "multiple credentials",
+            input:    []string{"user:pass", "api_key:secret"},
+            expected: map[string]string{"user": "pass", "api_key": "secret"},
+        },
+        {
+            name:    "invalid format",
+            input:   []string{"invalid"},
+            wantErr: true,
+        },
+    }
+    
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            pd := &ParameterDefinition{
+                Name: "credentials",
+                Type: ParameterTypeCredentials,
+            }
+            
+            result, err := pd.ParseParameter(tt.input)
+            if tt.wantErr {
+                assert.Error(t, err)
+                return
+            }
+            
+            assert.NoError(t, err)
+            assert.Equal(t, tt.expected, result.Value)
+        })
+    }
+}
+```
+
+## Example: Complete Credentials Parameter Type
+
+Here's what the complete implementation would look like for a credentials parameter type:
+
+### In parameter-type.go
+```go
+const (
+    // ... existing types ...
+    ParameterTypeCredentials ParameterType = "credentials"
+)
+
+func (p ParameterType) IsKeyValue() bool {
+    switch p {
+    case ParameterTypeKeyValue, ParameterTypeCredentials:
+        return true
+    default:
+        return false
+    }
+}
+```
+
+This implementation would:
+- Accept credentials in `username:password` format from command line
+- Support loading from JSON/YAML files with `@filename` syntax
+- Validate that required fields (username, password) are present
+- Mask sensitive data when rendering
+- Support both single and multiple credential pairs
+
+## Summary
+
+When adding a new parameter type to glazed, you need to modify these core files and follow these steps:
+
+1. **Define the type constant** in `parameter-type.go`
+2. **Add parsing logic** in `parse.go` 
+3. **Add validation and value assignment** in `parameters.go`
+4. **Add CLI flag support** in `cobra.go`
+5. **Add configuration file support** in `viper.go`
+6. **Add display formatting** in `render.go`
+7. **Update exhaustive switches** in additional files
+8. **Update the parameter types example** in `cmd/examples/parameter-types/main.go`
+9. **Test the example** to verify functionality
+10. **Write comprehensive tests**
+
+## Tips and Best Practices
+
+1. **Consistent naming**: Use the pattern `ParameterType<Name>` for constants
+2. **Error handling**: Provide clear, descriptive error messages
+3. **Security**: Be careful with sensitive data - mask passwords/tokens in displays
+4. **Validation**: Validate input format early and provide helpful error messages
+5. **File support**: Consider whether your type should support file loading
+6. **Testing**: Write comprehensive tests covering all parsing scenarios
+7. **Documentation**: Update parameter type documentation and help text
+8. **Backwards compatibility**: Ensure new types don't break existing functionality
+9. **Update examples**: Always update the parameter types example to showcase new types
+
+## Common Patterns
+
+- **Simple values**: String, int, float, bool - direct value assignment
+- **Lists**: StringList, IntegerList - parse multiple values into slices
+- **Files**: File types load content and parse based on extension
+- **Key-value**: Maps parsed from colon-separated pairs or files
+- **Choices**: Validated against predefined options
+- **Objects**: Complex structured data loaded from JSON/YAML
+
+Follow these patterns when implementing your custom parameter type to ensure consistency with the rest of the glazed framework.
+
+**Important**: The parameter types example in `cmd/examples/parameter-types/` serves as both documentation and a testing tool. Always update it when adding new parameter types so users and developers can easily understand and test the new functionality.

--- a/pkg/lua/lua.go
+++ b/pkg/lua/lua.go
@@ -129,7 +129,7 @@ func ParseNestedLuaTableMiddleware(L *lua.LState, luaTable *lua.LTable) middlewa
 // ParseParameterFromLua parses a Lua value into a Go value based on the parameter definition
 func ParseParameterFromLua(L *lua.LState, value lua.LValue, paramDef *parameters.ParameterDefinition) (interface{}, error) {
 	switch paramDef.Type {
-	case parameters.ParameterTypeString:
+	case parameters.ParameterTypeString, parameters.ParameterTypeSecret:
 		if v, ok := value.(lua.LString); ok {
 			return string(v), nil
 		}


### PR DESCRIPTION
## Changes

### New Parameter Type
- Add `ParameterTypeSecret` constant for sensitive string values
- Behaves like string parameters but masks values when displayed
- Integrates with all existing parameter processing systems

### Rendering Logic
- Secret values display as `***` for strings ≤6 characters
- Longer strings show first 2 chars + `***` + last 2 chars
- Actual values remain unchanged in memory for processing

### Integration Points
- Update Cobra command flag handling for secret parameters
- Add Viper configuration support for secret values
- Include in JSON schema generation as string type
- Support in Lua parameter parsing
- Add to code generation utilities

### Example Application
- Create comprehensive parameter types example demonstrating all available
  types including the new secret type
- Include sample files and documentation for testing different parameter
  scenarios