### PR TITLE
Add help command to root and reduce FTS5 logging verbosity

### DIFF
--- a/pkg/help/cmd/cobra.go
+++ b/pkg/help/cmd/cobra.go
@@ -32,6 +32,7 @@ func SetupCobraRootCommand(hs *help.HelpSystem, cmd *cobra.Command) {
 
 	helpCmd := NewCobraHelpCommand(hs)
 	cmd.SetHelpCommand(helpCmd)
+	cmd.AddCommand(helpCmd)
 }
 
 func getCobraHelpUsageFuncs(hs *help.HelpSystem) (HelpFunc, UsageFunc) {

--- a/pkg/help/store/nofts.go
+++ b/pkg/help/store/nofts.go
@@ -8,6 +8,6 @@ import (
 
 // createFTSTables is a no-op when FTS5 is not enabled
 func (s *Store) createFTSTables() error {
-	log.Debug().Msg("FTS5 support disabled, skipping FTS table creation")
+	log.Trace().Msg("FTS5 support disabled, skipping FTS table creation")
 	return nil
 }


### PR DESCRIPTION
This PR makes two small improvements to the help system and logging:

## Changes

• **Add help command to root**: Makes the help command available as a 
  standalone subcommand in addition to the existing help flag functionality
• **Reduce FTS5 logging verbosity**: Changes FTS5 disabled message from 
  Debug to Trace level to reduce log noise