### PR TITLE
Docs: Clarify Cobra parser middleware and config loading

### DIFF
--- a/pkg/cli/cobra-parser.go
+++ b/pkg/cli/cobra-parser.go
@@ -16,22 +16,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// CobraMiddlewaresFunc is a function that returns a list of middlewares for a cobra command.
-// It can be used to overload the default middlewares for cobra commands.
-// It is mostly used to add a "load from json" section set in the GlazedCommandSettings.
+// CobraMiddlewaresFunc returns the full middleware chain for a Cobra command.
+// If you set it on CobraParserConfig, it replaces the built-in parser chain entirely.
+// That means you must re-add any sources you still want (for example env, config,
+// args, flags, or defaults) inside the custom function.
 type CobraMiddlewaresFunc func(
 	parsedCommandSections *values.Values,
 	cmd *cobra.Command,
 	args []string,
 ) ([]cmd_sources.Middleware, error)
 
-// CobraCommandDefaultMiddlewares is the default implementation for creating
-// the middlewares used in a Cobra command. It handles parsing fields
-// from Cobra flags, command line arguments, environment variables, and
-// default values. The middlewares gather all these fields into a
-// FieldValues object.
-//
-// If the commandSettings specify fields to be loaded from a file, this gets added as a middleware.
+// CobraCommandDefaultMiddlewares builds a minimal middleware chain for Cobra commands.
+// It reads Cobra flags and positional arguments, then applies defaults.
+// Use it when you want an explicit chain; if you also need env loading or config
+// file loading, add those middlewares yourself.
 func CobraCommandDefaultMiddlewares(
 	parsedCommandSections *values.Values,
 	cmd *cobra.Command,
@@ -70,13 +68,13 @@ func CobraCommandDefaultMiddlewares(
 // from the description.
 type CobraParser struct {
 	Sections *schema.Schema
-	// middlewaresFunc is called after the command has been executed, once the
-	// GlazedCommandSettings struct has been filled. At this point, cobra has done the parsing
-	// of CLI flags and arguments, but these haven't yet been parsed into Values
-	// by the glazed framework.
+	// middlewaresFunc builds the parser chain after GlazedCommandSettings has been parsed.
+	// At this point, Cobra has already parsed CLI flags and arguments, but the values
+	// have not yet been turned into Glazed Values.
 	//
-	// This hooks allows the implementor to specify additional ways of loading fields
-	// (for example, sqleton loads the dbt and sql connection fields from env as well).
+	// In the built-in parser path, Glazed wires in env/config loading when configured.
+	// If a custom function is supplied through CobraParserConfig, it replaces that
+	// built-in chain and must re-add any sources it still needs.
 	middlewaresFunc CobraMiddlewaresFunc
 	// List of sections to be shown in short help, empty: always show all
 	shortHelpSections []string
@@ -91,15 +89,18 @@ type CobraParser struct {
 type ConfigPlanBuilder func(parsedCommandSections *values.Values, cmd *cobra.Command, args []string) (*glazedConfig.Plan, error)
 
 type CobraParserConfig struct {
+	// MiddlewaresFunc replaces the default Cobra parser chain.
+	// Leave it nil to keep the built-in parser path, which can add env/config loading when configured.
 	MiddlewaresFunc                    CobraMiddlewaresFunc
 	ShortHelpSections                  []string
 	SkipCommandSettingsSection         bool
 	EnableProfileSettingsSection       bool
 	EnableCreateCommandSettingsSection bool
-	// AppName controls the default env prefix (strings.ToUpper(AppName)). It no longer implies config discovery.
+	// AppName controls the default env prefix (strings.ToUpper(AppName)) used by the
+	// built-in parser path. It enables env loading, but it does not imply config discovery.
 	AppName string
-	// ConfigPlanBuilder resolves explicit layered config policy for the command. If nil, the default
-	// Cobra parser path loads no config files automatically.
+	// ConfigPlanBuilder resolves explicit layered config policy for the command.
+	// It is only used by the built-in parser path; if nil, no config files are loaded automatically.
 	ConfigPlanBuilder ConfigPlanBuilder
 }
 
@@ -139,6 +140,7 @@ func NewCobraParserFromSections(
 		ret.skipCommandSettingsSection = cfg.SkipCommandSettingsSection
 		ret.enableProfileSettingsSection = cfg.EnableProfileSettingsSection
 		ret.enableCreateCommandSettingsSection = cfg.EnableCreateCommandSettingsSection
+		// Build the built-in env/config-aware chain only when the caller did not supply a custom middleware function.
 		if cfg.MiddlewaresFunc == nil {
 			cfgCopy := *cfg
 			ret.middlewaresFunc = func(parsedCommandSections *values.Values, cmd *cobra.Command, args []string) ([]cmd_sources.Middleware, error) {

--- a/pkg/doc/topics/21-cmds-middlewares.md
+++ b/pkg/doc/topics/21-cmds-middlewares.md
@@ -719,16 +719,19 @@ func GetCommandMiddlewares(
 }
 ```
 
+> **Warning:** A custom `MiddlewaresFunc` or `GetMiddlewares` replaces Glazed's default Cobra parser chain. Glazed does not merge the defaults for you. If you want env loading, config loading, profiles, or defaults, add those middlewares explicitly in the function you return.
+
 ## Key Points
 
 1. Middleware order determines priority (last middleware runs first)
-2. Use `WithCobraMiddlewaresFunc` or `CobraParserConfig` to add middleware to commands
+2. `WithCobraMiddlewaresFunc` or `CobraParserConfig.MiddlewaresFunc` replaces the default Cobra parser chain, so you own every source in that chain
 3. Common middleware order:
    - Config files (base overlays)
    - Environment
    - Positional arguments
    - Command-line flags (highest)
    - Defaults (lowest)
+4. Leave `MiddlewaresFunc` nil when you want Glazed's built-in env/config-aware Cobra parser path
 
 ## Section-Specific Configuration
 

--- a/pkg/doc/topics/24-config-files.md
+++ b/pkg/doc/topics/24-config-files.md
@@ -63,9 +63,9 @@ func run(cmd *cobra.Command, args []string) error {
 
 ## Option B: Cobra integration (recommended for CLIs)
 
-If you’re building a CLI, the Cobra integration wires configuration, environment variables, positional arguments, and flags into a predictable pipeline with minimal boilerplate. `CobraParserConfig` lets you enable app-wide env prefixes and attach an explicit declarative config plan. This keeps your command code focused on business logic while Glazed handles the parsing pipeline and debug flags (like `--print-parsed-fields`).
+If you’re building a CLI, the Cobra integration keeps environment-variable loading and config-file loading separate on purpose. `AppName` turns on the env prefix for the built-in parser path, while `ConfigPlanBuilder` adds explicit config-file discovery. This keeps your command code focused on business logic while Glazed handles the parsing pipeline and debug flags (like `--print-parsed-fields`).
 
-Use `github.com/go-go-golems/glazed/pkg/cli` to build Cobra commands and attach config processing. The parser config auto-wires env parsing; config loading is explicit through `ConfigPlanBuilder`.
+Use `github.com/go-go-golems/glazed/pkg/cli` to build Cobra commands and attach config processing. The default parser path wires env loading when `AppName` is set; config loading stays explicit through `ConfigPlanBuilder`. If you supply `MiddlewaresFunc`, you replace that built-in chain and must re-add any sources you still want.
 
 ```go
 package main
@@ -87,8 +87,8 @@ func build() (*cobra.Command, error) {
     )
     desc := cmds.NewCommandDescription("demo", cmds.WithSectionsList(demo))
 
-    // AppName enables env overrides (prefix = APPNAME_)
-    // ConfigPlanBuilder defines config discovery explicitly
+    // AppName enables env loading in the default parser path (prefix = APPNAME_)
+    // ConfigPlanBuilder defines config-file discovery explicitly
     return cli.BuildCobraCommandFromCommand(&DemoBare{desc},
         cli.WithParserConfig(cli.CobraParserConfig{
             AppName: "myapp",
@@ -450,7 +450,7 @@ These guidelines help keep your configuration predictable across environments an
 
 - Keep overlays small and ordered: `base.yaml`, `env.yaml`, `local.yaml`.
 - Prefer named captures over wildcards in pattern rules when collecting multiple values.
-- Use `AppName` in `CobraParserConfig` to enable env overrides automatically.
+- Use `AppName` in `CobraParserConfig` to enable env overrides automatically on the built-in parser path.
 - Record parse sources with `sources.WithSource("config")` (done for you by the config middlewares).
 
 ## Example projects and scripts

--- a/pkg/doc/tutorials/05-build-first-command.md
+++ b/pkg/doc/tutorials/05-build-first-command.md
@@ -351,8 +351,8 @@ func main() {
     // Convert to Cobra command with enhanced options
     cobraListUsersCmd, err := cli.BuildCobraCommand(listUsersCmd,
         cli.WithParserConfig(cli.CobraParserConfig{
+            AppName:           "glazed-quickstart",
             ShortHelpSections: []string{schema.DefaultSlug},
-            MiddlewaresFunc: cli.CobraCommandDefaultMiddlewares,
         }),
     )
     if err != nil {
@@ -413,19 +413,31 @@ Key points:
 
 1. **Root Command**: Creates a standard Cobra root command as the application entry point
 2. **Command Creation**: `NewListUsersCommand()` creates the Glazed command with configuration
-3. **Enhanced Cobra Bridge**: Use `cli.WithParserConfig` to pass a `CobraParserConfig` that customizes parser behavior (e.g., `ShortHelpSections`, `MiddlewaresFunc`).
+3. **Enhanced Cobra Bridge**: Use `cli.WithParserConfig` to pass a `CobraParserConfig` that customizes parser behavior (for example `AppName` for env loading and `ShortHelpSections` for help). Only set `MiddlewaresFunc` when you want to replace the built-in chain.
 4. **Registration**: Adds the converted command as a subcommand
 5. **Help System Setup**: `help.NewHelpSystem()` and `help_cmd.SetupCobraRootCommand()` provide enhanced help functionality
 6. **Execution**: Starts the CLI application and processes command-line arguments
 
 **Built-in Command Features**
 
-The `CobraCommandDefaultMiddlewares` provides several useful debugging and configuration features automatically:
+The built-in Cobra parser path (leave `MiddlewaresFunc` nil) provides several useful debugging and configuration features automatically when you set `AppName`. `CobraCommandDefaultMiddlewares` is a lower-level helper for flags, args, and defaults only.
 
 - `--print-parsed-fields`: Shows how fields were parsed from different sources
 - `--print-yaml`: Outputs the command's configuration as YAML
 - `--print-schema`: Displays the command's field schema
 - `--config-file`: Explicit config file path (overlays supported via resolver)
+
+**Environment-Backed Settings**
+
+To read settings from environment variables, keep the default parser chain and use the `AppName` prefix:
+
+```bash
+export GLAZED_QUICKSTART_LIMIT=3
+export GLAZED_QUICKSTART_ACTIVE_ONLY=true
+./glazed-quickstart list-users --print-parsed-fields
+```
+
+The parsed-field output will show `env` entries alongside Cobra flags and defaults. If you supply a custom `MiddlewaresFunc`, you must re-add env loading yourself.
 
 **Enhanced Help System**
 

--- a/pkg/doc/tutorials/config-files-quickstart.md
+++ b/pkg/doc/tutorials/config-files-quickstart.md
@@ -16,7 +16,7 @@ SectionType: Tutorial
 
 This tutorial shows how to load configuration from one or more files using Glazed middlewares. You’ll see a simple single-file setup and a multi-file overlay with deterministic precedence. We’ll also show how to inspect parse steps using `--print-parsed-fields`.
 
-For CLIs, the normal entry point is `CobraParserConfig.ConfigPlanBuilder`. For library-style middleware execution, the equivalent direct APIs are `sources.FromConfigPlan(...)` and `sources.FromConfigPlanBuilder(...)`.
+For CLIs, the normal entry point is `CobraParserConfig`: use `AppName` for env overrides and `ConfigPlanBuilder` for file discovery. For library-style middleware execution, the equivalent direct APIs are `sources.FromConfigPlan(...)` and `sources.FromConfigPlanBuilder(...)`.
 
 ## Prerequisites
 
@@ -43,6 +43,7 @@ cmd := &DemoBareCommand{CommandDescription: desc}
 
 cobraCmd, _ := cli.BuildCobraCommandFromCommand(cmd,
     cli.WithParserConfig(cli.CobraParserConfig{
+        AppName:                   "demo",
         SkipCommandSettingsSection: true,
         ConfigPlanBuilder: func(_ *values.Values, _ *cobra.Command, _ []string) (*config.Plan, error) {
             return config.NewPlan(
@@ -82,6 +83,7 @@ Use a config plan to return an ordered set of files (low → high precedence):
 ```go
 cobraCmd, _ := cli.BuildCobraCommandFromCommand(cmd,
     cli.WithParserConfig(cli.CobraParserConfig{
+        AppName:                   "demo",
         SkipCommandSettingsSection: true,
         ConfigPlanBuilder: func(_ *values.Values, _ *cobra.Command, _ []string) (*config.Plan, error) {
             return config.NewPlan(
@@ -175,10 +177,24 @@ Precedence remains: Defaults < Config Files < Env < Args < Flags.
 
 ```bash
 # Env override
-DEMO_API_KEY=env-var go run ./cmd/examples/config-overlay overlay
+DEMO_API_KEY=env-var go run ./cmd/examples/config-overlay overlay --print-parsed-fields
 
 # Flag override
-go run ./cmd/examples/config-overlay overlay --demo-threshold 77
+go run ./cmd/examples/config-overlay overlay --demo-threshold 77 --print-parsed-fields
+```
+
+Example parse excerpt for the env override:
+
+```yaml
+demo:
+  api-key:
+    log:
+      - source: config
+        metadata: { config_file: base.yaml, index: 0 }
+        value: base
+      - source: env
+        value: env-var
+    value: env-var
 ```
 
 ## 5. Pattern: base + .override.yaml


### PR DESCRIPTION
This change clarifies the behavior of the Cobra parser's middleware handling,
particularly concerning environment variables and config files. The previous
documentation and code comments were ambiguous about how custom middlewares
interact with the built-in loading mechanisms.

The core update is to clearly define two distinct configuration paths:

*   **Built-in Path:** By setting `AppName` and `ConfigPlanBuilder` in the
    `CobraParserConfig`, the framework automatically wires up middlewares for
    environment variables and config files. This is the intended path for most
    use cases.

*   **Custom Path:** Providing a `MiddlewaresFunc` *replaces* the entire
    default middleware chain. The developer is then fully responsible for adding
    all desired sources (flags, args, env, config, defaults) in the correct
    order.