### PR TITLE
Add dedicated dual-commands documentation

### DIFF
--- a/cmd/examples/refactor-new-packages/README.md
+++ b/cmd/examples/refactor-new-packages/README.md
@@ -7,7 +7,7 @@ This example demonstrates the new wrapper packages (`schema`, `fields`, `values`
 Show how to use the new vocabulary packages to:
 - Define schema sections using `schema.NewSection()`
 - Define field definitions using `fields.New()`
-- Decode resolved values into structs using `values.DecodeSectionInto()`
+- Decode resolved values into structs using `vals.DecodeSectionInto()`
 - Demonstrate env + cobra parsing with proper precedence
 
 ## Usage
@@ -75,7 +75,7 @@ The example defines three schema sections:
 
 - Uses `schema.NewSection()` to create schema sections
 - Uses `fields.New()` to define fields with types and options
-- Uses `values.DecodeSectionInto()` to decode resolved values into structs
+- Uses `vals.DecodeSectionInto()` to decode resolved values into structs
 - Uses `cli.BuildCobraCommand()` with `CobraParserConfig.AppName` for env parsing
 
 ## Related

--- a/cmd/examples/register-cobra/README.md
+++ b/cmd/examples/register-cobra/README.md
@@ -5,7 +5,7 @@ This example demonstrates the four different ways to register commands with Cobr
 ## 1. Bare Command (`bare`)
 A simple command that implements only the `BareCommand` interface:
 - Outputs text directly to stdout
-- Uses the traditional `BuildCobraCommandFromBareCommand` builder
+- Uses `cli.BuildCobraCommand`
 
 ```bash
 go run . bare --message "Hello World!"
@@ -14,7 +14,7 @@ go run . bare --message "Hello World!"
 ## 2. Writer Command (`writer`)
 A command that implements the `WriterCommand` interface:
 - Outputs to a specified `io.Writer`
-- Uses the traditional `BuildCobraCommandFromWriterCommand` builder
+- Uses `cli.BuildCobraCommand`
 
 ```bash
 go run . writer --count 3
@@ -23,7 +23,7 @@ go run . writer --count 3
 ## 3. Glaze Command (`glaze`)
 A command that implements the `GlazeCommand` interface:
 - Outputs structured data through the Glaze processor
-- Uses the traditional `BuildCobraCommandFromGlazeCommand` builder
+- Uses `cli.BuildCobraCommand`
 - Supports all Glaze output formatting options
 
 ```bash
@@ -40,7 +40,7 @@ go run . glaze --rows 3 --output csv
 ## 4. Dual Command (`dual`) - NEW!
 A command that implements both `BareCommand` and `GlazeCommand` interfaces:
 - Can run in both classic and glaze modes
-- Uses the new `BuildCobraCommandDualMode` builder
+- Uses `cli.BuildCobraCommand` with `cli.WithDualMode(true)`
 - Mode is controlled by the `--with-glaze-output` flag
 
 ```bash
@@ -64,13 +64,14 @@ go run . dual --name "Manuel" --times 2 --with-glaze-output --output json
 
 ## Customization Options
 
-The dual command builder supports several options:
+Dual-mode registration supports several options:
 
 ```go
-cobraDualCmd, err := cli.BuildCobraCommandDualMode(
+cobraDualCmd, err := cli.BuildCobraCommand(
     dualCmd,
-    cli.WithGlazeToggleFlag("custom-flag-name"),     // Rename the toggle flag
-    cli.WithHiddenGlazeFlags("output", "format"),    // Keep specific flags hidden
-    cli.WithDefaultToGlaze(),                        // Make glaze mode the default
+    cli.WithDualMode(true),
+    cli.WithGlazeToggleFlag("custom-flag-name"),      // Rename the toggle flag
+    cli.WithHiddenGlazeFlags("output", "format"),   // Keep specific flags hidden
+    cli.WithDefaultToGlaze(),                         // Make glaze mode the default
 )
 ```

--- a/pkg/doc/topics/07-dual-commands.md
+++ b/pkg/doc/topics/07-dual-commands.md
@@ -1,0 +1,181 @@
+---
+Title: Dual Commands
+Slug: dual-commands
+Short: Build commands with both human-readable and structured output
+Topics:
+- commands
+- dual-mode
+- bare-command
+- glaze-command
+- structured-output
+IsTemplate: false
+IsTopLevel: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+# Dual Commands
+
+Dual commands implement both `BareCommand` and `GlazeCommand` interfaces, switching between human-readable and structured output based on the `--with-glaze-output` flag.
+
+## When to Use
+
+- **Interactive use** needs readable text output
+- **Scripting/integration** needs machine-parseable data (JSON, YAML, CSV)
+- Single command serves both use cases
+
+## Minimal Example
+
+```go
+type StatusCommand struct {
+    *cmds.CommandDescription
+}
+
+type StatusSettings struct {
+    Verbose bool `glazed:"verbose"`
+}
+
+// BareCommand: human-readable output
+func (c *StatusCommand) Run(ctx context.Context, parsedLayers *layers.ParsedLayers) error {
+    s := &StatusSettings{}
+    if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+        return err
+    }
+    fmt.Println("Status: Healthy")
+    if s.Verbose {
+        fmt.Println("Version: 1.0.0")
+    }
+    return nil
+}
+
+// GlazeCommand: structured output
+func (c *StatusCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+    s := &StatusSettings{}
+    if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+        return err
+    }
+    row := types.NewRow(
+        types.MRP("status", "healthy"),
+    )
+    if s.Verbose {
+        row.Set("version", "1.0.0")
+    }
+    return gp.AddRow(ctx, row)
+}
+
+var _ cmds.BareCommand = &StatusCommand{}
+var _ cmds.GlazeCommand = &StatusCommand{}
+```
+
+## Builder Options
+
+```go
+cobraCmd, err := cli.BuildCobraCommand(cmd,
+    cli.WithDualMode(true),                  // enable dual-mode toggle
+    cli.WithGlazeToggleFlag("with-glaze-output"), // flag name
+    cli.WithDefaultToGlaze(),                // default to glaze mode (optional)
+    cli.WithHiddenGlazeFlags("template", "select"), // hide specific glaze flags
+)
+```
+
+| Option | Description |
+|--------|-------------|
+| `WithDualMode(true)` | Enable toggle between BareCommand and GlazeCommand |
+| `WithGlazeToggleFlag` | Set the flag name (default: `with-glaze-output`) |
+| `WithDefaultToGlaze` | Start in glaze mode instead of classic mode |
+| `WithHiddenGlazeFlags` | Hide specific glaze output flags |
+
+## Default Output Format
+
+Set the default output format for glaze mode using `WithOutputParameterLayerOptions`:
+
+```go
+glazedLayer, err := settings.NewGlazedParameterLayers(
+    settings.WithOutputParameterLayerOptions(
+        layers.WithDefaults(map[string]interface{}{
+            "output": "json",  // default to JSON
+        }),
+    ),
+)
+```
+
+## Common Patterns
+
+### Field Consistency
+
+When multiple commands output similar data, use consistent field names:
+
+```go
+// Common fields across cloud commands
+types.MRP("id", node.Id()),
+types.MRP("name", node.Name()),
+types.MRP("type", node.Document.Type),
+types.MRP("is_dir", node.IsDirectory()),
+types.MRP("path", buildPathFromParents(node)),
+```
+
+### Error Handling in Callbacks
+
+When iterating (e.g., WalkTree), `gp.AddRow()` returns `error`, not `bool`:
+
+```go
+// ❌ Wrong: returns error, not bool
+Visit: func(node *model.Node, _ []string) bool {
+    gp.AddRow(ctx, row)  // ignores error
+    return err            // compile error
+}
+
+// ✅ Correct: handle or ignore error
+Visit: func(node *model.Node, _ []string) bool {
+    if err := gp.AddRow(ctx, row); err != nil {
+        // log or handle
+    }
+    return false  // continue walking
+}
+```
+
+### Settings Struct Pattern
+
+Share the same settings struct between both interface implementations:
+
+```go
+type FindSettings struct {
+    AuthSettings
+    Compact bool `glazed.parameter:"compact"`
+    Start   string `glazed.parameter:"start"`
+    Pattern string `glazed.parameter:"pattern"`
+}
+
+// Used by both Run() and RunIntoGlazeProcessor()
+func (c *FindCommand) Run(ctx context.Context, parsedLayers *layers.ParsedLayers) error {
+    s := &FindSettings{}
+    parsedLayers.InitializeStruct(layers.DefaultSlug, s)
+    // ...
+}
+
+func (c *FindCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+    s := &FindSettings{}
+    parsedLayers.InitializeStruct(layers.DefaultSlug, s)
+    // ...
+}
+```
+
+## Testing
+
+```bash
+# Classic mode (default)
+./remarquee cloud ls
+
+# Glaze mode - JSON (now default if configured)
+./remarquee cloud ls --with-glaze-output
+
+# Override format
+./remarquee cloud ls --with-glaze-output --output yaml
+./remarquee cloud ls --with-glaze-output --output csv --fields name,path
+```
+
+## Reference
+
+- Tutorial: `glazed/pkg/doc/tutorials/05-build-first-command.md`
+- Commands reference: `glazed/pkg/doc/topics/commands-reference.md`
+- Example: `cmd/examples/new-api-dual-mode/main.go`

--- a/pkg/doc/topics/07-dual-commands.md
+++ b/pkg/doc/topics/07-dual-commands.md
@@ -36,9 +36,9 @@ type StatusSettings struct {
 }
 
 // BareCommand: human-readable output
-func (c *StatusCommand) Run(ctx context.Context, parsedLayers *layers.ParsedLayers) error {
+func (c *StatusCommand) Run(ctx context.Context, vals *values.Values) error {
     s := &StatusSettings{}
-    if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+    if err := vals.DecodeSectionInto(schema.DefaultSlug, s); err != nil {
         return err
     }
     fmt.Println("Status: Healthy")
@@ -49,9 +49,9 @@ func (c *StatusCommand) Run(ctx context.Context, parsedLayers *layers.ParsedLaye
 }
 
 // GlazeCommand: structured output
-func (c *StatusCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+func (c *StatusCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values.Values, gp middlewares.Processor) error {
     s := &StatusSettings{}
-    if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+    if err := vals.DecodeSectionInto(schema.DefaultSlug, s); err != nil {
         return err
     }
     row := types.NewRow(
@@ -87,13 +87,13 @@ cobraCmd, err := cli.BuildCobraCommand(cmd,
 
 ## Default Output Format
 
-Set the default output format for glaze mode using `WithOutputParameterLayerOptions`:
+Set the default output format for glaze mode using `WithOutputSectionOptions`:
 
 ```go
-glazedLayer, err := settings.NewGlazedParameterLayers(
-    settings.WithOutputParameterLayerOptions(
-        layers.WithDefaults(map[string]interface{}{
-            "output": "json",  // default to JSON
+glazedSection, err := settings.NewGlazedSection(
+    settings.WithOutputSectionOptions(
+        schema.WithDefaults(map[string]interface{}{
+            "output": "json", // default to JSON
         }),
     ),
 )
@@ -141,21 +141,25 @@ Share the same settings struct between both interface implementations:
 ```go
 type FindSettings struct {
     AuthSettings
-    Compact bool `glazed.parameter:"compact"`
-    Start   string `glazed.parameter:"start"`
-    Pattern string `glazed.parameter:"pattern"`
+    Compact bool   `glazed:"compact"`
+    Start   string `glazed:"start"`
+    Pattern string `glazed:"pattern"`
 }
 
 // Used by both Run() and RunIntoGlazeProcessor()
-func (c *FindCommand) Run(ctx context.Context, parsedLayers *layers.ParsedLayers) error {
+func (c *FindCommand) Run(ctx context.Context, vals *values.Values) error {
     s := &FindSettings{}
-    parsedLayers.InitializeStruct(layers.DefaultSlug, s)
+    if err := vals.DecodeSectionInto(schema.DefaultSlug, s); err != nil {
+        return err
+    }
     // ...
 }
 
-func (c *FindCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+func (c *FindCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values.Values, gp middlewares.Processor) error {
     s := &FindSettings{}
-    parsedLayers.InitializeStruct(layers.DefaultSlug, s)
+    if err := vals.DecodeSectionInto(schema.DefaultSlug, s); err != nil {
+        return err
+    }
     // ...
 }
 ```

--- a/pkg/doc/topics/commands-reference.md
+++ b/pkg/doc/topics/commands-reference.md
@@ -318,54 +318,23 @@ All from the same command implementation.
 
 ### Dual Commands
 
-Dual commands implement multiple interfaces and switch between output modes based on runtime flags. This approach provides both human-readable text output and structured data from a single command.
+Dual commands implement multiple interfaces and switch between output modes based on runtime flags. For the complete guide, see [Dual Commands](./07-dual-commands.md).
 
-Dual commands address the need for different output formats: interactive use typically requires readable text output, while scripts need structured data. Rather than maintaining separate commands, dual commands adapt their behavior based on context.
+**Quick reference:**
 
 ```go
-// Dual command example
-type StatusCommand struct {
-    *cmds.CommandDescription
-}
-
-// Implement BareCommand for classic mode
-func (c *StatusCommand) Run(ctx context.Context, parsedSections *values.Values) error {
-    s := &StatusSettings{}
-    if err := parsedSections.DecodeSectionInto(schema.DefaultSlug, s); err != nil {
-        return err
-    }
-    
-    // Human-readable output
-    fmt.Printf("System Status:\n")
-    fmt.Printf("  CPU: %.1f%%\n", s.CPUUsage)
-    fmt.Printf("  Memory: %s\n", s.MemoryUsage)
-    return nil
-}
-
-// Implement GlazeCommand for structured output mode
-func (c *StatusCommand) RunIntoGlazeProcessor(
-    ctx context.Context, 
-    parsedSections *values.Values, 
-    gp middlewares.Processor,
-) error {
-    s := &StatusSettings{}
-    if err := parsedSections.DecodeSectionInto(schema.DefaultSlug, s); err != nil {
-        return err
-    }
-    
-    // Structured data output
-    row := types.NewRow(
-        types.MRP("cpu_usage", s.CPUUsage),
-        types.MRP("memory_usage", s.MemoryUsage),
-        types.MRP("timestamp", time.Now()),
-    )
-    return gp.AddRow(ctx, row)
-}
-
-// Ensure both interfaces are implemented
+// Implement both interfaces
 var _ cmds.BareCommand = &StatusCommand{}
 var _ cmds.GlazeCommand = &StatusCommand{}
+
+// Build with dual mode
+cli.BuildCobraCommand(cmd,
+    cli.WithDualMode(true),
+    cli.WithGlazeToggleFlag("with-glaze-output"),
+)
 ```
+
+See [Dual Commands](./07-dual-commands.md) for advanced options (default output format, hidden flags, callback patterns).
 
 ## Command Implementation
 
@@ -898,18 +867,7 @@ if err != nil {
 }
 ```
 
-### Dual Command Builder Options
-
-The dual command builder supports several customization options:
-
-```go
-cobraCmd, err := cli.BuildCobraCommand(dualCmd,
-    cli.WithDualMode(true),                  // enable dual-mode
-    cli.WithGlazeToggleFlag("structured-output"),
-    cli.WithHiddenGlazeFlags("template", "select"),
-    cli.WithDefaultToGlaze(),                // default to glaze
-)
-```
+See [Dual Commands](./07-dual-commands.md) for complete documentation of all builder options.
 
 ## Best Practices
 
@@ -922,7 +880,7 @@ Choose interfaces based on user requirements:
 - **BareCommand** when users need rich feedback, progress updates, or interactive elements
 - **WriterCommand** when output might go to files, logs, or other destinations
 - **GlazeCommand** when data will be processed, filtered, or integrated with other tools
-- **Dual Commands** when usage patterns vary
+- **Dual Commands** when usage patterns vary — see [Dual Commands](./07-dual-commands.md)
 
 Example: A backup command might start as BareCommand for user feedback (`Backing up 1,247 files...`), but users eventually want structured output for monitoring scripts. A dual command serves both needs.
 

--- a/pkg/doc/tutorials/05-build-first-command.md
+++ b/pkg/doc/tutorials/05-build-first-command.md
@@ -112,7 +112,7 @@ func (c *ListUsersCommand) RunIntoGlazeProcessor(
 ) error {
     // Parse settings from command line
     settings := &ListUsersSettings{}
-    if err := values.DecodeSectionInto(vals, schema.DefaultSlug, settings); err != nil {
+    if err := vals.DecodeSectionInto(schema.DefaultSlug, settings); err != nil {
         return err
     }
 
@@ -141,18 +141,18 @@ func (c *ListUsersCommand) RunIntoGlazeProcessor(
 
 **Implementation details:**
 
-1. **Settings Extraction**: `values.DecodeSectionInto()` (or `vals.DecodeSectionInto()`) populates the settings struct from resolved values with automatic parsing and validation
+1. **Settings Extraction**: `vals.DecodeSectionInto()` populates the settings struct from resolved values with automatic parsing and validation
 2. **Business Logic**: `generateMockUsers()` simulates data retrieval with the parsed settings
 3. **Structured Output**: Creates `types.Row` objects instead of using direct output functions
 4. **Row Structure**: `types.MRP("key", value)` creates key-value pairs for each data field
 
 The `GlazeProcessor` collects these rows and can output them in multiple formats without additional format-specific code.
 
-**Important — Decode values into a struct:** Always decode resolved values into your settings struct using `values.DecodeSectionInto(vals, schema.DefaultSlug, &YourSettings{})` (or the underlying `vals.DecodeSectionInto(schema.DefaultSlug, &YourSettings{})`). Avoid reading Cobra flags directly; decoding ensures defaults, validation, and help text stay consistent with your schema field definitions and active sections.
+**Important — Decode values into a struct:** Always decode resolved values into your settings struct using `vals.DecodeSectionInto(schema.DefaultSlug, &YourSettings{})`. Avoid reading Cobra flags directly; decoding ensures defaults, validation, and help text stay consistent with your schema field definitions and active sections.
 
 ### Command Configuration and Fields
 
-Command configuration combines your custom fields with Glazed's built-in output formatting capabilities. The `settings.NewGlazedSchema()` helper (a wrapper around `settings.NewGlazedSchema()`) adds standard flags like `--output`, `--fields`, and `--sort-columns`, while your custom field definitions specify the command's business logic inputs.
+Command configuration combines your custom fields with Glazed's built-in output formatting capabilities. The `settings.NewGlazedSchema()` helper adds standard flags like `--output`, `--fields`, and `--sort-columns`, while your custom field definitions specify the command's business logic inputs.
 
 ```go
 // Step 2.4: Create constructor function
@@ -599,7 +599,7 @@ cmds.WithFlags(
 ```go
 func (c *ListUsersCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values.Values, gp middlewares.Processor) error {
     settings := &ListUsersSettings{}
-    if err := values.DecodeSectionInto(vals, schema.DefaultSlug, settings); err != nil {
+    if err := vals.DecodeSectionInto(schema.DefaultSlug, settings); err != nil {
         return fmt.Errorf("failed to parse settings: %w", err)
     }
     

--- a/pkg/doc/tutorials/05-build-first-command.md
+++ b/pkg/doc/tutorials/05-build-first-command.md
@@ -507,182 +507,35 @@ The primary benefit of using `types.Row` objects is automatic support for multip
 
 ## Step 5: Dual Commands (Advanced)
 
-Some commands benefit from providing both human-readable text output and machine-parseable structured data. Glazed supports this pattern through dual commands that implement both `BareCommand` and `GlazeCommand` interfaces, with automatic switching between output modes.
+Some commands benefit from providing both human-readable text output and machine-parseable structured data. Glazed supports this pattern through dual commands that implement both `BareCommand` and `GlazeCommand` interfaces.
+
+**For the complete guide, see [Dual Commands](../topics/07-dual-commands.md).**
+
+**Key pattern:**
 
 ```go
-// Dual command that implements both BareCommand and GlazeCommand
-type StatusCommand struct {
-    *cmds.CommandDescription
-}
-
-// Settings for status command
-type StatusSettings struct {
-    Verbose bool `glazed:"verbose"`
-}
-
-// Classic mode - simple text output
-func (c *StatusCommand) Run(ctx context.Context, vals *values.Values) error {
-    settings := &StatusSettings{}
-    if err := values.DecodeSectionInto(vals, schema.DefaultSlug, settings); err != nil {
-        return err
-    }
-    
-    fmt.Println("System Status:")
-    fmt.Println("  Users: 8 total, 6 active")
-    fmt.Println("  Departments: 5")
-    fmt.Println("  Status: Healthy")
-    
-    if settings.Verbose {
-        fmt.Println("  Last updated:", time.Now().Format("2006-01-02 15:04:05"))
-        fmt.Println("  Version: 1.0.0")
-    }
-    
-    return nil
-}
-
-// Glaze mode - structured output
-func (c *StatusCommand) RunIntoGlazeProcessor(
-    ctx context.Context,
-    vals *values.Values,
-    gp middlewares.Processor,
-) error {
-    settings := &StatusSettings{}
-    if err := values.DecodeSectionInto(vals, schema.DefaultSlug, settings); err != nil {
-        return err
-    }
-    
-    row := types.NewRow(
-        types.MRP("total_users", 8),
-        types.MRP("active_users", 6),
-        types.MRP("departments", 5),
-        types.MRP("status", "healthy"),
-        types.MRP("timestamp", time.Now().Format(time.RFC3339)),
-    )
-    
-    if settings.Verbose {
-        row.Set("version", "1.0.0")
-        row.Set("uptime", "24h30m")
-    }
-    
-    return gp.AddRow(ctx, row)
-}
-
-// Constructor for status command
-func NewStatusCommand() (*StatusCommand, error) {
-    // Add command settings section for debugging features
-    commandSettingsSection, err := cli.NewCommandSettingsSection()
-    if err != nil {
-        return nil, err
-    }
-
-    cmdDesc := cmds.NewCommandDescription(
-        "status",
-        cmds.WithShort("Show system status"),
-        cmds.WithLong("Show system status in either human-readable or structured format"),
-        cmds.WithFlags(
-            fields.New(
-                "verbose",
-                fields.TypeBool,
-                fields.WithDefault(false),
-                fields.WithHelp("Show additional details"),
-                fields.WithShortFlag("v"),
-            ),
-        ),
-        cmds.WithSectionsList(commandSettingsSection),
-    )
-    
-    return &StatusCommand{
-        CommandDescription: cmdDesc,
-    }, nil
-}
-
-// Ensure both interfaces are implemented
+// Implement both interfaces
 var _ cmds.BareCommand = &StatusCommand{}
 var _ cmds.GlazeCommand = &StatusCommand{}
-```
 
-**Dual command pattern:**
-
-The `StatusCommand` implements two interfaces:
-
-1. **`BareCommand`** (via `Run` method): Produces human-readable text output
-2. **`GlazeCommand`** (via `RunIntoGlazeProcessor` method): Produces structured data
-
-**Interface differences:**
-- **Human Mode**: Uses `fmt.Println()` for formatted text display
-- **Structured Mode**: Uses `types.Row` for machine-parseable data
-- **Shared Logic**: Both methods access the same parsed settings
-
-### Integrating the Dual Command
-
-Dual commands enable dual-mode behavior via `cli.WithDualMode(true)` (or the deprecated `BuildCobraCommandDualMode` helper). The builder detects both interface implementations and creates a toggle flag to switch between output modes.
-
-```go
-// Create status command with dual mode
-statusCmd, err := NewStatusCommand()
-if err != nil {
-    fmt.Fprintf(os.Stderr, "Error creating status command: %v\n", err)
-    os.Exit(1)
-}
-
-// Build with dual-mode enabled and custom parser settings
-cobraStatusCmd, err := cli.BuildCobraCommand(statusCmd,
+// Build with dual mode
+cli.BuildCobraCommand(cmd,
     cli.WithDualMode(true),
     cli.WithGlazeToggleFlag("with-glaze-output"),
-    cli.WithParserConfig(cli.CobraParserConfig{
-        ShortHelpSections: []string{schema.DefaultSlug},
-        MiddlewaresFunc: cli.CobraCommandDefaultMiddlewares,
-    }),
 )
-if err != nil {
-    fmt.Fprintf(os.Stderr, "Error building status command: %v\n", err)
-    os.Exit(1)
-}
-
-rootCmd.AddCommand(cobraStatusCmd)
-
-// Setup enhanced help system for the complete application
-helpSystem := help.NewHelpSystem()
-help_cmd.SetupCobraRootCommand(helpSystem, rootCmd)
 ```
 
-**Key differences from single-mode commands:**
-
-1. **Dual mode option**: Use `cli.WithDualMode(true)` to enable the dual-command toggle
-2. **Toggle Flag**: `WithGlazeToggleFlag("with-glaze-output")` creates a flag that switches between interfaces
-3. **Automatic Detection**: Glazed detects both interface implementations and configures the toggle mechanism
-
-### Testing Dual Command
-
-Test both output modes:
+**Testing:**
 
 ```bash
-# Rebuild
-go build -o glazed-quickstart
-
 # Classic mode (default)
 ./glazed-quickstart status
-./glazed-quickstart status --verbose
-
-# Test debugging features in classic mode
-./glazed-quickstart status --print-parsed-fields
 
 # Glaze mode
-./glazed-quickstart status --with-glaze-output
 ./glazed-quickstart status --with-glaze-output --output json
-./glazed-quickstart status --with-glaze-output --verbose --output yaml
-
-# Test debugging features in glaze mode
-./glazed-quickstart status --with-glaze-output --print-schema
-
-# Test help system with dual command
-./glazed-quickstart status --help
 ```
 
-**Output comparison:**
-
-- **Classic Mode**: Human-readable text with clear labels and formatting
-- **Glaze Mode**: Structured data compatible with automation tools and scripts
+See [Dual Commands](../topics/07-dual-commands.md) for advanced options like `WithDefaultToGlaze`, setting default output format, and common patterns.
 
 ## Best Practices and Patterns
 


### PR DESCRIPTION
Created pkg/doc/topics/07-dual-commands.md with:
- Minimal example
- Builder options table
- Default output format pattern (WithOutputParameterLayerOptions)
- Common patterns (field consistency, callback error handling)
- Testing examples

Updated existing docs to link to the new guide:
- 05-build-first-command.md: condensed Step 5 to summary + link
- commands-reference.md: condensed dual commands section + link

Net: -8 lines (removed redundancy, consolidated info)

Co-authored-by: pi-coding-agent
