### PR TITLE
Do not use color in logging for non-interactive ttys

### DIFF
--- a/pkg/cmds/logging/init.go
+++ b/pkg/cmds/logging/init.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mattn/go-isatty"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
@@ -24,7 +25,11 @@ func InitLoggerFromSettings(settings *LoggingSettings) error {
 	// default is json
 	var logWriter io.Writer
 	if settings.LogFormat == "text" {
-		logWriter = zerolog.ConsoleWriter{Out: os.Stderr}
+		logWriter = zerolog.ConsoleWriter{
+			Out:        os.Stderr,
+			NoColor:    !isatty.IsTerminal(os.Stderr.Fd()) && !isatty.IsCygwinTerminal(os.Stderr.Fd()),
+			TimeFormat: time.RFC3339Nano,
+		}
 	} else {
 		logWriter = os.Stderr
 	}


### PR DESCRIPTION
- Modify logging behavior to disable color output when not in an 
  interactive terminal (tty).
- Update documentation to guide users on initializing logging with 
  Cobra commands and Viper configuration.