### PR TITLE
Allow multiple instances of the same layer with different slugs

### DIFF
--- a/pkg/cmds/layers/parsed-layer.go
+++ b/pkg/cmds/layers/parsed-layer.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
@@ -171,7 +170,6 @@ func (p *ParsedLayers) GetOrCreate(layer ParameterLayer) *ParsedLayer {
 		panic("layer must not be nil")
 	}
 	slug := layer.GetSlug()
-	log.Debug().Str("slug", slug).Str("name", layer.GetName()).Str("prefix", layer.GetPrefix()).Msg("ParsedLayers.GetOrCreate: using slug for layer")
 	v, ok := p.Get(slug)
 	if !ok {
 		v = &ParsedLayer{
@@ -179,7 +177,6 @@ func (p *ParsedLayers) GetOrCreate(layer ParameterLayer) *ParsedLayer {
 			Parameters: parameters.NewParsedParameters(),
 		}
 		p.Set(slug, v)
-		log.Debug().Str("slug", slug).Str("name", layer.GetName()).Msg("ParsedLayers.GetOrCreate: created new parsed layer entry")
 	}
 	return v
 }

--- a/pkg/cmds/layers/parsed-layer.go
+++ b/pkg/cmds/layers/parsed-layer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
@@ -170,6 +171,7 @@ func (p *ParsedLayers) GetOrCreate(layer ParameterLayer) *ParsedLayer {
 		panic("layer must not be nil")
 	}
 	slug := layer.GetSlug()
+	log.Debug().Str("slug", slug).Str("name", layer.GetName()).Str("prefix", layer.GetPrefix()).Msg("ParsedLayers.GetOrCreate: using slug for layer")
 	v, ok := p.Get(slug)
 	if !ok {
 		v = &ParsedLayer{
@@ -177,6 +179,7 @@ func (p *ParsedLayers) GetOrCreate(layer ParameterLayer) *ParsedLayer {
 			Parameters: parameters.NewParsedParameters(),
 		}
 		p.Set(slug, v)
+		log.Debug().Str("slug", slug).Str("name", layer.GetName()).Msg("ParsedLayers.GetOrCreate: created new parsed layer entry")
 	}
 	return v
 }

--- a/pkg/cmds/middlewares/cobra.go
+++ b/pkg/cmds/middlewares/cobra.go
@@ -3,6 +3,7 @@ package middlewares
 import (
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -24,15 +25,20 @@ func ParseFromCobraCommand(cmd *cobra.Command, options ...parameters.ParseStepOp
 			}
 
 			err = layers_.ForEachE(func(key string, l layers.ParameterLayer) error {
+				log.Debug().Str("registeredKey", key).Str("layerSlug", l.GetSlug()).Str("layerName", l.GetName()).Msg("ParseFromCobraCommand: iterating layer")
 				options_ := append([]parameters.ParseStepOption{
 					parameters.WithParseStepMetadata(map[string]interface{}{
-						"layer": l.GetName(),
+						"layer":          l.GetName(),
+						"layer_slug":     l.GetSlug(),
+						"layer_prefix":   l.GetPrefix(),
+						"registered_key": key,
 					}),
 				}, options...)
 
 				parsedLayer := parsedLayers.GetOrCreate(l)
 
 				if cobraLayer, ok := l.(layers.CobraParameterLayer); ok {
+					log.Debug().Str("layerSlug", l.GetSlug()).Msg("ParseFromCobraCommand: parsing layer from cobra")
 					cobraLayer, err := cobraLayer.ParseLayerFromCobraCommand(cmd, options_...)
 					if err != nil {
 						return err
@@ -72,7 +78,7 @@ func GatherArguments(args []string, options ...parameters.ParseStepOption) Middl
 
 			if defaultLayer, ok := layers_.Get(layers.DefaultSlug); ok {
 				pds := defaultLayer.GetParameterDefinitions()
-				ps_, err := pds.GatherArguments(args, false, false, options...)
+				ps_, err := pds.GatherArguments(args, false, false, append(options, parameters.WithParseStepSource("arguments"))...)
 				if err != nil {
 					return err
 				}
@@ -109,7 +115,10 @@ func GatherFlagsFromViper(options ...parameters.ParseStepOption) Middleware {
 				options_ := append([]parameters.ParseStepOption{
 					parameters.WithParseStepSource("viper"),
 					parameters.WithParseStepMetadata(map[string]interface{}{
-						"layer": l.GetName(),
+						"layer":          l.GetName(),
+						"layer_slug":     l.GetSlug(),
+						"layer_prefix":   l.GetPrefix(),
+						"registered_key": key,
 					}),
 				}, options...)
 

--- a/pkg/cmds/middlewares/cobra.go
+++ b/pkg/cmds/middlewares/cobra.go
@@ -3,7 +3,6 @@ package middlewares
 import (
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
-	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
@@ -25,7 +24,6 @@ func ParseFromCobraCommand(cmd *cobra.Command, options ...parameters.ParseStepOp
 			}
 
 			err = layers_.ForEachE(func(key string, l layers.ParameterLayer) error {
-				log.Debug().Str("registeredKey", key).Str("layerSlug", l.GetSlug()).Str("layerName", l.GetName()).Msg("ParseFromCobraCommand: iterating layer")
 				options_ := append([]parameters.ParseStepOption{
 					parameters.WithParseStepMetadata(map[string]interface{}{
 						"layer":          l.GetName(),
@@ -38,7 +36,6 @@ func ParseFromCobraCommand(cmd *cobra.Command, options ...parameters.ParseStepOp
 				parsedLayer := parsedLayers.GetOrCreate(l)
 
 				if cobraLayer, ok := l.(layers.CobraParameterLayer); ok {
-					log.Debug().Str("layerSlug", l.GetSlug()).Msg("ParseFromCobraCommand: parsing layer from cobra")
 					cobraLayer, err := cobraLayer.ParseLayerFromCobraCommand(cmd, options_...)
 					if err != nil {
 						return err

--- a/pkg/cmds/parameters/viper.go
+++ b/pkg/cmds/parameters/viper.go
@@ -3,6 +3,7 @@ package parameters
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+	"strings"
 )
 
 func (pds *ParameterDefinitions) GatherFlagsFromViper(
@@ -36,11 +37,14 @@ func (pds *ParameterDefinitions) GatherFlagsFromViper(
 			continue
 		}
 
-		// TODO(manuel, 2023-12-22) Would be cool if viper were to tell us where the flag came from...
+		// Add metadata about the viper key and derived env key shape
+		upperKey := strings.ToUpper(strings.ReplaceAll(flagName, "-", "_"))
+		meta := map[string]interface{}{
+			"flag":    flagName,
+			"env_key": upperKey,
+		}
 		options := append([]ParseStepOption{
-			WithParseStepMetadata(map[string]interface{}{
-				"flag": flagName,
-			}),
+			WithParseStepMetadata(meta),
 			WithParseStepSource("viper"),
 		}, options...)
 		//exhaustive:ignore

--- a/pkg/doc/topics/13-layers-and-parsed-layers.md
+++ b/pkg/doc/topics/13-layers-and-parsed-layers.md
@@ -161,6 +161,30 @@ layers := NewParameterLayers(
 )
 ```
 
+### Registering Layers Under Explicit Slugs on Commands
+
+When creating a `cmds.CommandDescription`, you can register layers under explicit slugs using `cmds.WithLayersMap`.
+
+```go
+// Create layers with internal slugs
+cfgLayer, _ := layers.NewParameterLayer("config", "Configuration")
+outLayer, _ := layers.NewParameterLayer("output", "Output")
+
+// Register them under different command slugs
+cmd := cmds.NewCommandDescription(
+    "run",
+    cmds.WithLayersMap(map[string]layers.ParameterLayer{
+        "cfg": cfgLayer,   // registered as "cfg"
+        "out": outLayer,   // registered as "out"
+    }),
+)
+
+// Later, parsed layers will be accessed by these slugs
+// parsedLayers.InitializeStruct("cfg", &myCfg)
+```
+
+Note: If the layer is a `*layers.ParameterLayerImpl` and the key differs from the layer's internal slug, the layer is cloned and aligned to the registration key to maintain consistency at runtime.
+
 ### Accessing Layer Information
 
 ```go

--- a/pkg/doc/topics/layers-guide.md
+++ b/pkg/doc/topics/layers-guide.md
@@ -584,6 +584,29 @@ dbLayer, _ := NewDatabaseLayerBuilder().
     Build()
 ```
 
+### Method 4: Registering Layers with Explicit Slugs on Commands
+
+In some cases you may want to register layers on a command under explicit slugs that differ from the layer's internal slug. Use `cmds.WithLayersMap` to provide a map of slug-to-layer entries when creating a command description.
+
+```go
+dbLayer, _ := NewDatabaseLayer()        // internal slug: "database"
+loggingLayer, _ := NewLoggingLayer()    // internal slug: "logging"
+
+cmd := cmds.NewCommandDescription(
+    "process",
+    cmds.WithLayersMap(map[string]layers.ParameterLayer{
+        "db":  dbLayer,    // registered under explicit slug "db"
+        "log": loggingLayer,
+    }),
+)
+
+// Later at runtime, access by the registration slugs (e.g., "db", "log")
+```
+
+Note:
+- If a layer's internal slug differs from the map key and the layer is a `*layers.ParameterLayerImpl`, Glazed will clone the layer and align its slug to the provided key for consistent runtime behavior.
+- For custom layer implementations, prefer using matching internal and registration slugs when possible.
+
 ## Practical Examples
 
 ### Example 1: Web Server Application


### PR DESCRIPTION
- Introduce support for registering layers under explicit slugs using
  `cmds.WithLayersMap`.
- Enable multiple instances of the same layer with different slugs for
  improved parsing and debugging.
- Ensure that if a layer's internal slug differs from the provided key,
  the layer can be cloned and aligned to maintain consistency.
- Enhance metadata associated with layers during parsing for better
  traceability.
- Update documentation to provide examples on how to use the new feature
  effectively.