### PR TITLE
Feat: Add `help export` command and support for serving from external sources

### DIFF
--- a/cmd/glaze/main.go
+++ b/cmd/glaze/main.go
@@ -35,6 +35,12 @@ func main() {
 
 	help_cmd.SetupCobraRootCommand(helpSystem, rootCmd)
 
+	// Add the export subcommand to help.
+	helpCmd, _, err := rootCmd.Find([]string{"help"})
+	cobra.CheckErr(err)
+	err = help_cmd.AddExportCommand(helpCmd, helpSystem)
+	cobra.CheckErr(err)
+
 	// Add the serve command (embeds the React SPA via pkg/web).
 	spaHandler, err := web.NewSPAHandler()
 	cobra.CheckErr(err)

--- a/pkg/doc/topics/01-help-system.md
+++ b/pkg/doc/topics/01-help-system.md
@@ -34,6 +34,8 @@ The Glazed help system provides a structured, queryable approach to CLI document
 
 The help system stores sections in an SQLite-backed store, enabling fast queries, text search, and metadata filtering. You typically load documentation from markdown files with YAML frontmatter at startup, creating a self-contained help database that you can query from both the command line and Go code.
 
+You can also export the entire help tree—or a filtered slice of it—to JSON, CSV, YAML, individual markdown files, or a standalone SQLite database. This is useful for backups, external indexing, and shipping documentation alongside your application. See [`glaze help export-help-entries`](glaze help export-help-entries) for details.
+
 ## Section Types and Structure
 
 Help sections follow a type-based classification system that separates conceptual documentation from practical examples. This separation enables precise filtering and contextual help display, allowing users to find exactly the type of information they need based on their current task.
@@ -358,3 +360,11 @@ For more information about the query DSL syntax and capabilities:
 ```
 glaze help simple-query-dsl
 ```
+
+## See Also
+
+- [`glaze help export-help-entries`](glaze help export-help-entries) — Export help sections to files, JSON, CSV, or SQLite
+- [`glaze help serve-help-over-http`](glaze help serve-help-over-http) — Browse help in a web browser
+- [`glaze help export-help-static-website`](glaze help export-help-static-website) — Export help as a static website
+- [`glaze help writing-help-entries`](glaze help writing-help-entries) — How to write help sections
+- [`glaze help sections-guide`](glaze help sections-guide) — Deep dive into section metadata and query DSL

--- a/pkg/doc/topics/25-serving-help-over-http.md
+++ b/pkg/doc/topics/25-serving-help-over-http.md
@@ -249,6 +249,7 @@ If a page does not appear in the browser, the most common cause is that the mark
 
 ## See Also
 
+- `glaze help export-help-entries` — Export help sections to files, JSON, CSV, or SQLite
 - `glaze help export-help-static-website`
 - `glaze help help-system`
 - `glaze help writing-help-entries`

--- a/pkg/doc/topics/25-serving-help-over-http.md
+++ b/pkg/doc/topics/25-serving-help-over-http.md
@@ -249,6 +249,7 @@ If a page does not appear in the browser, the most common cause is that the mark
 
 ## See Also
 
+- `glaze help serve-external-help-sources` — Serve help exported from other Glazed binaries and snapshots
 - `glaze help export-help-entries` — Export help sections to files, JSON, CSV, or SQLite
 - `glaze help export-help-static-website`
 - `glaze help help-system`

--- a/pkg/doc/topics/26-export-help-as-static-website.md
+++ b/pkg/doc/topics/26-export-help-as-static-website.md
@@ -146,6 +146,7 @@ Choose `serve` when you want a running server process. Choose `render-site` when
 
 ## See Also
 
+- `glaze help export-help-entries` — Export help sections to files, JSON, CSV, or SQLite
 - `glaze help serve-help-over-http`
 - `glaze help writing-help-entries`
 - `glaze help how-to-write-good-documentation-pages`

--- a/pkg/doc/topics/28-export-help-entries.md
+++ b/pkg/doc/topics/28-export-help-entries.md
@@ -1,0 +1,248 @@
+---
+Title: Export Help Entries
+Slug: export-help-entries
+Short: Use `glaze help export` to export help section metadata and content to JSON, CSV, files, or SQLite for backup, indexing, and external tooling.
+Topics:
+- help
+- export
+- cli
+- sqlite
+- json
+- documentation
+Commands:
+- help
+- export
+Flags:
+- with-content
+- format
+- output-path
+- flatten-dirs
+- type
+- topic
+- command
+- flag
+- slug
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+## Why `glaze help export` exists
+
+The Glazed help system stores documentation in an SQLite-backed store at runtime. That makes querying fast, but it also means the data is trapped inside a running process. `glaze help export` solves this by letting you dump the entire help tree—or a filtered slice of it—to formats you can use elsewhere.
+
+This matters when you want to:
+
+- back up or version-control your help content as plain files,
+- feed help metadata into an external search index or CMS,
+- generate reports on documentation coverage (which commands have examples, which topics are missing),
+- or ship a SQLite database of your app's documentation alongside the binary.
+
+The command is built on the same `HelpSystem` and `Store` primitives that `glaze serve` and `glaze render-site` use, so the exported data is always consistent with what the CLI and the web browser show.
+
+## Basic usage
+
+The simplest invocation exports every loaded section as JSON:
+
+```bash
+glaze help export --output json
+```
+
+By default, `--with-content` is `true`, so the JSON includes the full markdown body of each section. If you only need metadata, disable content:
+
+```bash
+glaze help export --with-content=false --output csv
+```
+
+## Export formats
+
+The `--format` flag controls the export target:
+
+| Format | What it produces | Best for |
+|--------|-----------------|----------|
+| `glazed` (default) | Tabular output via the GlazeProcessor | JSON, CSV, YAML, or table dumps to stdout |
+| `files` | One `.md` file per section on disk | Backup, version control, or editing |
+| `sqlite` | A standalone SQLite database | Querying with SQL, shipping with apps |
+
+### Tabular export (`--format glazed`)
+
+This is the default. It behaves like any other Glazed command: you can choose the output serializer with `--output`.
+
+```bash
+# Pretty-printed JSON with full content
+glaze help export --output json
+
+# Compact CSV for spreadsheet import
+glaze help export --with-content=false --output csv
+
+# YAML for human review
+glaze help export --output yaml
+```
+
+The tabular mode emits one row per section with these columns:
+
+| Column | Description |
+|--------|-------------|
+| `slug` | Unique section identifier |
+| `title` | Display title |
+| `short` | One-line description |
+| `content` | Full markdown body (omitted when `--with-content=false`) |
+| `section_type` | `GeneralTopic`, `Example`, `Application`, or `Tutorial` |
+| `topics` | Comma-separated topic tags |
+| `commands` | Comma-linked command associations |
+| `flags` | Comma-linked flag associations |
+| `is_top_level` | Whether the section appears in top-level listings |
+| `show_per_default` | Whether the section is shown without `--all` |
+| `order` | Sort order within its type group |
+
+### File export (`--format files`)
+
+File mode writes each section to a separate `.md` file, reconstructing the original frontmatter so the files can be re-loaded into Glazed later.
+
+```bash
+# Default: typed subdirectories
+glaze help export --format files --output-path ./exported-help
+```
+
+This produces a directory tree like:
+
+```
+exported-help/
+  general-topic/
+    help-system.md
+    sections-guide.md
+  example/
+    json-output.md
+  application/
+    real-world-pipeline.md
+  tutorial/
+    getting-started.md
+```
+
+If you prefer a flat layout, use `--flatten-dirs`:
+
+```bash
+glaze help export --format files --output-path ./flat --flatten-dirs
+```
+
+Which produces:
+
+```
+flat/
+  help-system.md
+  sections-guide.md
+  json-output.md
+  ...
+```
+
+Each exported file is a valid Glazed help section. You can load it back with:
+
+```bash
+glaze serve ./exported-help
+```
+
+### SQLite export (`--format sqlite`)
+
+SQLite mode creates a new database file containing all exported sections in the same schema that Glazed uses internally.
+
+```bash
+glaze help export --format sqlite --output-path ./help.db
+```
+
+You can then query it directly:
+
+```bash
+sqlite3 ./help.db "SELECT slug, title, section_type FROM sections LIMIT 5;"
+```
+
+The exported database is fully self-contained. It does not depend on the original application binary, so you can ship it to tools that understand Glazed's schema or use it as a snapshot for offline browsing.
+
+## Filtering exports
+
+You rarely need to export everything. The command accepts the same metadata filters that `glaze help` uses for querying:
+
+```bash
+# Export only examples about JSON
+glaze help export --type Example --topic json --output yaml
+
+# Export sections related to a specific command
+glaze help export --command serve --format files --output-path ./serve-docs
+
+# Export by exact slug (useful for one-off backups)
+glaze help export --slug help-system --output json
+
+# Combine multiple filters (AND logic)
+glaze help export --type Example --topic advanced --command json --output csv
+```
+
+Available filters:
+
+| Flag | Matches |
+|------|---------|
+| `--type` | Section type: `GeneralTopic`, `Example`, `Application`, `Tutorial` |
+| `--topic` | Topic tag in the section's `Topics` list |
+| `--command` | Command name in the section's `Commands` list |
+| `--flag` | Flag name in the section's `Flags` list |
+| `--slug` | Exact slug match (repeatable for multiple slugs) |
+
+All filters are combined with AND logic. If no filters are given, every loaded section is exported.
+
+## Practical examples
+
+### Back up documentation before a refactor
+
+Before restructuring your help files, snapshot the current state:
+
+```bash
+glaze help export --format files --output-path ./docs-backup-$(date +%Y%m%d)
+```
+
+### Generate a CSV inventory for a spreadsheet
+
+Create a lightweight inventory of all sections for editorial review:
+
+```bash
+glaze help export --with-content=false --output csv > section-inventory.csv
+```
+
+### Ship a documentation database with your app
+
+Build a release artifact that contains both the binary and a queryable help DB:
+
+```bash
+glaze help export --format sqlite --output-path ./dist/myapp-help.db
+```
+
+### Reconstruct markdown from the internal store
+
+If you loaded sections programmatically and want to recover the original `.md` files:
+
+```bash
+glaze help export --format files --flatten-dirs --output-path ./recovered
+```
+
+## How the export command is wired
+
+`glaze help export` is implemented as a `BareCommand` in `pkg/help/cmd/export.go`. It adds a glazed section to its schema so that `--output json/csv/table/yaml` flags are available, but bypasses the GlazeProcessor when `--format` is `files` or `sqlite` so it can write to disk instead of stdout.
+
+The command lives under the `help` subcommand tree. It is registered automatically when a binary calls `help_cmd.SetupCobraRootCommand(...)` followed by `help_cmd.AddExportCommand(...)`. The `glaze` binary does this in `cmd/glaze/main.go`, so the export verb is available out of the box.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| `Flag 'output' already exists` error | Using an older version that conflicts with glazed flags | Upgrade to the latest glazed version; the export command uses `--output-path` for file destinations. |
+| Exported files are missing content | `--with-content=false` was set, or the source sections had empty `Content` fields | Re-run with `--with-content=true` (the default). |
+| `no sections matched the given filters` | Filters are too restrictive, or no sections are loaded | Run `glaze help export --output json` without filters to verify sections exist. |
+| SQLite export fails with `database is locked` | Another process is holding the target database open | Close the other process or choose a different `--output-path`. |
+| Reconstructed markdown has reordered frontmatter fields | `yaml.v3` encodes maps in alphabetical order | This is cosmetic; the fields are semantically identical and parse correctly. |
+| `flatten-dirs` causes filename collisions | Two sections have the same slug in different types | Avoid `--flatten-dirs` when exporting mixed section types, or rename slugs before export. |
+
+## See Also
+
+- [`glaze help help-system`](glaze help help-system) — Overview of the Glazed help system
+- [`glaze help serve-help-over-http`](glaze help serve-help-over-http) — Browse help in a web browser
+- [`glaze help export-help-static-website`](glaze help export-help-static-website) — Export help as a static site
+- [`glaze help writing-help-entries`](glaze help writing-help-entries) — How to write help sections
+- [`glaze help sections-guide`](glaze help sections-guide) — Deep dive into section metadata and the query DSL

--- a/pkg/doc/topics/28-export-help-entries.md
+++ b/pkg/doc/topics/28-export-help-entries.md
@@ -241,6 +241,7 @@ The command lives under the `help` subcommand tree. It is registered automatical
 
 ## See Also
 
+- [`glaze help serve-external-help-sources`](glaze help serve-external-help-sources) — Serve exported help from other Glazed binaries and snapshots
 - [`glaze help help-system`](glaze help help-system) — Overview of the Glazed help system
 - [`glaze help serve-help-over-http`](glaze help serve-help-over-http) — Browse help in a web browser
 - [`glaze help export-help-static-website`](glaze help export-help-static-website) — Export help as a static site

--- a/pkg/doc/topics/29-serve-external-help-sources.md
+++ b/pkg/doc/topics/29-serve-external-help-sources.md
@@ -1,0 +1,168 @@
+---
+Title: Serve External Help Sources
+Slug: serve-external-help-sources
+Short: Use `glaze serve` to browse help exported from other Glazed binaries, JSON files, SQLite snapshots, and markdown directories.
+Topics:
+- help
+- serve
+- export
+- web
+- documentation
+- sqlite
+Commands:
+- serve
+- help
+- export
+Flags:
+- from-glazed-cmd
+- from-cmd
+- from-json
+- from-sqlite
+- with-embedded
+- address
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+## Why external help sources exist
+
+`glaze serve` can act as a browser for more than the documentation embedded in the `glaze` binary. Many Glazed-based tools expose their own help pages through `help export`; external source loading lets you collect those pages into one local web server.
+
+This is useful when you maintain a family of command-line tools. Instead of running one help browser per binary, run one server that loads help from all of them:
+
+```bash
+glaze serve --from-glazed-cmd pinocchio,sqleton,xxx
+```
+
+By default, explicit external sources replace the embedded Glazed documentation. This keeps the browser focused on the tools you asked for. If you also want the built-in Glazed docs, add `--with-embedded=true`.
+
+## Quick start: serve another Glazed binary
+
+Use `--from-glazed-cmd` when each value is the name or path of a binary that supports `help export`.
+
+```bash
+glaze serve --from-glazed-cmd pinocchio
+```
+
+For each binary, `glaze serve` runs:
+
+```bash
+<binary> help export --with-content=true --output json
+```
+
+Then it imports the JSON into the in-memory help store and starts the existing help browser.
+
+You can load multiple binaries at once:
+
+```bash
+glaze serve --from-glazed-cmd pinocchio,sqleton,xxx
+```
+
+Or use repeated flags:
+
+```bash
+glaze serve \
+  --from-glazed-cmd pinocchio \
+  --from-glazed-cmd sqleton \
+  --from-glazed-cmd xxx
+```
+
+## Source types
+
+`glaze serve` can load several kinds of sources. All string source flags are list-valued, so you can pass multiple sources together.
+
+| Source | Flag | Example |
+|--------|------|---------|
+| Glazed binary shorthand | `--from-glazed-cmd` | `--from-glazed-cmd pinocchio,sqleton` |
+| Arbitrary JSON-producing command | `--from-cmd` | `--from-cmd "pinocchio help export --output json --topic db"` |
+| JSON export file | `--from-json` | `--from-json ./pinocchio-help.json` |
+| SQLite export database | `--from-sqlite` | `--from-sqlite ./pinocchio-help.db` |
+| Markdown files/directories | positional paths | `glaze serve ./docs ./more-docs` |
+
+Use `--from-glazed-cmd` for the normal case. Use `--from-cmd` only when you need extra export flags or a wrapper command.
+
+## Embedded documentation behavior
+
+When you run `glaze serve` with no sources, it serves the built-in Glazed documentation:
+
+```bash
+glaze serve
+```
+
+When you provide any explicit source, embedded docs are cleared by default:
+
+```bash
+glaze serve --from-glazed-cmd pinocchio
+```
+
+This serves Pinocchio help only. To merge Pinocchio help with the embedded Glazed docs, set:
+
+```bash
+glaze serve --with-embedded=true --from-glazed-cmd pinocchio
+```
+
+## Serve from exported JSON
+
+JSON files are useful when you want a cached snapshot or when the source binary is not available on the serving machine.
+
+```bash
+pinocchio help export --output json > /tmp/pinocchio-help.json
+glaze serve --from-json /tmp/pinocchio-help.json
+```
+
+You can also read JSON from stdin:
+
+```bash
+pinocchio help export --output json | glaze serve --from-json -
+```
+
+Only one `--from-json -` source is allowed because stdin can only be read once.
+
+## Serve from SQLite
+
+SQLite files are useful for archived snapshots and tooling that wants a queryable database.
+
+```bash
+pinocchio help export --format sqlite --output-path ./pinocchio-help.db
+glaze serve --from-sqlite ./pinocchio-help.db
+```
+
+You can combine several snapshots:
+
+```bash
+glaze serve --from-sqlite ./pinocchio.db,./sqleton.db
+```
+
+## Combine all source types
+
+You can build a unified help browser by combining live binaries, snapshots, and local markdown overrides:
+
+```bash
+glaze serve \
+  --from-glazed-cmd pinocchio,sqleton \
+  --from-json ./team-overrides.json \
+  --from-sqlite ./legacy-help.db \
+  ./company-docs
+```
+
+If two sources contain the same slug, the later source wins. The loading order is markdown paths, JSON files, SQLite files, arbitrary commands, then `--from-glazed-cmd` binaries.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| `executable file not found` | A `--from-glazed-cmd` binary is not on `PATH` | Use an absolute path or install the binary. |
+| Browser shows only one tool's docs | Explicit sources clear embedded docs by default | Add more sources or use `--with-embedded=true` to include built-in Glazed docs. |
+| JSON import fails with missing type | The JSON file is not a Glazed help export | Generate it with `<binary> help export --output json`. |
+| Command source fails but works in a shell | `--from-cmd` does not run through a shell | Put shell pipelines in a wrapper script, or export to JSON first. |
+| Stdin source hangs | The process feeding stdin did not finish | Verify the upstream command exits and writes valid JSON. |
+| Duplicate pages disappear | Later sources overwrite earlier slugs | Rename slugs or change source order. |
+
+## See Also
+
+- `glaze help export-help-entries` — Export help sections to JSON, files, and SQLite
+- `glaze help serve-help-over-http` — Serve the built-in help browser over HTTP
+- `glaze help export-help-static-website` — Export help as a static website
+- `glaze help help-system` — Overview of the Glazed help system

--- a/pkg/doc/topics/29-serve-external-help-sources.md
+++ b/pkg/doc/topics/29-serve-external-help-sources.md
@@ -15,7 +15,6 @@ Commands:
 - export
 Flags:
 - from-glazed-cmd
-- from-cmd
 - from-json
 - from-sqlite
 - with-embedded
@@ -76,12 +75,11 @@ glaze serve \
 | Source | Flag | Example |
 |--------|------|---------|
 | Glazed binary shorthand | `--from-glazed-cmd` | `--from-glazed-cmd pinocchio,sqleton` |
-| Arbitrary JSON-producing command | `--from-cmd` | `--from-cmd "pinocchio help export --output json --topic db"` |
 | JSON export file | `--from-json` | `--from-json ./pinocchio-help.json` |
 | SQLite export database | `--from-sqlite` | `--from-sqlite ./pinocchio-help.db` |
 | Markdown files/directories | positional paths | `glaze serve ./docs ./more-docs` |
 
-Use `--from-glazed-cmd` for the normal case. Use `--from-cmd` only when you need extra export flags or a wrapper command.
+Use `--from-glazed-cmd` for live binaries and `--from-json` or `--from-sqlite` when you need a filtered or archived snapshot.
 
 ## Embedded documentation behavior
 
@@ -147,7 +145,7 @@ glaze serve \
   ./company-docs
 ```
 
-If two sources contain the same slug, the later source wins. The loading order is markdown paths, JSON files, SQLite files, arbitrary commands, then `--from-glazed-cmd` binaries.
+If two sources contain the same slug, the later source wins. The loading order is markdown paths, JSON files, SQLite files, then `--from-glazed-cmd` binaries.
 
 ## Troubleshooting
 
@@ -156,7 +154,6 @@ If two sources contain the same slug, the later source wins. The loading order i
 | `executable file not found` | A `--from-glazed-cmd` binary is not on `PATH` | Use an absolute path or install the binary. |
 | Browser shows only one tool's docs | Explicit sources clear embedded docs by default | Add more sources or use `--with-embedded=true` to include built-in Glazed docs. |
 | JSON import fails with missing type | The JSON file is not a Glazed help export | Generate it with `<binary> help export --output json`. |
-| Command source fails but works in a shell | `--from-cmd` does not run through a shell | Put shell pipelines in a wrapper script, or export to JSON first. |
 | Stdin source hangs | The process feeding stdin did not finish | Verify the upstream command exits and writes valid JSON. |
 | Duplicate pages disappear | Later sources overwrite earlier slugs | Rename slugs or change source order. |
 

--- a/pkg/help/cmd/export.go
+++ b/pkg/help/cmd/export.go
@@ -95,7 +95,10 @@ func (c *ExportCommand) Run(ctx context.Context, parsedValues *values.Values) er
 		return errors.Errorf("unknown format: %s (expected glazed, files, or sqlite)", s.Format)
 	}
 
-	predicate := buildExportPredicate(s)
+	predicate, err := buildExportPredicate(s)
+	if err != nil {
+		return err
+	}
 	sections, err := c.helpSystem.Store.Find(ctx, predicate)
 	if err != nil {
 		return errors.Wrap(err, "failed to query sections")
@@ -162,14 +165,15 @@ func (c *ExportCommand) runGlazed(ctx context.Context, parsedValues *values.Valu
 }
 
 // buildExportPredicate constructs a store.Predicate from export settings.
-func buildExportPredicate(s *ExportSettings) store.Predicate {
+func buildExportPredicate(s *ExportSettings) (store.Predicate, error) {
 	var preds []store.Predicate
 
 	if s.Type != "" {
 		st, err := model.SectionTypeFromString(s.Type)
-		if err == nil {
-			preds = append(preds, store.IsType(st))
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid section type %q", s.Type)
 		}
+		preds = append(preds, store.IsType(st))
 	}
 	if s.Topic != "" {
 		preds = append(preds, store.HasTopic(s.Topic))
@@ -194,9 +198,9 @@ func buildExportPredicate(s *ExportSettings) store.Predicate {
 
 	base := store.OrderByOrder()
 	if len(preds) == 0 {
-		return base
+		return base, nil
 	}
-	return store.And(store.And(preds...), base)
+	return store.And(store.And(preds...), base), nil
 }
 
 // exportToFiles writes each section as an individual markdown file.
@@ -219,7 +223,10 @@ func exportToFiles(sections []*model.Section, s *ExportSettings) error {
 			}
 		}
 
-		path := filepath.Join(dir, section.Slug+".md")
+		path, err := safeSectionFilePath(dir, section.Slug)
+		if err != nil {
+			return err
+		}
 		data, err := reconstructMarkdown(section)
 		if err != nil {
 			return errors.Wrapf(err, "failed to reconstruct markdown for %s", section.Slug)
@@ -230,6 +237,33 @@ func exportToFiles(sections []*model.Section, s *ExportSettings) error {
 	}
 
 	return nil
+}
+
+func safeSectionFilePath(dir, slug string) (string, error) {
+	if slug == "" {
+		return "", errors.New("section slug is required for file export")
+	}
+	if slug == "." || slug == ".." || strings.ContainsAny(slug, `/\\`) {
+		return "", errors.Errorf("unsafe section slug for file export: %q", slug)
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", errors.Wrapf(err, "resolve output directory %s", dir)
+	}
+	path := filepath.Join(absDir, slug+".md")
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", errors.Wrapf(err, "resolve output path for slug %s", slug)
+	}
+	rel, err := filepath.Rel(absDir, absPath)
+	if err != nil {
+		return "", errors.Wrapf(err, "validate output path for slug %s", slug)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", errors.Errorf("section slug escapes output directory: %q", slug)
+	}
+	return absPath, nil
 }
 
 // exportToSQLite writes sections to a new SQLite database.

--- a/pkg/help/cmd/export.go
+++ b/pkg/help/cmd/export.go
@@ -1,0 +1,314 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/fields"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/go-go-golems/glazed/pkg/help"
+	"github.com/go-go-golems/glazed/pkg/help/model"
+	"github.com/go-go-golems/glazed/pkg/help/store"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// ExportCommand exports help sections as structured data or to disk.
+type ExportCommand struct {
+	*cmds.CommandDescription
+	helpSystem *help.HelpSystem
+}
+
+var _ cmds.BareCommand = (*ExportCommand)(nil)
+
+// ExportSettings holds parsed flag values for the export command.
+type ExportSettings struct {
+	Type        string `glazed:"type"`
+	Topic       string `glazed:"topic"`
+	Command     string `glazed:"command"`
+	Flag        string `glazed:"flag"`
+	Slug        string `glazed:"slug"`
+	WithContent bool   `glazed:"with-content"`
+	Format      string `glazed:"format"`
+	OutputPath  string `glazed:"output-path"`
+	FlattenDirs bool   `glazed:"flatten-dirs"`
+}
+
+// NewExportCommand creates a new export command.
+func NewExportCommand(hs *help.HelpSystem) (*ExportCommand, error) {
+	glazedSection, err := settings.NewGlazedSchema()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create glazed schema")
+	}
+
+	return &ExportCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"export",
+			cmds.WithShort("Export help sections to external formats"),
+			cmds.WithLong(`Export help sections as structured data or to disk.
+
+By default, exports all matching sections as JSON/CSV/table/YAML via the Glazed
+processor, including full markdown content (--with-content defaults to true).
+
+Use --format files to write individual .md files, or --format sqlite to
+produce a portable SQLite database. Use --with-content=false for lightweight
+metadata-only exports.
+`),
+			cmds.WithFlags(
+				fields.New("type", fields.TypeString, fields.WithHelp("Filter by section type"), fields.WithDefault("")),
+				fields.New("topic", fields.TypeString, fields.WithHelp("Filter by topic"), fields.WithDefault("")),
+				fields.New("command", fields.TypeString, fields.WithHelp("Filter by command"), fields.WithDefault("")),
+				fields.New("flag", fields.TypeString, fields.WithHelp("Filter by flag"), fields.WithDefault("")),
+				fields.New("slug", fields.TypeString, fields.WithHelp("Filter by slug(s), comma-separated"), fields.WithDefault("")),
+				fields.New("with-content", fields.TypeBool, fields.WithHelp("Include content field in tabular output"), fields.WithDefault(true)),
+				fields.New("format", fields.TypeString, fields.WithHelp("Export mode: glazed, files, sqlite"), fields.WithDefault("glazed")),
+				fields.New("output-path", fields.TypeString, fields.WithHelp("Output path for files/sqlite mode"), fields.WithDefault("")),
+				fields.New("flatten-dirs", fields.TypeBool, fields.WithHelp("Flatten directory structure in files mode"), fields.WithDefault(false)),
+			),
+			cmds.WithSchema(schema.NewSchema(schema.WithSections(glazedSection))),
+		),
+		helpSystem: hs,
+	}, nil
+}
+
+// Run executes the export command.
+func (c *ExportCommand) Run(ctx context.Context, parsedValues *values.Values) error {
+	s := &ExportSettings{}
+	if err := parsedValues.DecodeSectionInto(schema.DefaultSlug, s); err != nil {
+		return errors.Wrap(err, "failed to decode export settings")
+	}
+
+	// Validate format
+	switch s.Format {
+	case "glazed", "files", "sqlite":
+		// OK
+	default:
+		return errors.Errorf("unknown format: %s (expected glazed, files, or sqlite)", s.Format)
+	}
+
+	predicate := buildExportPredicate(s)
+	sections, err := c.helpSystem.Store.Find(ctx, predicate)
+	if err != nil {
+		return errors.Wrap(err, "failed to query sections")
+	}
+
+	switch s.Format {
+	case "glazed":
+		return c.runGlazed(ctx, parsedValues, sections, s)
+	case "files":
+		return exportToFiles(sections, s)
+	case "sqlite":
+		return exportToSQLite(ctx, sections, s)
+	}
+
+	return nil
+}
+
+// runGlazed emits sections through the Glaze processor.
+func (c *ExportCommand) runGlazed(ctx context.Context, parsedValues *values.Values, sections []*model.Section, s *ExportSettings) error {
+	glazedValues, ok := parsedValues.Get(settings.GlazedSlug)
+	if !ok {
+		return errors.New("glazed section not found in parsed values")
+	}
+
+	gp, err := settings.SetupTableProcessor(glazedValues)
+	if err != nil {
+		return errors.Wrap(err, "failed to setup table processor")
+	}
+
+	_, err = settings.SetupProcessorOutput(gp, glazedValues, os.Stdout)
+	if err != nil {
+		return errors.Wrap(err, "failed to setup processor output")
+	}
+
+	for _, section := range sections {
+		row := types.NewRow(
+			types.MRP("id", section.ID),
+			types.MRP("slug", section.Slug),
+			types.MRP("type", section.SectionType.String()),
+			types.MRP("title", section.Title),
+			types.MRP("short", section.Short),
+			types.MRP("topics", section.Topics),
+			types.MRP("flags", section.Flags),
+			types.MRP("commands", section.Commands),
+			types.MRP("is_top_level", section.IsTopLevel),
+			types.MRP("show_per_default", section.ShowPerDefault),
+			types.MRP("order", section.Order),
+			types.MRP("created_at", section.CreatedAt),
+			types.MRP("updated_at", section.UpdatedAt),
+		)
+		if s.WithContent {
+			row.Set("content", section.Content)
+		}
+		if err := gp.AddRow(ctx, row); err != nil {
+			return errors.Wrap(err, "failed to add row")
+		}
+	}
+
+	if err := gp.Close(ctx); err != nil {
+		return errors.Wrap(err, "failed to close processor")
+	}
+
+	return nil
+}
+
+// buildExportPredicate constructs a store.Predicate from export settings.
+func buildExportPredicate(s *ExportSettings) store.Predicate {
+	var preds []store.Predicate
+
+	if s.Type != "" {
+		st, err := model.SectionTypeFromString(s.Type)
+		if err == nil {
+			preds = append(preds, store.IsType(st))
+		}
+	}
+	if s.Topic != "" {
+		preds = append(preds, store.HasTopic(s.Topic))
+	}
+	if s.Command != "" {
+		preds = append(preds, store.HasCommand(s.Command))
+	}
+	if s.Flag != "" {
+		preds = append(preds, store.HasFlag(s.Flag))
+	}
+	if s.Slug != "" {
+		slugs := strings.Split(s.Slug, ",")
+		for i := range slugs {
+			slugs[i] = strings.TrimSpace(slugs[i])
+		}
+		if len(slugs) == 1 {
+			preds = append(preds, store.SlugEquals(slugs[0]))
+		} else {
+			preds = append(preds, store.SlugIn(slugs))
+		}
+	}
+
+	base := store.OrderByOrder()
+	if len(preds) == 0 {
+		return base
+	}
+	return store.And(store.And(preds...), base)
+}
+
+// exportToFiles writes each section as an individual markdown file.
+func exportToFiles(sections []*model.Section, s *ExportSettings) error {
+	outDir := s.OutputPath
+	if outDir == "" {
+		outDir = "./help-export"
+	}
+
+	if err := os.MkdirAll(outDir, 0755); err != nil {
+		return errors.Wrap(err, "failed to create output directory")
+	}
+
+	for _, section := range sections {
+		dir := outDir
+		if !s.FlattenDirs {
+			dir = filepath.Join(outDir, slugify(section.SectionType.String()))
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return errors.Wrapf(err, "failed to create directory %s", dir)
+			}
+		}
+
+		path := filepath.Join(dir, section.Slug+".md")
+		data, err := reconstructMarkdown(section)
+		if err != nil {
+			return errors.Wrapf(err, "failed to reconstruct markdown for %s", section.Slug)
+		}
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			return errors.Wrapf(err, "failed to write file %s", path)
+		}
+	}
+
+	return nil
+}
+
+// exportToSQLite writes sections to a new SQLite database.
+func exportToSQLite(ctx context.Context, sections []*model.Section, s *ExportSettings) error {
+	dbPath := s.OutputPath
+	if dbPath == "" {
+		dbPath = "./help-export.sqlite"
+	}
+	if !strings.HasSuffix(dbPath, ".sqlite") && !strings.HasSuffix(dbPath, ".db") {
+		dbPath += ".sqlite"
+	}
+
+	// Remove existing file to start fresh
+	_ = os.Remove(dbPath)
+
+	exportStore, err := store.New(dbPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to create SQLite store")
+	}
+	defer func() {
+		_ = exportStore.Close()
+	}()
+
+	for _, section := range sections {
+		if err := exportStore.Upsert(ctx, section); err != nil {
+			return errors.Wrapf(err, "failed to upsert section %s", section.Slug)
+		}
+	}
+
+	return nil
+}
+
+// reconstructMarkdown rebuilds a markdown file from a Section.
+func reconstructMarkdown(section *model.Section) ([]byte, error) {
+	frontmatter := map[string]interface{}{
+		"Title":          section.Title,
+		"Slug":           section.Slug,
+		"Short":          section.Short,
+		"SectionType":    section.SectionType.String(),
+		"Topics":         section.Topics,
+		"Flags":          section.Flags,
+		"Commands":       section.Commands,
+		"IsTopLevel":     section.IsTopLevel,
+		"IsTemplate":     section.IsTemplate,
+		"ShowPerDefault": section.ShowPerDefault,
+		"Order":          section.Order,
+	}
+	if section.SubTitle != "" {
+		frontmatter["SubTitle"] = section.SubTitle
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("---\n")
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(frontmatter); err != nil {
+		return nil, err
+	}
+	_ = enc.Close()
+	buf.WriteString("---\n")
+	buf.WriteString(section.Content)
+	return buf.Bytes(), nil
+}
+
+// slugify converts a string to a filesystem-friendly slug.
+func slugify(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, " ", "-"))
+}
+
+// AddExportCommand wires the export command into the help subcommand tree.
+func AddExportCommand(helpCmd *cobra.Command, hs *help.HelpSystem) error {
+	exportGlazedCmd, err := NewExportCommand(hs)
+	if err != nil {
+		return err
+	}
+	exportCobraCmd, err := cli.BuildCobraCommand(exportGlazedCmd)
+	if err != nil {
+		return err
+	}
+	helpCmd.AddCommand(exportCobraCmd)
+	return nil
+}

--- a/pkg/help/cmd/export_test.go
+++ b/pkg/help/cmd/export_test.go
@@ -67,7 +67,8 @@ func setupTestHelpSystem(t *testing.T) *help.HelpSystem {
 
 func TestBuildExportPredicate_NoFilters(t *testing.T) {
 	s := &ExportSettings{}
-	pred := buildExportPredicate(s)
+	pred, err := buildExportPredicate(s)
+	require.NoError(t, err)
 	require.NotNil(t, pred)
 }
 
@@ -76,11 +77,19 @@ func TestBuildExportPredicate_ByType(t *testing.T) {
 	ctx := context.Background()
 
 	s := &ExportSettings{Type: "Example"}
-	pred := buildExportPredicate(s)
+	pred, err := buildExportPredicate(s)
+	require.NoError(t, err)
 	sections, err := hs.Store.Find(ctx, pred)
 	require.NoError(t, err)
 	assert.Len(t, sections, 1)
 	assert.Equal(t, "json-example", sections[0].Slug)
+}
+
+func TestBuildExportPredicate_InvalidType(t *testing.T) {
+	s := &ExportSettings{Type: "tutorial"}
+	_, err := buildExportPredicate(s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid section type")
 }
 
 func TestBuildExportPredicate_ByTopic(t *testing.T) {
@@ -88,7 +97,8 @@ func TestBuildExportPredicate_ByTopic(t *testing.T) {
 	ctx := context.Background()
 
 	s := &ExportSettings{Topic: "json"}
-	pred := buildExportPredicate(s)
+	pred, err := buildExportPredicate(s)
+	require.NoError(t, err)
 	sections, err := hs.Store.Find(ctx, pred)
 	require.NoError(t, err)
 	assert.Len(t, sections, 1)
@@ -100,7 +110,8 @@ func TestBuildExportPredicate_ByCommand(t *testing.T) {
 	ctx := context.Background()
 
 	s := &ExportSettings{Command: "csv"}
-	pred := buildExportPredicate(s)
+	pred, err := buildExportPredicate(s)
+	require.NoError(t, err)
 	sections, err := hs.Store.Find(ctx, pred)
 	require.NoError(t, err)
 	assert.Len(t, sections, 1)
@@ -112,7 +123,8 @@ func TestBuildExportPredicate_ByFlag(t *testing.T) {
 	ctx := context.Background()
 
 	s := &ExportSettings{Flag: "separator"}
-	pred := buildExportPredicate(s)
+	pred, err := buildExportPredicate(s)
+	require.NoError(t, err)
 	sections, err := hs.Store.Find(ctx, pred)
 	require.NoError(t, err)
 	assert.Len(t, sections, 1)
@@ -124,7 +136,8 @@ func TestBuildExportPredicate_BySlug(t *testing.T) {
 	ctx := context.Background()
 
 	s := &ExportSettings{Slug: "help-system"}
-	pred := buildExportPredicate(s)
+	pred, err := buildExportPredicate(s)
+	require.NoError(t, err)
 	sections, err := hs.Store.Find(ctx, pred)
 	require.NoError(t, err)
 	assert.Len(t, sections, 1)
@@ -136,7 +149,8 @@ func TestBuildExportPredicate_ByMultipleSlugs(t *testing.T) {
 	ctx := context.Background()
 
 	s := &ExportSettings{Slug: "help-system, json-example"}
-	pred := buildExportPredicate(s)
+	pred, err := buildExportPredicate(s)
+	require.NoError(t, err)
 	sections, err := hs.Store.Find(ctx, pred)
 	require.NoError(t, err)
 	assert.Len(t, sections, 2)
@@ -153,7 +167,8 @@ func TestExportToFiles(t *testing.T) {
 		FlattenDirs: false,
 	}
 
-	pred := buildExportPredicate(s)
+	pred, err := buildExportPredicate(s)
+	require.NoError(t, err)
 	sections, err := hs.Store.Find(ctx, pred)
 	require.NoError(t, err)
 
@@ -189,7 +204,8 @@ func TestExportToFiles_Flatten(t *testing.T) {
 		FlattenDirs: true,
 	}
 
-	pred := buildExportPredicate(s)
+	pred, err := buildExportPredicate(s)
+	require.NoError(t, err)
 	sections, err := hs.Store.Find(ctx, pred)
 	require.NoError(t, err)
 
@@ -200,6 +216,27 @@ func TestExportToFiles_Flatten(t *testing.T) {
 	assert.FileExists(t, filepath.Join(tmpDir, "help-system.md"))
 	assert.FileExists(t, filepath.Join(tmpDir, "json-example.md"))
 	assert.FileExists(t, filepath.Join(tmpDir, "csv-tutorial.md"))
+}
+
+func TestExportToFiles_RejectsUnsafeSlug(t *testing.T) {
+	tmpDir := t.TempDir()
+	sections := []*model.Section{{
+		Slug:        "../escape",
+		Title:       "Unsafe",
+		SectionType: model.SectionGeneralTopic,
+	}}
+
+	err := exportToFiles(sections, &ExportSettings{Format: "files", OutputPath: tmpDir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsafe section slug")
+	assert.NoFileExists(t, filepath.Join(tmpDir, "..", "escape.md"))
+}
+
+func TestSafeSectionFilePath_AllowsNormalSlug(t *testing.T) {
+	tmpDir := t.TempDir()
+	path, err := safeSectionFilePath(tmpDir, "help-system")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(tmpDir, "help-system.md"), path)
 }
 
 func TestExportToSQLite(t *testing.T) {
@@ -213,7 +250,8 @@ func TestExportToSQLite(t *testing.T) {
 		OutputPath: dbPath,
 	}
 
-	pred := buildExportPredicate(s)
+	pred, err := buildExportPredicate(s)
+	require.NoError(t, err)
 	sections, err := hs.Store.Find(ctx, pred)
 	require.NoError(t, err)
 

--- a/pkg/help/cmd/export_test.go
+++ b/pkg/help/cmd/export_test.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-go-golems/glazed/pkg/help"
+	"github.com/go-go-golems/glazed/pkg/help/model"
+	"github.com/go-go-golems/glazed/pkg/help/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestHelpSystem(t *testing.T) *help.HelpSystem {
+	hs := help.NewHelpSystem()
+
+	sections := []*model.Section{
+		{
+			Slug:           "help-system",
+			Title:          "Help System",
+			Short:          "Overview of the help system",
+			SectionType:    model.SectionGeneralTopic,
+			Topics:         []string{"help", "documentation"},
+			Commands:       []string{"help"},
+			IsTopLevel:     true,
+			ShowPerDefault: true,
+			Order:          0,
+			Content:        "The help system allows...",
+		},
+		{
+			Slug:           "json-example",
+			Title:          "JSON Output Example",
+			Short:          "How to format JSON output",
+			SectionType:    model.SectionExample,
+			Topics:         []string{"json", "output"},
+			Commands:       []string{"json"},
+			IsTopLevel:     false,
+			ShowPerDefault: true,
+			Order:          1,
+			Content:        "Use the json command with...",
+		},
+		{
+			Slug:           "csv-tutorial",
+			Title:          "Working with CSV",
+			Short:          "Tutorial on CSV processing",
+			SectionType:    model.SectionTutorial,
+			Topics:         []string{"csv", "data"},
+			Commands:       []string{"csv"},
+			Flags:          []string{"separator"},
+			IsTopLevel:     false,
+			ShowPerDefault: false,
+			Order:          2,
+			Content:        "CSV files can be processed...",
+		},
+	}
+
+	ctx := context.Background()
+	for _, s := range sections {
+		err := hs.Store.Upsert(ctx, s)
+		require.NoError(t, err)
+	}
+
+	return hs
+}
+
+func TestBuildExportPredicate_NoFilters(t *testing.T) {
+	s := &ExportSettings{}
+	pred := buildExportPredicate(s)
+	require.NotNil(t, pred)
+}
+
+func TestBuildExportPredicate_ByType(t *testing.T) {
+	hs := setupTestHelpSystem(t)
+	ctx := context.Background()
+
+	s := &ExportSettings{Type: "Example"}
+	pred := buildExportPredicate(s)
+	sections, err := hs.Store.Find(ctx, pred)
+	require.NoError(t, err)
+	assert.Len(t, sections, 1)
+	assert.Equal(t, "json-example", sections[0].Slug)
+}
+
+func TestBuildExportPredicate_ByTopic(t *testing.T) {
+	hs := setupTestHelpSystem(t)
+	ctx := context.Background()
+
+	s := &ExportSettings{Topic: "json"}
+	pred := buildExportPredicate(s)
+	sections, err := hs.Store.Find(ctx, pred)
+	require.NoError(t, err)
+	assert.Len(t, sections, 1)
+	assert.Equal(t, "json-example", sections[0].Slug)
+}
+
+func TestBuildExportPredicate_ByCommand(t *testing.T) {
+	hs := setupTestHelpSystem(t)
+	ctx := context.Background()
+
+	s := &ExportSettings{Command: "csv"}
+	pred := buildExportPredicate(s)
+	sections, err := hs.Store.Find(ctx, pred)
+	require.NoError(t, err)
+	assert.Len(t, sections, 1)
+	assert.Equal(t, "csv-tutorial", sections[0].Slug)
+}
+
+func TestBuildExportPredicate_ByFlag(t *testing.T) {
+	hs := setupTestHelpSystem(t)
+	ctx := context.Background()
+
+	s := &ExportSettings{Flag: "separator"}
+	pred := buildExportPredicate(s)
+	sections, err := hs.Store.Find(ctx, pred)
+	require.NoError(t, err)
+	assert.Len(t, sections, 1)
+	assert.Equal(t, "csv-tutorial", sections[0].Slug)
+}
+
+func TestBuildExportPredicate_BySlug(t *testing.T) {
+	hs := setupTestHelpSystem(t)
+	ctx := context.Background()
+
+	s := &ExportSettings{Slug: "help-system"}
+	pred := buildExportPredicate(s)
+	sections, err := hs.Store.Find(ctx, pred)
+	require.NoError(t, err)
+	assert.Len(t, sections, 1)
+	assert.Equal(t, "help-system", sections[0].Slug)
+}
+
+func TestBuildExportPredicate_ByMultipleSlugs(t *testing.T) {
+	hs := setupTestHelpSystem(t)
+	ctx := context.Background()
+
+	s := &ExportSettings{Slug: "help-system, json-example"}
+	pred := buildExportPredicate(s)
+	sections, err := hs.Store.Find(ctx, pred)
+	require.NoError(t, err)
+	assert.Len(t, sections, 2)
+}
+
+func TestExportToFiles(t *testing.T) {
+	hs := setupTestHelpSystem(t)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	s := &ExportSettings{
+		Format:      "files",
+		OutputPath:  tmpDir,
+		FlattenDirs: false,
+	}
+
+	pred := buildExportPredicate(s)
+	sections, err := hs.Store.Find(ctx, pred)
+	require.NoError(t, err)
+
+	err = exportToFiles(sections, s)
+	require.NoError(t, err)
+
+	// Verify directory structure
+	assert.DirExists(t, filepath.Join(tmpDir, "generaltopic"))
+	assert.DirExists(t, filepath.Join(tmpDir, "example"))
+	assert.DirExists(t, filepath.Join(tmpDir, "tutorial"))
+
+	// Verify a file exists and can be parsed back
+	helpSystemPath := filepath.Join(tmpDir, "generaltopic", "help-system.md")
+	require.FileExists(t, helpSystemPath)
+
+	data, err := os.ReadFile(helpSystemPath)
+	require.NoError(t, err)
+	parsed, err := model.ParseSectionFromMarkdown(data)
+	require.NoError(t, err)
+	assert.Equal(t, "help-system", parsed.Slug)
+	assert.Equal(t, "Help System", parsed.Title)
+	assert.Equal(t, "The help system allows...", parsed.Content)
+}
+
+func TestExportToFiles_Flatten(t *testing.T) {
+	hs := setupTestHelpSystem(t)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	s := &ExportSettings{
+		Format:      "files",
+		OutputPath:  tmpDir,
+		FlattenDirs: true,
+	}
+
+	pred := buildExportPredicate(s)
+	sections, err := hs.Store.Find(ctx, pred)
+	require.NoError(t, err)
+
+	err = exportToFiles(sections, s)
+	require.NoError(t, err)
+
+	// All files should be in the root
+	assert.FileExists(t, filepath.Join(tmpDir, "help-system.md"))
+	assert.FileExists(t, filepath.Join(tmpDir, "json-example.md"))
+	assert.FileExists(t, filepath.Join(tmpDir, "csv-tutorial.md"))
+}
+
+func TestExportToSQLite(t *testing.T) {
+	hs := setupTestHelpSystem(t)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.sqlite")
+	s := &ExportSettings{
+		Format:     "sqlite",
+		OutputPath: dbPath,
+	}
+
+	pred := buildExportPredicate(s)
+	sections, err := hs.Store.Find(ctx, pred)
+	require.NoError(t, err)
+
+	err = exportToSQLite(ctx, sections, s)
+	require.NoError(t, err)
+
+	require.FileExists(t, dbPath)
+
+	// Re-open and query
+	exportStore, err := store.New(dbPath)
+	require.NoError(t, err)
+	defer func() {
+		_ = exportStore.Close()
+	}()
+
+	count, err := exportStore.Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+
+	section, err := exportStore.GetBySlug(ctx, "help-system")
+	require.NoError(t, err)
+	assert.Equal(t, "Help System", section.Title)
+	assert.Equal(t, "The help system allows...", section.Content)
+}
+
+func TestReconstructMarkdown(t *testing.T) {
+	section := &model.Section{
+		Slug:           "test-section",
+		Title:          "Test Section",
+		Short:          "A test section",
+		SectionType:    model.SectionGeneralTopic,
+		Topics:         []string{"test", "docs"},
+		Commands:       []string{"test"},
+		Flags:          []string{"verbose"},
+		IsTopLevel:     true,
+		ShowPerDefault: true,
+		Order:          5,
+		Content:        "This is the content.",
+	}
+
+	data, err := reconstructMarkdown(section)
+	require.NoError(t, err)
+
+	// Should be parseable back
+	parsed, err := model.ParseSectionFromMarkdown(data)
+	require.NoError(t, err)
+	assert.Equal(t, section.Slug, parsed.Slug)
+	assert.Equal(t, section.Title, parsed.Title)
+	assert.Equal(t, section.Short, parsed.Short)
+	assert.Equal(t, section.SectionType, parsed.SectionType)
+	assert.Equal(t, section.Topics, parsed.Topics)
+	assert.Equal(t, section.Commands, parsed.Commands)
+	assert.Equal(t, section.Flags, parsed.Flags)
+	assert.Equal(t, section.IsTopLevel, parsed.IsTopLevel)
+	assert.Equal(t, section.ShowPerDefault, parsed.ShowPerDefault)
+	assert.Equal(t, section.Order, parsed.Order)
+	assert.Equal(t, section.Content, parsed.Content)
+}

--- a/pkg/help/loader/sources.go
+++ b/pkg/help/loader/sources.go
@@ -1,0 +1,395 @@
+package loader
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/go-go-golems/glazed/pkg/help"
+	"github.com/go-go-golems/glazed/pkg/help/model"
+	"github.com/go-go-golems/glazed/pkg/help/store"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// ContentLoader loads help sections from an external source into a HelpSystem.
+type ContentLoader interface {
+	Load(ctx context.Context, hs *help.HelpSystem) error
+	String() string
+}
+
+// NormalizeStringList trims values and expands comma-separated entries.
+func NormalizeStringList(values []string) []string {
+	ret := make([]string, 0, len(values))
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				ret = append(ret, part)
+			}
+		}
+	}
+	return ret
+}
+
+// NormalizeCommandList trims command values without comma-splitting them.
+// Command strings may legitimately contain commas inside arguments.
+func NormalizeCommandList(values []string) []string {
+	ret := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			ret = append(ret, value)
+		}
+	}
+	return ret
+}
+
+// MarkdownPathLoader loads markdown help sections from files or directories.
+type MarkdownPathLoader struct {
+	Paths []string
+}
+
+func (l *MarkdownPathLoader) Load(ctx context.Context, hs *help.HelpSystem) error {
+	return LoadPaths(ctx, hs, NormalizeStringList(l.Paths))
+}
+
+func (l *MarkdownPathLoader) String() string {
+	return "markdown paths: " + strings.Join(NormalizeStringList(l.Paths), ", ")
+}
+
+// JSONFileLoader loads help sections from JSON export files. A path of "-" reads stdin.
+type JSONFileLoader struct {
+	Paths []string
+}
+
+func (l *JSONFileLoader) Load(ctx context.Context, hs *help.HelpSystem) error {
+	paths := NormalizeStringList(l.Paths)
+	stdinCount := 0
+	for _, path := range paths {
+		if path == "-" {
+			stdinCount++
+		}
+	}
+	if stdinCount > 1 {
+		return errors.New("--from-json - may only be used once")
+	}
+
+	for _, path := range paths {
+		var r io.ReadCloser
+		if path == "-" {
+			r = io.NopCloser(os.Stdin)
+		} else {
+			f, err := os.Open(path)
+			if err != nil {
+				return errors.Wrapf(err, "open JSON source %s", path)
+			}
+			r = f
+		}
+
+		sections, err := DecodeSectionsJSON(r)
+		closeErr := r.Close()
+		if err != nil {
+			return errors.Wrapf(err, "decode JSON source %s", path)
+		}
+		if closeErr != nil {
+			return errors.Wrapf(closeErr, "close JSON source %s", path)
+		}
+
+		for _, section := range sections {
+			if err := upsertWithCollisionLog(ctx, hs, section, "json: "+path); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (l *JSONFileLoader) String() string {
+	return "json files: " + strings.Join(NormalizeStringList(l.Paths), ", ")
+}
+
+// SQLiteLoader loads help sections from exported Glazed help SQLite databases.
+type SQLiteLoader struct {
+	Paths []string
+}
+
+func (l *SQLiteLoader) Load(ctx context.Context, hs *help.HelpSystem) error {
+	for _, path := range NormalizeStringList(l.Paths) {
+		sourceStore, err := store.New(path)
+		if err != nil {
+			return errors.Wrapf(err, "open SQLite source %s", path)
+		}
+
+		sections, listErr := sourceStore.List(ctx, "")
+		closeErr := sourceStore.Close()
+		if listErr != nil {
+			return errors.Wrapf(listErr, "list sections from SQLite source %s", path)
+		}
+		if closeErr != nil {
+			return errors.Wrapf(closeErr, "close SQLite source %s", path)
+		}
+
+		for _, section := range sections {
+			if err := upsertWithCollisionLog(ctx, hs, section, "sqlite: "+path); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (l *SQLiteLoader) String() string {
+	return "sqlite files: " + strings.Join(NormalizeStringList(l.Paths), ", ")
+}
+
+// CommandJSONLoader runs commands whose stdout is a JSON help export.
+type CommandJSONLoader struct {
+	Commands []string
+}
+
+func (l *CommandJSONLoader) Load(ctx context.Context, hs *help.HelpSystem) error {
+	for _, command := range NormalizeCommandList(l.Commands) {
+		data, err := runCommandForJSON(ctx, command)
+		if err != nil {
+			return err
+		}
+		if err := importJSONBytes(ctx, hs, data, "command: "+command); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *CommandJSONLoader) String() string {
+	return "commands: " + strings.Join(NormalizeCommandList(l.Commands), ", ")
+}
+
+// GlazedCommandLoader runs '<binary> help export --output json' for each binary.
+type GlazedCommandLoader struct {
+	Binaries []string
+}
+
+func (l *GlazedCommandLoader) Load(ctx context.Context, hs *help.HelpSystem) error {
+	for _, binary := range NormalizeStringList(l.Binaries) {
+		data, err := runGlazedHelpExport(ctx, binary)
+		if err != nil {
+			return err
+		}
+		if err := importJSONBytes(ctx, hs, data, "glazed command: "+binary); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *GlazedCommandLoader) String() string {
+	return "glazed commands: " + strings.Join(NormalizeStringList(l.Binaries), ", ")
+}
+
+func runCommandForJSON(ctx context.Context, command string) ([]byte, error) {
+	args, err := tokenizeCommand(command)
+	if err != nil {
+		return nil, err
+	}
+	if len(args) == 0 {
+		return nil, errors.New("empty command")
+	}
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, errors.Wrapf(err, "command %q failed; stderr: %s", command, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+func runGlazedHelpExport(ctx context.Context, binary string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, binary, "help", "export", "--with-content=true", "--output", "json")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, errors.Wrapf(err, "%s help export failed; stderr: %s", binary, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+func importJSONBytes(ctx context.Context, hs *help.HelpSystem, data []byte, source string) error {
+	sections, err := DecodeSectionsJSON(bytes.NewReader(data))
+	if err != nil {
+		return errors.Wrapf(err, "decode %s", source)
+	}
+	for _, section := range sections {
+		if err := upsertWithCollisionLog(ctx, hs, section, source); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upsertWithCollisionLog(ctx context.Context, hs *help.HelpSystem, section *model.Section, source string) error {
+	if err := section.Validate(); err != nil {
+		return errors.Wrapf(err, "invalid section from %s", source)
+	}
+	if existing, err := hs.Store.GetBySlug(ctx, section.Slug); err == nil && existing != nil {
+		log.Warn().Str("slug", section.Slug).Str("source", source).Msg("Replacing existing help section")
+	}
+	if err := hs.Store.Upsert(ctx, section); err != nil {
+		return errors.Wrapf(err, "upsert section %s from %s", section.Slug, source)
+	}
+	return nil
+}
+
+// DecodeSectionsJSON decodes Glazed help export JSON into model sections.
+func DecodeSectionsJSON(r io.Reader) ([]*model.Section, error) {
+	var rows []sectionImportRow
+	if err := json.NewDecoder(r).Decode(&rows); err != nil {
+		return nil, err
+	}
+	sections := make([]*model.Section, 0, len(rows))
+	for i, row := range rows {
+		section, err := row.ToSection()
+		if err != nil {
+			return nil, errors.Wrapf(err, "row %d", i)
+		}
+		if err := section.Validate(); err != nil {
+			return nil, errors.Wrapf(err, "row %d", i)
+		}
+		sections = append(sections, section)
+	}
+	return sections, nil
+}
+
+type sectionImportRow struct {
+	ID             int64           `json:"id,omitempty"`
+	Slug           string          `json:"slug"`
+	Type           json.RawMessage `json:"type,omitempty"`
+	SectionType    json.RawMessage `json:"section_type,omitempty"`
+	Title          string          `json:"title"`
+	SubTitle       string          `json:"sub_title"`
+	Short          string          `json:"short"`
+	Content        string          `json:"content"`
+	Topics         []string        `json:"topics"`
+	Flags          []string        `json:"flags"`
+	Commands       []string        `json:"commands"`
+	IsTopLevel     bool            `json:"is_top_level"`
+	IsTemplate     bool            `json:"is_template"`
+	ShowPerDefault bool            `json:"show_per_default"`
+	Order          int             `json:"order"`
+	CreatedAt      string          `json:"created_at"`
+	UpdatedAt      string          `json:"updated_at"`
+}
+
+func (r sectionImportRow) ToSection() (*model.Section, error) {
+	st, err := parseSectionType(r.Type, r.SectionType)
+	if err != nil {
+		return nil, err
+	}
+	return &model.Section{
+		ID:             r.ID,
+		Slug:           r.Slug,
+		SectionType:    st,
+		Title:          r.Title,
+		SubTitle:       r.SubTitle,
+		Short:          r.Short,
+		Content:        r.Content,
+		Topics:         r.Topics,
+		Flags:          r.Flags,
+		Commands:       r.Commands,
+		IsTopLevel:     r.IsTopLevel,
+		IsTemplate:     r.IsTemplate,
+		ShowPerDefault: r.ShowPerDefault,
+		Order:          r.Order,
+		CreatedAt:      r.CreatedAt,
+		UpdatedAt:      r.UpdatedAt,
+	}, nil
+}
+
+func parseSectionType(typeRaw, sectionTypeRaw json.RawMessage) (model.SectionType, error) {
+	if len(typeRaw) > 0 && string(typeRaw) != "null" {
+		return parseSectionTypeRaw(typeRaw)
+	}
+	if len(sectionTypeRaw) > 0 && string(sectionTypeRaw) != "null" {
+		return parseSectionTypeRaw(sectionTypeRaw)
+	}
+	return model.SectionGeneralTopic, errors.New("missing type or section_type")
+}
+
+func parseSectionTypeRaw(raw json.RawMessage) (model.SectionType, error) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return model.SectionTypeFromString(s)
+	}
+
+	var n int
+	if err := json.Unmarshal(raw, &n); err == nil {
+		st := model.SectionType(n)
+		switch st {
+		case model.SectionGeneralTopic, model.SectionExample, model.SectionApplication, model.SectionTutorial:
+			return st, nil
+		default:
+			return model.SectionGeneralTopic, fmt.Errorf("unknown section type number %d", n)
+		}
+	}
+
+	return model.SectionGeneralTopic, fmt.Errorf("invalid section type %s", string(raw))
+}
+
+func tokenizeCommand(command string) ([]string, error) {
+	var args []string
+	var current strings.Builder
+	var quote rune
+	escaped := false
+
+	for _, r := range command {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			} else {
+				current.WriteRune(r)
+			}
+			continue
+		}
+		switch r {
+		case '\'', '"':
+			quote = r
+		case ' ', '\t', '\n', '\r':
+			if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if escaped {
+		current.WriteRune('\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote %s", strconv.QuoteRune(quote))
+	}
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+	return args, nil
+}

--- a/pkg/help/loader/sources.go
+++ b/pkg/help/loader/sources.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/go-go-golems/glazed/pkg/help"
@@ -33,19 +32,6 @@ func NormalizeStringList(values []string) []string {
 			if part != "" {
 				ret = append(ret, part)
 			}
-		}
-	}
-	return ret
-}
-
-// NormalizeCommandList trims command values without comma-splitting them.
-// Command strings may legitimately contain commas inside arguments.
-func NormalizeCommandList(values []string) []string {
-	ret := make([]string, 0, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value != "" {
-			ret = append(ret, value)
 		}
 	}
 	return ret
@@ -149,28 +135,6 @@ func (l *SQLiteLoader) String() string {
 	return "sqlite files: " + strings.Join(NormalizeStringList(l.Paths), ", ")
 }
 
-// CommandJSONLoader runs commands whose stdout is a JSON help export.
-type CommandJSONLoader struct {
-	Commands []string
-}
-
-func (l *CommandJSONLoader) Load(ctx context.Context, hs *help.HelpSystem) error {
-	for _, command := range NormalizeCommandList(l.Commands) {
-		data, err := runCommandForJSON(ctx, command)
-		if err != nil {
-			return err
-		}
-		if err := importJSONBytes(ctx, hs, data, "command: "+command); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (l *CommandJSONLoader) String() string {
-	return "commands: " + strings.Join(NormalizeCommandList(l.Commands), ", ")
-}
-
 // GlazedCommandLoader runs '<binary> help export --output json' for each binary.
 type GlazedCommandLoader struct {
 	Binaries []string
@@ -191,26 +155,6 @@ func (l *GlazedCommandLoader) Load(ctx context.Context, hs *help.HelpSystem) err
 
 func (l *GlazedCommandLoader) String() string {
 	return "glazed commands: " + strings.Join(NormalizeStringList(l.Binaries), ", ")
-}
-
-func runCommandForJSON(ctx context.Context, command string) ([]byte, error) {
-	args, err := tokenizeCommand(command)
-	if err != nil {
-		return nil, err
-	}
-	if len(args) == 0 {
-		return nil, errors.New("empty command")
-	}
-
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return nil, errors.Wrapf(err, "command %q failed; stderr: %s", command, strings.TrimSpace(stderr.String()))
-	}
-	return stdout.Bytes(), nil
 }
 
 func runGlazedHelpExport(ctx context.Context, binary string) ([]byte, error) {
@@ -344,52 +288,4 @@ func parseSectionTypeRaw(raw json.RawMessage) (model.SectionType, error) {
 	}
 
 	return model.SectionGeneralTopic, fmt.Errorf("invalid section type %s", string(raw))
-}
-
-func tokenizeCommand(command string) ([]string, error) {
-	var args []string
-	var current strings.Builder
-	var quote rune
-	escaped := false
-
-	for _, r := range command {
-		if escaped {
-			current.WriteRune(r)
-			escaped = false
-			continue
-		}
-		if r == '\\' {
-			escaped = true
-			continue
-		}
-		if quote != 0 {
-			if r == quote {
-				quote = 0
-			} else {
-				current.WriteRune(r)
-			}
-			continue
-		}
-		switch r {
-		case '\'', '"':
-			quote = r
-		case ' ', '\t', '\n', '\r':
-			if current.Len() > 0 {
-				args = append(args, current.String())
-				current.Reset()
-			}
-		default:
-			current.WriteRune(r)
-		}
-	}
-	if escaped {
-		current.WriteRune('\\')
-	}
-	if quote != 0 {
-		return nil, fmt.Errorf("unterminated quote %s", strconv.QuoteRune(quote))
-	}
-	if current.Len() > 0 {
-		args = append(args, current.String())
-	}
-	return args, nil
 }

--- a/pkg/help/loader/sources_test.go
+++ b/pkg/help/loader/sources_test.go
@@ -2,7 +2,6 @@ package loader
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -136,57 +135,4 @@ func TestSQLiteLoader_LoadsSections(t *testing.T) {
 	if section.SectionType != model.SectionApplication {
 		t.Fatalf("expected Application, got %s", section.SectionType.String())
 	}
-}
-
-func TestCommandJSONLoader_LoadsSections(t *testing.T) {
-	ctx := context.Background()
-	hs := help.NewHelpSystem()
-	jsonPayload, err := json.Marshal([]map[string]any{{
-		"slug":  "cmd-topic",
-		"title": "Command Topic",
-		"type":  "Tutorial",
-	}})
-	if err != nil {
-		t.Fatalf("json.Marshal: %v", err)
-	}
-
-	loader := &CommandJSONLoader{Commands: []string{"printf " + strconvQuote(string(jsonPayload))}}
-	if err := loader.Load(ctx, hs); err != nil {
-		t.Fatalf("loader.Load: %v", err)
-	}
-	section, err := hs.Store.GetBySlug(ctx, "cmd-topic")
-	if err != nil {
-		t.Fatalf("GetBySlug: %v", err)
-	}
-	if section.SectionType != model.SectionTutorial {
-		t.Fatalf("expected Tutorial, got %s", section.SectionType.String())
-	}
-}
-
-func TestTokenizeCommand_Quotes(t *testing.T) {
-	args, err := tokenizeCommand(`tool help export --query "topic:hello world"`)
-	if err != nil {
-		t.Fatalf("tokenizeCommand: %v", err)
-	}
-	want := []string{"tool", "help", "export", "--query", "topic:hello world"}
-	if len(args) != len(want) {
-		t.Fatalf("expected %v, got %v", want, args)
-	}
-	for i := range want {
-		if args[i] != want[i] {
-			t.Fatalf("expected %v, got %v", want, args)
-		}
-	}
-}
-
-func TestTokenizeCommand_UnterminatedQuote(t *testing.T) {
-	_, err := tokenizeCommand(`tool "oops`)
-	if err == nil {
-		t.Fatalf("expected unterminated quote error")
-	}
-}
-
-func strconvQuote(s string) string {
-	b, _ := json.Marshal(s)
-	return string(b)
 }

--- a/pkg/help/loader/sources_test.go
+++ b/pkg/help/loader/sources_test.go
@@ -1,0 +1,192 @@
+package loader
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-go-golems/glazed/pkg/help"
+	"github.com/go-go-golems/glazed/pkg/help/model"
+	"github.com/go-go-golems/glazed/pkg/help/store"
+)
+
+func TestNormalizeStringList(t *testing.T) {
+	got := NormalizeStringList([]string{"pinocchio,sqleton", " xxx ", "", "a, b"})
+	want := []string{"pinocchio", "sqleton", "xxx", "a", "b"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestDecodeSectionsJSON_CurrentExportTypeField(t *testing.T) {
+	input := `[{
+		"slug":"help-system",
+		"title":"Help System",
+		"type":"GeneralTopic",
+		"content":"body",
+		"topics":["help"],
+		"flags":["topic"],
+		"commands":["help"],
+		"is_top_level":true,
+		"show_per_default":true,
+		"order":7
+	}]`
+	sections, err := DecodeSectionsJSON(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("DecodeSectionsJSON: %v", err)
+	}
+	if len(sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(sections))
+	}
+	s := sections[0]
+	if s.SectionType != model.SectionGeneralTopic {
+		t.Fatalf("expected GeneralTopic, got %s", s.SectionType.String())
+	}
+	if s.Slug != "help-system" || s.Title != "Help System" || s.Order != 7 {
+		t.Fatalf("unexpected section: %#v", s)
+	}
+	if len(s.Topics) != 1 || s.Topics[0] != "help" {
+		t.Fatalf("topics not preserved: %#v", s.Topics)
+	}
+}
+
+func TestDecodeSectionsJSON_SectionTypeStringField(t *testing.T) {
+	input := `[{"slug":"tutorial","title":"Tutorial","section_type":"Tutorial"}]`
+	sections, err := DecodeSectionsJSON(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("DecodeSectionsJSON: %v", err)
+	}
+	if sections[0].SectionType != model.SectionTutorial {
+		t.Fatalf("expected Tutorial, got %s", sections[0].SectionType.String())
+	}
+}
+
+func TestDecodeSectionsJSON_SectionTypeNumericField(t *testing.T) {
+	input := `[{"slug":"application","title":"Application","section_type":2}]`
+	sections, err := DecodeSectionsJSON(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("DecodeSectionsJSON: %v", err)
+	}
+	if sections[0].SectionType != model.SectionApplication {
+		t.Fatalf("expected Application, got %s", sections[0].SectionType.String())
+	}
+}
+
+func TestDecodeSectionsJSON_MissingTypeFails(t *testing.T) {
+	input := `[{"slug":"missing","title":"Missing"}]`
+	_, err := DecodeSectionsJSON(strings.NewReader(input))
+	if err == nil {
+		t.Fatalf("expected missing type error")
+	}
+}
+
+func TestJSONFileLoader_LoadsSections(t *testing.T) {
+	ctx := context.Background()
+	hs := help.NewHelpSystem()
+	path := filepath.Join(t.TempDir(), "help.json")
+	input := `[{"slug":"json-topic","title":"JSON Topic","type":"Example"}]`
+	if err := os.WriteFile(path, []byte(input), 0o644); err != nil {
+		t.Fatalf("write JSON: %v", err)
+	}
+
+	loader := &JSONFileLoader{Paths: []string{path}}
+	if err := loader.Load(ctx, hs); err != nil {
+		t.Fatalf("loader.Load: %v", err)
+	}
+	section, err := hs.Store.GetBySlug(ctx, "json-topic")
+	if err != nil {
+		t.Fatalf("GetBySlug: %v", err)
+	}
+	if section.SectionType != model.SectionExample {
+		t.Fatalf("expected Example, got %s", section.SectionType.String())
+	}
+}
+
+func TestSQLiteLoader_LoadsSections(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "help.db")
+	source, err := store.New(dbPath)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	if err := source.Upsert(ctx, &model.Section{Slug: "sqlite-topic", Title: "SQLite Topic", SectionType: model.SectionApplication}); err != nil {
+		t.Fatalf("source.Upsert: %v", err)
+	}
+	if err := source.Close(); err != nil {
+		t.Fatalf("source.Close: %v", err)
+	}
+
+	hs := help.NewHelpSystem()
+	loader := &SQLiteLoader{Paths: []string{dbPath}}
+	if err := loader.Load(ctx, hs); err != nil {
+		t.Fatalf("loader.Load: %v", err)
+	}
+	section, err := hs.Store.GetBySlug(ctx, "sqlite-topic")
+	if err != nil {
+		t.Fatalf("GetBySlug: %v", err)
+	}
+	if section.SectionType != model.SectionApplication {
+		t.Fatalf("expected Application, got %s", section.SectionType.String())
+	}
+}
+
+func TestCommandJSONLoader_LoadsSections(t *testing.T) {
+	ctx := context.Background()
+	hs := help.NewHelpSystem()
+	jsonPayload, err := json.Marshal([]map[string]any{{
+		"slug":  "cmd-topic",
+		"title": "Command Topic",
+		"type":  "Tutorial",
+	}})
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	loader := &CommandJSONLoader{Commands: []string{"printf " + strconvQuote(string(jsonPayload))}}
+	if err := loader.Load(ctx, hs); err != nil {
+		t.Fatalf("loader.Load: %v", err)
+	}
+	section, err := hs.Store.GetBySlug(ctx, "cmd-topic")
+	if err != nil {
+		t.Fatalf("GetBySlug: %v", err)
+	}
+	if section.SectionType != model.SectionTutorial {
+		t.Fatalf("expected Tutorial, got %s", section.SectionType.String())
+	}
+}
+
+func TestTokenizeCommand_Quotes(t *testing.T) {
+	args, err := tokenizeCommand(`tool help export --query "topic:hello world"`)
+	if err != nil {
+		t.Fatalf("tokenizeCommand: %v", err)
+	}
+	want := []string{"tool", "help", "export", "--query", "topic:hello world"}
+	if len(args) != len(want) {
+		t.Fatalf("expected %v, got %v", want, args)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, args)
+		}
+	}
+}
+
+func TestTokenizeCommand_UnterminatedQuote(t *testing.T) {
+	_, err := tokenizeCommand(`tool "oops`)
+	if err == nil {
+		t.Fatalf("expected unterminated quote error")
+	}
+}
+
+func strconvQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/pkg/help/server/serve.go
+++ b/pkg/help/server/serve.go
@@ -35,8 +35,13 @@ var _ cmds.BareCommand = (*ServeCommand)(nil)
 
 // ServeSettings holds the parsed flag values for the serve command.
 type ServeSettings struct {
-	Address string   `glazed:"address"`
-	Paths   []string `glazed:"paths"`
+	Address       string   `glazed:"address"`
+	Paths         []string `glazed:"paths"`
+	FromJSON      []string `glazed:"from-json"`
+	FromSQLite    []string `glazed:"from-sqlite"`
+	FromCmd       []string `glazed:"from-cmd"`
+	FromGlazedCmd []string `glazed:"from-glazed-cmd"`
+	WithEmbedded  bool     `glazed:"with-embedded"`
 }
 
 // NewServeCommand creates a BareCommand that starts the help browser HTTP server.
@@ -49,10 +54,17 @@ func NewServeCommand(hs *help.HelpSystem, spaHandler http.Handler) (*ServeComman
 server that serves them with an optional React SPA frontend.
 
 Paths can be individual .md files or directories. Directories are walked
-recursively. When no paths are given, the server serves the built-in Glazed
-documentation already loaded into the help system. When one or more paths are
-given, the serve command clears any preloaded sections and serves only the
-sections discovered from those explicit paths.
+recursively. When no external sources are given, the server serves the built-in
+Glazed documentation already loaded into the help system. When one or more
+external sources are given, the serve command clears any preloaded sections by
+default and serves only the sections discovered from those explicit sources.
+Use --with-embedded to merge external sources with the built-in documentation.
+
+External sources can be JSON exports, SQLite exports, arbitrary commands that
+print JSON help exports, or Glazed-compatible binaries loaded through
+--from-glazed-cmd. For example:
+  glaze serve --from-glazed-cmd pinocchio,sqleton
+  glaze serve --from-json ./help.json --from-sqlite ./help.db
 
 The server listens on the address specified by --address (default :8088) and
 serves:
@@ -67,6 +79,32 @@ using MountPrefix or NewMountedHandler.`),
 					fields.TypeString,
 					fields.WithHelp("Address to listen on"),
 					fields.WithDefault(DefaultAddr),
+				),
+				fields.New(
+					"from-json",
+					fields.TypeStringList,
+					fields.WithHelp("JSON help export files to load; use - for stdin"),
+				),
+				fields.New(
+					"from-sqlite",
+					fields.TypeStringList,
+					fields.WithHelp("SQLite help export databases to load"),
+				),
+				fields.New(
+					"from-cmd",
+					fields.TypeStringList,
+					fields.WithHelp("Commands to run; stdout must be a JSON help export"),
+				),
+				fields.New(
+					"from-glazed-cmd",
+					fields.TypeStringList,
+					fields.WithHelp("Glazed binaries to load by running '<binary> help export --output json'"),
+				),
+				fields.New(
+					"with-embedded",
+					fields.TypeBool,
+					fields.WithHelp("Include embedded docs when external sources are provided"),
+					fields.WithDefault(false),
 				),
 			),
 			cmds.WithArguments(
@@ -94,22 +132,50 @@ func (sc *ServeCommand) Run(ctx context.Context, parsedValues *values.Values) er
 		return errors.New("HelpSystem.Store is nil")
 	}
 
-	// When no paths are given, the help system was already loaded with the
-	// built-in documentation (e.g. via doc.AddDocToHelpSystem). When explicit
-	// paths are given, they are authoritative: clear any preloaded sections and
-	// serve only the requested content.
-	if len(s.Paths) > 0 {
-		if err := helploader.ReplaceStoreWithPaths(ctx, hs, s.Paths); err != nil {
-			return err
+	loaders := buildServeLoaders(s)
+	if len(loaders) > 0 {
+		if !s.WithEmbedded {
+			if err := hs.Store.Clear(ctx); err != nil {
+				return fmt.Errorf("clearing preloaded sections: %w", err)
+			}
+		}
+		for _, l := range loaders {
+			log.Info().Str("source", l.String()).Msg("Loading help source")
+			if err := l.Load(ctx, hs); err != nil {
+				return fmt.Errorf("loading %s: %w", l.String(), err)
+			}
 		}
 	}
 
-	count, _ := hs.Store.Count(ctx)
+	count, err := hs.Store.Count(ctx)
+	if err != nil {
+		return fmt.Errorf("counting help sections: %w", err)
+	}
 	log.Info().Int64("sections", count).Msg("Loaded help sections")
 
 	deps := HandlerDeps{Store: hs.Store}
 	handler := NewServeHandler(deps, sc.spaHandler)
 	return serveHTTP(s.Address, handler)
+}
+
+func buildServeLoaders(s *ServeSettings) []helploader.ContentLoader {
+	var loaders []helploader.ContentLoader
+	if len(helploader.NormalizeStringList(s.Paths)) > 0 {
+		loaders = append(loaders, &helploader.MarkdownPathLoader{Paths: s.Paths})
+	}
+	if len(helploader.NormalizeStringList(s.FromJSON)) > 0 {
+		loaders = append(loaders, &helploader.JSONFileLoader{Paths: s.FromJSON})
+	}
+	if len(helploader.NormalizeStringList(s.FromSQLite)) > 0 {
+		loaders = append(loaders, &helploader.SQLiteLoader{Paths: s.FromSQLite})
+	}
+	if len(helploader.NormalizeCommandList(s.FromCmd)) > 0 {
+		loaders = append(loaders, &helploader.CommandJSONLoader{Commands: s.FromCmd})
+	}
+	if len(helploader.NormalizeStringList(s.FromGlazedCmd)) > 0 {
+		loaders = append(loaders, &helploader.GlazedCommandLoader{Binaries: s.FromGlazedCmd})
+	}
+	return loaders
 }
 
 // NewServeHandler composes the API handler and optional SPA handler for use at

--- a/pkg/help/server/serve.go
+++ b/pkg/help/server/serve.go
@@ -39,7 +39,6 @@ type ServeSettings struct {
 	Paths         []string `glazed:"paths"`
 	FromJSON      []string `glazed:"from-json"`
 	FromSQLite    []string `glazed:"from-sqlite"`
-	FromCmd       []string `glazed:"from-cmd"`
 	FromGlazedCmd []string `glazed:"from-glazed-cmd"`
 	WithEmbedded  bool     `glazed:"with-embedded"`
 }
@@ -60,9 +59,8 @@ external sources are given, the serve command clears any preloaded sections by
 default and serves only the sections discovered from those explicit sources.
 Use --with-embedded to merge external sources with the built-in documentation.
 
-External sources can be JSON exports, SQLite exports, arbitrary commands that
-print JSON help exports, or Glazed-compatible binaries loaded through
---from-glazed-cmd. For example:
+External sources can be JSON exports, SQLite exports, or Glazed-compatible
+binaries loaded through --from-glazed-cmd. For example:
   glaze serve --from-glazed-cmd pinocchio,sqleton
   glaze serve --from-json ./help.json --from-sqlite ./help.db
 
@@ -89,11 +87,6 @@ using MountPrefix or NewMountedHandler.`),
 					"from-sqlite",
 					fields.TypeStringList,
 					fields.WithHelp("SQLite help export databases to load"),
-				),
-				fields.New(
-					"from-cmd",
-					fields.TypeStringList,
-					fields.WithHelp("Commands to run; stdout must be a JSON help export"),
 				),
 				fields.New(
 					"from-glazed-cmd",
@@ -168,9 +161,6 @@ func buildServeLoaders(s *ServeSettings) []helploader.ContentLoader {
 	}
 	if len(helploader.NormalizeStringList(s.FromSQLite)) > 0 {
 		loaders = append(loaders, &helploader.SQLiteLoader{Paths: s.FromSQLite})
-	}
-	if len(helploader.NormalizeCommandList(s.FromCmd)) > 0 {
-		loaders = append(loaders, &helploader.CommandJSONLoader{Commands: s.FromCmd})
 	}
 	if len(helploader.NormalizeStringList(s.FromGlazedCmd)) > 0 {
 		loaders = append(loaders, &helploader.GlazedCommandLoader{Binaries: s.FromGlazedCmd})

--- a/pkg/help/server/serve_test.go
+++ b/pkg/help/server/serve_test.go
@@ -95,6 +95,38 @@ func TestMountPrefix_RejectsOutsidePrefix(t *testing.T) {
 	}
 }
 
+func TestBuildServeLoaders_UsesAllExternalSources(t *testing.T) {
+	settings := &ServeSettings{
+		Paths:         []string{"./docs"},
+		FromJSON:      []string{"a.json,b.json"},
+		FromSQLite:    []string{"a.db"},
+		FromCmd:       []string{"tool help export --output json"},
+		FromGlazedCmd: []string{"pinocchio,sqleton"},
+	}
+
+	loaders := buildServeLoaders(settings)
+	if len(loaders) != 5 {
+		t.Fatalf("expected 5 loaders, got %d", len(loaders))
+	}
+	if !strings.Contains(loaders[4].String(), "pinocchio") || !strings.Contains(loaders[4].String(), "sqleton") {
+		t.Fatalf("expected glazed command loader to include normalized binary list, got %q", loaders[4].String())
+	}
+}
+
+func TestBuildServeLoaders_DoesNotSplitArbitraryCommandsOnComma(t *testing.T) {
+	settings := &ServeSettings{
+		FromCmd: []string{`tool help export --query "topic:a,b" --output json`},
+	}
+
+	loaders := buildServeLoaders(settings)
+	if len(loaders) != 1 {
+		t.Fatalf("expected 1 loader, got %d", len(loaders))
+	}
+	if !strings.Contains(loaders[0].String(), "topic:a,b") {
+		t.Fatalf("command was unexpectedly comma-split: %q", loaders[0].String())
+	}
+}
+
 func TestReplaceStoreWithPaths_ClearsPreloadedSections(t *testing.T) {
 	hs := help.NewHelpSystem()
 	hs.AddSection(&model.Section{

--- a/pkg/help/server/serve_test.go
+++ b/pkg/help/server/serve_test.go
@@ -100,30 +100,15 @@ func TestBuildServeLoaders_UsesAllExternalSources(t *testing.T) {
 		Paths:         []string{"./docs"},
 		FromJSON:      []string{"a.json,b.json"},
 		FromSQLite:    []string{"a.db"},
-		FromCmd:       []string{"tool help export --output json"},
 		FromGlazedCmd: []string{"pinocchio,sqleton"},
 	}
 
 	loaders := buildServeLoaders(settings)
-	if len(loaders) != 5 {
-		t.Fatalf("expected 5 loaders, got %d", len(loaders))
+	if len(loaders) != 4 {
+		t.Fatalf("expected 4 loaders, got %d", len(loaders))
 	}
-	if !strings.Contains(loaders[4].String(), "pinocchio") || !strings.Contains(loaders[4].String(), "sqleton") {
-		t.Fatalf("expected glazed command loader to include normalized binary list, got %q", loaders[4].String())
-	}
-}
-
-func TestBuildServeLoaders_DoesNotSplitArbitraryCommandsOnComma(t *testing.T) {
-	settings := &ServeSettings{
-		FromCmd: []string{`tool help export --query "topic:a,b" --output json`},
-	}
-
-	loaders := buildServeLoaders(settings)
-	if len(loaders) != 1 {
-		t.Fatalf("expected 1 loader, got %d", len(loaders))
-	}
-	if !strings.Contains(loaders[0].String(), "topic:a,b") {
-		t.Fatalf("command was unexpectedly comma-split: %q", loaders[0].String())
+	if !strings.Contains(loaders[3].String(), "pinocchio") || !strings.Contains(loaders[3].String(), "sqleton") {
+		t.Fatalf("expected glazed command loader to include normalized binary list, got %q", loaders[3].String())
 	}
 }
 

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/README.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/README.md
@@ -1,0 +1,21 @@
+# Add glazed help export verb: export metadata and entries to disk/SQLite
+
+This is the document workspace for ticket GLAZE-HELP-EXPORT.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GLAZE-HELP-EXPORT --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GLAZE-HELP-EXPORT --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GLAZE-HELP-EXPORT --field Status --value review`

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/changelog.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/changelog.md
@@ -139,3 +139,8 @@ Step 9: Uploaded updated bundle with serve external sources design and implement
 
 - /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/doc/topics/29-serve-external-help-sources.md — Documented new serve external source workflow
 
+
+## 2026-04-28
+
+Ticket closed
+

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/changelog.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/changelog.md
@@ -144,3 +144,21 @@ Step 9: Uploaded updated bundle with serve external sources design and implement
 
 Ticket closed
 
+
+## 2026-04-28
+
+Step 10: Addressed PR #558 review comments: removed --from-cmd, rejected invalid export --type filters, and hardened file export paths
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-glazed-help-export/glazed/pkg/help/cmd/export.go — Reject invalid type filters and validate file export paths
+
+
+## 2026-04-28
+
+Step 10: Updated serve external sources design to remove arbitrary command loading
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-glazed-help-export/glazed/pkg/help/server/serve.go — Removed --from-cmd flag and loader wiring
+

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/changelog.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/changelog.md
@@ -1,0 +1,141 @@
+# Changelog
+
+## 2026-04-28
+
+- Initial workspace created
+
+
+## 2026-04-28
+
+Step 1: Initialized ticket and read skill files for workflow guidance
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-glazed-help-export/glazed/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/design-doc/01-design-glazed-help-export-verb-metadata-and-content-export-to-disk-and-sqlite.md — Created design document
+
+
+## 2026-04-28
+
+Step 2: Explored glazed help system codebase architecture
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/help.go — Explored HelpSystem facade
+
+
+## 2026-04-28
+
+Step 3: Wrote comprehensive design document for intern onboarding
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-glazed-help-export/glazed/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/design-doc/01-design-glazed-help-export-verb-metadata-and-content-export-to-disk-and-sqlite.md — Completed design doc
+
+
+## 2026-04-28
+
+Step 4: Validated docs with docmgr doctor and uploaded bundle to reMarkable
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-glazed-help-export/glazed/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/design-doc/01-design-glazed-help-export-verb-metadata-and-content-export-to-disk-and-sqlite.md — Final delivery
+
+
+## 2026-04-28
+
+Step 5: Simplified design to single verb 'glaze help export' with --with-content=true by default
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-glazed-help-export/glazed/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/design-doc/01-design-glazed-help-export-verb-metadata-and-content-export-to-disk-and-sqlite.md — Collapsed export metadata and export content into single ExportCommand
+
+
+## 2026-04-28
+
+Step 6: Implemented glaze help export verb (tabular, files, sqlite) with 11 passing tests
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/cmd/export.go — ExportCommand implementation (commit 391a62f)
+
+
+## 2026-04-28
+
+Step 6: Added unit tests for export command covering filters, files, sqlite, and round-trip
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/cmd/export_test.go — Unit tests (commit 81f52fc)
+
+
+## 2026-04-28
+
+Step 7: Added help documentation topic 'export-help-entries' and cross-references in related docs
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/doc/topics/28-export-help-entries.md — New help topic documenting glaze help export
+
+
+## 2026-04-28
+
+Step 7: Updated help-system, serve-help-over-http, and export-help-static-website docs with cross-references
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/doc/topics/01-help-system.md — Added export mention and See Also
+
+
+## 2026-04-28
+
+Step 8: Added design document for serve-external-sources feature (multi-source help browser)
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go — ServeCommand extension design
+
+
+## 2026-04-28
+
+Step 8: Designed ContentLoader interface with JSON, SQLite, Command, and Markdown loaders
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/model/section.go — SectionType JSON marshaling needed
+
+
+## 2026-04-28
+
+Step 9: Revised serve external sources design for --from-glazed-cmd and --with-embedded=false default
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go — ServeCommand external source implementation
+
+
+## 2026-04-28
+
+Step 9: Implemented external help source loaders and ServeCommand source flags
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/loader/sources.go — ContentLoader implementations
+
+
+## 2026-04-28
+
+Step 9: Added user documentation for serve external help sources
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/doc/topics/29-serve-external-help-sources.md — New help topic
+
+
+## 2026-04-28
+
+Step 9: Uploaded updated bundle with serve external sources design and implementation diary to reMarkable
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/doc/topics/29-serve-external-help-sources.md — Documented new serve external source workflow
+

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/design-doc/01-design-glazed-help-export-verb-metadata-and-content-export-to-disk-and-sqlite.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/design-doc/01-design-glazed-help-export-verb-metadata-and-content-export-to-disk-and-sqlite.md
@@ -1,0 +1,1196 @@
+---
+Title: 'Design: Glazed Help Export Verb - Metadata and Content Export to Disk and SQLite'
+Ticket: GLAZE-HELP-EXPORT
+Status: active
+Topics:
+    - glazed
+    - help-system
+    - cli
+    - export
+    - sqlite
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/cmd/glaze/main.go
+      Note: Application root
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/doc/topics/28-export-help-entries.md
+      Note: Help topic documenting the export verb
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/cmd/cobra.go
+      Note: Cobra help command wiring
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/cmd/export.go
+      Note: Implementation of ExportCommand
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/help.go
+      Note: HelpSystem facade
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/model/section.go
+      Note: Section struct definition
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/site/render.go
+      Note: Prior art for export logic
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/store/query.go
+      Note: Predicate query system
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/store/store.go
+      Note: SQLite store implementation
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T07:35:00-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+
+
+
+
+
+
+
+
+# Design: Glazed Help Export Verb - Metadata and Content Export to Disk and SQLite
+
+## Executive Summary
+
+This document describes the design for adding an **export verb** to the Glazed help system. The goal is to let any binary built on Glazed export its embedded help entries - both their metadata and their full content - to external files on disk. This enables downstream tooling: indexing, searching offline, generating documentation sites, auditing coverage, and integrating help content into other applications.
+
+The feature adds a single `glaze help export` verb that exports help sections from any binary built on Glazed. By default, it streams section metadata (and full content, since `--with-content` defaults to `true`) through the Glazed processor as JSON, CSV, or a table. With `--format files` or `--format sqlite`, it writes reconstructed markdown files or a portable SQLite database to disk instead.
+
+This document is written for a new intern joining the team. Every concept is explained from first principles, with concrete file references, pseudocode, API call patterns, and step-by-step implementation guidance.
+
+---
+
+## Problem Statement and Scope
+
+### What is the pain point today?
+
+The Glazed help system stores documentation as **help sections** inside the binary, loaded from embedded markdown files at startup. Users can browse these sections interactively via:
+
+- `glaze help <topic>` - view a single topic
+- `glaze help --list` - list available topics
+- `glaze help --query "..."` - search with the DSL
+- `glaze help --ui` - browse in a TUI
+- `glaze serve-help` - browse via HTTP
+- `glaze render-site` - export as a static website
+
+What is **missing** is a simple, scriptable way to get the help data *out* of the binary in a structured form. If a developer wants to:
+
+- Audit which topics document which commands
+- Build a custom search index in another tool
+- Archive the documentation at a specific version
+- Transform the markdown for another publishing pipeline
+- Merge help entries from multiple Glazed binaries
+
+...they currently have no CLI-native way to do so. The `render-site` command exists, but it produces a full React SPA with JSON payloads - overkill for many use cases.
+
+### Scope of this ticket
+
+1. Add `glaze help export` - a single verb that exports help section data.
+2. Default behavior: stream all matching sections (metadata + content, since `--with-content` is `true` by default) as JSON/CSV/table via the Glaze processor.
+3. Support filtering (by type, topic, command, flag, slug) so exports are targeted.
+4. Support disk-export modes (`--format files` for markdown files, `--format sqlite` for a SQLite database).
+5. Support `--with-content=false` to omit the `content` field from tabular output, producing lightweight metadata-only exports.
+6. Keep the implementation idiomatic to the existing Glazed command framework.
+
+### Out of scope
+
+- Modifying the help section schema (no new fields).
+- Changing how sections are loaded or rendered for interactive use.
+- Replacing `render-site` (it remains the right tool for full static-site generation).
+
+---
+
+## Current-State Architecture
+
+To understand where the export verb fits, we need to understand the help system's data flow. This section explains each layer from the bottom up.
+
+### Layer 1: The Markdown Source Files
+
+Help content lives in `.md` files inside the repository, typically under a `doc/` directory. Each file contains YAML frontmatter followed by markdown body.
+
+**Example file:** `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/doc/help-system.md`
+
+```yaml
+---
+Title: "Help System"
+Slug: "help-system"
+Short: "Overview of the glazed help system"
+Topics:
+- help
+- documentation
+Commands:
+- help
+SectionType: GeneralTopic
+---
+
+The help system allows...
+```
+
+**Key frontmatter fields:**
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `Title` | string | Human-readable title |
+| `Slug` | string | Unique identifier used for lookups |
+| `Short` | string | One-line summary |
+| `SectionType` | string | `GeneralTopic`, `Example`, `Application`, `Tutorial` |
+| `Topics` | []string | Tags for cross-referencing |
+| `Commands` | []string | Which CLI commands this section documents |
+| `Flags` | []string | Which flags this section documents |
+| `IsTopLevel` | bool | Show on the root help page? |
+| `ShowPerDefault` | bool | Show by default in listings? |
+| `Order` | int | Sort order |
+
+**File references:**
+- Parser: `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/model/parse.go`
+- Section struct: `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/model/section.go`
+
+### Layer 2: The `model.Section` Struct
+
+The parser converts each markdown file into a `model.Section` value in memory.
+
+```go
+// From pkg/help/model/section.go
+type Section struct {
+    ID          int64
+    Slug        string
+    SectionType SectionType  // GeneralTopic, Example, Application, Tutorial
+    Title       string
+    SubTitle    string
+    Short       string
+    Content     string       // Full markdown body (after frontmatter)
+    Topics      []string
+    Flags       []string
+    Commands    []string
+    IsTopLevel  bool
+    IsTemplate  bool
+    ShowPerDefault bool
+    Order       int
+    CreatedAt   string
+    UpdatedAt   string
+}
+```
+
+This struct is the **canonical data shape** for everything downstream. Whether we are rendering to the terminal, serving over HTTP, or exporting to disk, we start from `[]*model.Section`.
+
+### Layer 3: The `store.Store` - SQLite Backend
+
+Every `HelpSystem` owns a `store.Store`, which wraps a SQLite database. When sections are loaded, they are upserted into this store. The store provides:
+
+- `Insert(ctx, section)` - create new row
+- `Update(ctx, section)` - modify existing row by ID
+- `Upsert(ctx, section)` - insert or update by slug (the primary loading path)
+- `GetBySlug(ctx, slug)` - retrieve one section
+- `GetByID(ctx, id)` - retrieve one section by numeric ID
+- `List(ctx, orderBy)` - list all sections with optional ordering
+- `Find(ctx, predicate)` - query with structured predicates
+- `Count(ctx)` - total section count
+- `Clear(ctx)` - delete all sections
+
+**File reference:** `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/store/store.go`
+
+The SQLite schema is simple:
+
+```sql
+CREATE TABLE sections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug TEXT NOT NULL UNIQUE,
+    section_type INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    sub_title TEXT,
+    short TEXT,
+    content TEXT,
+    topics TEXT,       -- comma-separated
+    flags TEXT,        -- comma-separated
+    commands TEXT,     -- comma-separated
+    is_top_level BOOLEAN DEFAULT FALSE,
+    is_template BOOLEAN DEFAULT FALSE,
+    show_per_default BOOLEAN DEFAULT FALSE,
+    order_num INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+The store is created in-memory by default (`:memory:`), but the `store.New(dbPath)` constructor can also target a file path.
+
+### Layer 4: The `help.HelpSystem` Facade
+
+The `HelpSystem` is the high-level object that most of the application interacts with. It owns the `Store` and provides file-loading conveniences.
+
+```go
+// From pkg/help/help.go
+type HelpSystem struct {
+    Store *store.Store
+}
+
+func NewHelpSystem() *HelpSystem        // Creates in-memory store
+func NewHelpSystemWithStore(st *store.Store) *HelpSystem
+
+func (hs *HelpSystem) LoadSectionsFromFS(f fs.FS, dir string) error
+func (hs *HelpSystem) AddSection(section *model.Section)
+func (hs *HelpSystem) GetSectionWithSlug(slug string) (*model.Section, error)
+func (hs *HelpSystem) GetTopLevelHelpPage() *HelpPage
+```
+
+**File reference:** `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/help.go`
+
+### Layer 5: The Cobra Help Command
+
+The `help_cmd` package wires the `HelpSystem` into Cobra. The key function is:
+
+```go
+// From pkg/help/cmd/cobra.go
+func SetupCobraRootCommand(hs *help.HelpSystem, cmd *cobra.Command)
+```
+
+This function:
+1. Overrides the root command's `HelpFunc` and `UsageFunc` to use Glazed rendering.
+2. Creates a `help` subcommand (via `NewCobraHelpCommand`) that supports `--list`, `--topics`, `--query`, `--ui`, etc.
+3. Adds the `help` subcommand to the root command tree.
+
+The current `help` subcommand has a `Run` function that branches based on flags:
+- `--ui` → launch TUI
+- `--query` → DSL search
+- `--list`, `--topics`, `--examples`, etc. → filtered listing
+- positional args → lookup by slug or command path
+
+**File reference:** `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/cmd/cobra.go`
+
+### Layer 6: The Application Root (`main.go`)
+
+Each binary (e.g., `glaze`) initializes the help system in its `main`:
+
+```go
+// From cmd/glaze/main.go
+helpSystem := help.NewHelpSystem()
+err = doc.AddDocToHelpSystem(helpSystem)  // Load embedded docs
+help_cmd.SetupCobraRootCommand(helpSystem, rootCmd)
+```
+
+The `doc` package embeds the markdown files using `//go:embed *` and calls `hs.LoadSectionsFromFS(docFS, ".")`.
+
+**File reference:** `/home/manuel/code/wesen/corporate-headquarters/glazed/cmd/glaze/main.go`
+
+### Architecture Diagram (Current State)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Application (glaze)                      │
+│  ┌─────────────┐    ┌─────────────────────────────────────┐ │
+│  │ Cobra Root  │◄───│ help_cmd.SetupCobraRootCommand(...) │ │
+│  │   Command   │    └─────────────────────────────────────┘ │
+│  └──────┬──────┘                                           │
+│         │                                                    │
+│         ▼                                                    │
+│  ┌────────────────────────────────────────┐                 │
+│  │   "help" subcommand (cobra.Command)    │                 │
+│  │  - --list, --topics, --examples, etc.  │                 │
+│  │  - --query "DSL"                       │                 │
+│  │  - --ui                                │                 │
+│  └────────────────────────────────────────┘                 │
+│                        │                                     │
+│                        ▼                                     │
+│              ┌──────────────────┐                           │
+│              │  help.HelpSystem │                           │
+│              │  - LoadSectionsFromFS()                      │
+│              │  - GetSectionWithSlug()                      │
+│              │  - ComputeRenderData()                       │
+│              └────────┬─────────┘                           │
+│                       │                                      │
+│                       ▼                                      │
+│              ┌──────────────────┐                           │
+│              │   store.Store    │                           │
+│              │  (SQLite backend)│                           │
+│              │  - Upsert()      │                           │
+│              │  - Find()        │                           │
+│              │  - List()        │                           │
+│              └──────────────────┘                           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Gap Analysis
+
+### What exists today for getting data out?
+
+| Feature | Output | Granularity | Use Case |
+|---------|--------|-------------|----------|
+| `glaze help --list` | Terminal table | Slug + title | Human browsing |
+| `glaze help --query "..."` | Terminal list | Slug + title | Human search |
+| `glaze serve-help` | HTTP JSON API | Full sections | SPA browser |
+| `glaze render-site` | Static SPA + JSON | Full sections | Publish website |
+| `glaze docs <files>` | Glazed table | Frontmatter only | Analyze markdown files on disk |
+
+### What is missing?
+
+1. **No structured export from the live help system.**
+   - `docs` only reads files you explicitly pass it; it does not talk to the `HelpSystem`.
+   - There is no command that says "list every section in the current binary, with all metadata fields and content, as JSON/CSV."
+
+2. **No disk-export to plain files or SQLite.**
+   - `render-site` produces a React SPA - great for hosting, bad for piping into other tools.
+   - There is no way to say "write each help section to a `.md` file" or "dump everything into a `.sqlite` file I can query with SQL."
+
+3. **No filtering at export time.**
+   - Even if we added export, we would want to support `--type`, `--topic`, `--command` filters so users do not have to post-process.
+
+### Why this matters
+
+- **Composability:** Unix philosophy says tools should output data in formats other tools can consume. JSON, CSV, and SQLite are lingua franca.
+- **Offline access:** A SQLite file can be queried with any SQLite client, synced to mobile devices, or embedded into another application.
+- **Auditing:** CI pipelines can export metadata and assert that every command has at least one help section.
+- **Integration:** Documentation platforms, LLM context builders, and IDE plugins can consume structured help exports.
+
+---
+
+## Proposed Solution
+
+### Overview
+
+Add a single `export` subcommand under the existing `help` command:
+
+```
+glaze help export [flags]
+```
+
+The command operates on the `HelpSystem` already initialized by the binary. It uses the same `Store.Find()` and `Store.List()` APIs that the interactive help system uses. The behavior branches based on `--format`:
+
+### `glaze help export` - Default Tabular Mode
+
+**Purpose:** Export help sections as structured data via the Glaze processor.
+
+**Flags:**
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--type` | string | "" | Filter by section type (`GeneralTopic`, `Example`, `Application`, `Tutorial`) |
+| `--topic` | string | "" | Filter by topic tag |
+| `--command` | string | "" | Filter by associated command |
+| `--flag` | string | "" | Filter by associated flag |
+| `--slug` | string | "" | Filter by exact slug (or comma-separated list) |
+| `--with-content` | bool | `true` | Include the `content` field in tabular output |
+| `--format` | string | `"glazed"` | Output mode: `glazed` (tabular), `files`, or `sqlite` |
+| `--output` | string | `"-"` | Output file path ("-" for stdout; used by `files`/`sqlite`) |
+| `--flatten` | bool | `false` | For `files` mode: flatten directory structure |
+
+**Why `--with-content=true` by default?**
+- The most common use case is "get everything out of the binary." Including content by default means one command gives a complete snapshot.
+- Users who want lightweight metadata can opt out with `--with-content=false`.
+- This avoids the confusion of having two subcommands that users must choose between.
+
+**Output schema (JSON, `--with-content=true`):**
+
+```json
+[
+  {
+    "id": 1,
+    "slug": "help-system",
+    "type": "GeneralTopic",
+    "title": "Help System",
+    "short": "Overview of the glazed help system",
+    "topics": ["help", "documentation"],
+    "flags": [],
+    "commands": ["help"],
+    "is_top_level": true,
+    "show_per_default": true,
+    "order": 0,
+    "content": "The help system allows...",
+    "created_at": "2025-04-28T10:00:00Z",
+    "updated_at": "2025-04-28T10:00:00Z"
+  }
+]
+```
+
+**Output schema (JSON, `--with-content=false`):**
+
+```json
+[
+  {
+    "id": 1,
+    "slug": "help-system",
+    "type": "GeneralTopic",
+    "title": "Help System",
+    "short": "Overview of the glazed help system",
+    "topics": ["help", "documentation"],
+    "flags": [],
+    "commands": ["help"],
+    "is_top_level": true,
+    "show_per_default": true,
+    "order": 0,
+    "created_at": "2025-04-28T10:00:00Z",
+    "updated_at": "2025-04-28T10:00:00Z"
+  }
+]
+```
+
+### Disk-Export Modes (`--format files` and `--format sqlite`)
+
+When `--format` is `files` or `sqlite`, the command switches from tabular output to file-writing mode and behaves as a `BareCommand`.
+
+#### `files` mode (`--format files --output ./help-export`)
+
+Each matching section is written as an individual `.md` file. The file contents are reconstructed frontmatter + body, so they are valid Glazed help sections that can be re-imported.
+
+**Directory layout (default):**
+
+```
+help-export/
+├── general-topics/
+│   ├── help-system.md
+│   └── markdown-style.md
+├── examples/
+│   └── help-example-1.md
+├── applications/
+│   └── declarative-config-plan-example.md
+└── tutorials/
+    └── writing-help-entries.md
+```
+
+**Directory layout with `--flatten`:**
+
+```
+help-export/
+├── help-system.md
+├── markdown-style.md
+├── help-example-1.md
+└── ...
+```
+
+**Reconstructed file format:**
+
+Each file is written with YAML frontmatter reconstructed from the `model.Section` fields, followed by the original `Content`.
+
+```yaml
+---
+Title: "Help System"
+Slug: "help-system"
+Short: "Overview of the glazed help system"
+Topics:
+- help
+- documentation
+Commands:
+- help
+SectionType: GeneralTopic
+IsTopLevel: true
+ShowPerDefault: true
+Order: 0
+---
+
+The help system allows...
+```
+
+#### `sqlite` mode (`--format sqlite --output ./my-help.sqlite`)
+
+A single SQLite database file is created with the full `sections` schema, including the `content` column. This is a **portable, queryable snapshot** of the help system.
+
+```bash
+glaze help export --format sqlite --output ./my-help.sqlite
+sqlite3 ./my-help.sqlite "SELECT slug, title FROM sections WHERE section_type = 0;"
+```
+
+The SQLite schema matches the existing store schema exactly, so the exported file can be opened with `store.New("./my-help.sqlite")`.
+
+### Filtering Architecture
+
+Both commands reuse the existing **predicate system** in `pkg/help/store/query.go`.
+
+A predicate is a function `func(*QueryCompiler)` that adds WHERE clauses, JOINs, ORDER BY, LIMIT, and OFFSET to a SQL query. The store provides many built-in predicates:
+
+```go
+// From pkg/help/store/query.go
+store.IsType(model.SectionGeneralTopic)
+store.HasTopic("help")
+store.HasCommand("json")
+store.HasFlag("verbose")
+store.IsTopLevel()
+store.SlugEquals("help-system")
+store.SlugIn([]string{"a", "b"})
+store.OrderByTitle()
+store.Limit(10)
+```
+
+Predicates can be combined with boolean logic:
+
+```go
+store.And(pred1, pred2, pred3)
+store.Or(pred1, pred2)
+store.Not(pred)
+```
+
+**Pseudocode for building the export predicate:**
+
+```go
+func buildExportPredicate(flags ExportFlags) store.Predicate {
+    var preds []store.Predicate
+
+    if flags.Type != "" {
+        st, _ := model.SectionTypeFromString(flags.Type)
+        preds = append(preds, store.IsType(st))
+    }
+    if flags.Topic != "" {
+        preds = append(preds, store.HasTopic(flags.Topic))
+    }
+    if flags.Command != "" {
+        preds = append(preds, store.HasCommand(flags.Command))
+    }
+    if flags.Flag != "" {
+        preds = append(preds, store.HasFlag(flags.Flag))
+    }
+    if flags.Slug != "" {
+        slugs := strings.Split(flags.Slug, ",")
+        if len(slugs) == 1 {
+            preds = append(preds, store.SlugEquals(flags.Slug))
+        } else {
+            preds = append(preds, store.SlugIn(slugs))
+        }
+    }
+
+    // Always order predictably
+    base := store.OrderByOrder()
+    if len(preds) == 0 {
+        return base
+    }
+    return store.And(store.And(preds...), base)
+}
+```
+
+This predicate is passed to `hs.Store.Find(ctx, predicate)` to retrieve the matching sections.
+
+---
+
+## Detailed Design: Command Implementations
+
+### How Glazed Commands Work (Primer for Interns)
+
+Before diving into the export commands, we need to understand how Glazed commands are structured. Glazed provides its own command framework on top of Cobra.
+
+#### The `cmds.Command` interface
+
+```go
+// From pkg/cmds/cmds.go
+type Command interface {
+    Description() *CommandDescription
+    ToYAML(w io.Writer) error
+}
+```
+
+Every command must be able to describe itself (name, flags, arguments, help text) and serialize to YAML.
+
+#### The `cmds.BareCommand` interface
+
+```go
+// From pkg/cmds/cmds.go
+type BareCommand interface {
+    Command
+    Run(ctx context.Context, parsedValues *values.Values) error
+}
+```
+
+A `BareCommand` receives parsed flag/argument values and runs its logic. This is the simplest kind of Glazed command.
+
+#### The `cmds.GlazeCommand` interface
+
+```go
+// From pkg/cmds/cmds.go
+type GlazeCommand interface {
+    Command
+    RunIntoGlazeProcessor(ctx context.Context, parsedValues *values.Values, gp middlewares.Processor) error
+}
+```
+
+A `GlazeCommand` streams rows into a `GlazeProcessor`, which handles output formatting (JSON, CSV, table, YAML, etc.) automatically. This is ideal for commands that produce tabular data.
+
+#### Building a Cobra command from a Glazed command
+
+```go
+// From pkg/cli/cobra.go
+func BuildCobraCommand(cmd cmds.Command, options ...BuildOption) (*cobra.Command, error)
+```
+
+This function:
+1. Reflects on the Glazed command's `CommandDescription`.
+2. Creates a `cobra.Command` with matching flags and arguments.
+3. Wires the `Run` method to parse Cobra flags into `*values.Values` and invoke the Glazed command.
+
+**This is the standard pattern for adding new commands to `glaze`.**
+
+### Single `ExportCommand` with Mode Switching
+
+Instead of two separate commands, we implement one `ExportCommand` that behaves as either a `GlazeCommand` (tabular output) or a `BareCommand` (file output) depending on `--format`.
+
+```go
+// Pseudocode for the unified export command implementation
+
+type ExportCommand struct {
+    *cmds.CommandDescription
+    helpSystem *help.HelpSystem
+}
+
+// ExportCommand implements both GlazeCommand and BareCommand behaviors
+// depending on the --format flag. This is achieved by implementing
+// RunIntoGlazeProcessor for tabular modes and Run for disk-export modes.
+
+var _ cmds.GlazeCommand = (*ExportCommand)(nil)
+var _ cmds.BareCommand = (*ExportCommand)(nil)
+
+type ExportSettings struct {
+    Type        string `glazed:"type"`
+    Topic       string `glazed:"topic"`
+    Command     string `glazed:"command"`
+    Flag        string `glazed:"flag"`
+    Slug        string `glazed:"slug"`
+    WithContent bool   `glazed:"with-content"`
+    Format      string `glazed:"format"`   // "glazed" | "files" | "sqlite"
+    Output      string `glazed:"output"`
+    Flatten     bool   `glazed:"flatten"`
+}
+
+func NewExportCommand(hs *help.HelpSystem) (*ExportCommand, error) {
+    return &ExportCommand{
+        CommandDescription: cmds.NewCommandDescription(
+            "export",
+            cmds.WithShort("Export help sections to external formats"),
+            cmds.WithLong(`Export help sections as structured data or to disk.
+
+By default, exports all matching sections as JSON/CSV/table via the Glazed
+processor, including full markdown content (--with-content defaults to true).
+
+Use --format files to write individual .md files, or --format sqlite to
+produce a portable SQLite database. Use --with-content=false for lightweight
+metadata-only exports.`),
+            cmds.WithFlags(
+                fields.New("type", fields.TypeString, fields.WithHelp("Filter by section type"), fields.WithDefault("")),
+                fields.New("topic", fields.TypeString, fields.WithHelp("Filter by topic"), fields.WithDefault("")),
+                fields.New("command", fields.TypeString, fields.WithHelp("Filter by command"), fields.WithDefault("")),
+                fields.New("flag", fields.TypeString, fields.WithHelp("Filter by flag"), fields.WithDefault("")),
+                fields.New("slug", fields.TypeString, fields.WithHelp("Filter by slug(s)"), fields.WithDefault("")),
+                fields.New("with-content", fields.TypeBool, fields.WithHelp("Include content field in tabular output"), fields.WithDefault(true)),
+                fields.New("format", fields.TypeString, fields.WithHelp("Export mode: glazed, files, sqlite"), fields.WithDefault("glazed")),
+                fields.New("output", fields.TypeString, fields.WithHelp("Output path (- for stdout, or directory/file path)"), fields.WithDefault("-")),
+                fields.New("flatten", fields.TypeBool, fields.WithHelp("Flatten directory structure in files mode"), fields.WithDefault(false)),
+            ),
+        ),
+        helpSystem: hs,
+    }, nil
+}
+```
+
+#### Tabular mode (`--format glazed`) - implements `GlazeCommand`
+
+```go
+func (c *ExportCommand) RunIntoGlazeProcessor(
+    ctx context.Context,
+    parsedValues *values.Values,
+    gp middlewares.Processor,
+) error {
+    settings := &ExportSettings{}
+    if err := parsedValues.DecodeSectionInto(schema.DefaultSlug, settings); err != nil {
+        return err
+    }
+
+    // Validate: this method should only be called for glazed format
+    if settings.Format != "glazed" {
+        return errors.New("RunIntoGlazeProcessor called with non-glazed format; use Run() for files/sqlite")
+    }
+
+    predicate := buildExportPredicate(settings)
+    sections, err := c.helpSystem.Store.Find(ctx, predicate)
+    if err != nil {
+        return err
+    }
+
+    for _, section := range sections {
+        row := types.NewRow(
+            types.MRP("id", section.ID),
+            types.MRP("slug", section.Slug),
+            types.MRP("type", section.SectionType.String()),
+            types.MRP("title", section.Title),
+            types.MRP("short", section.Short),
+            types.MRP("topics", section.Topics),
+            types.MRP("flags", section.Flags),
+            types.MRP("commands", section.Commands),
+            types.MRP("is_top_level", section.IsTopLevel),
+            types.MRP("show_per_default", section.ShowPerDefault),
+            types.MRP("order", section.Order),
+            types.MRP("created_at", section.CreatedAt),
+            types.MRP("updated_at", section.UpdatedAt),
+        )
+        if settings.WithContent {
+            row.Set("content", section.Content)
+        }
+        if err := gp.AddRow(ctx, row); err != nil {
+            return err
+        }
+    }
+
+    return nil
+}
+```
+
+#### Disk-export mode (`--format files` / `--format sqlite`) - implements `BareCommand`
+
+```go
+func (c *ExportCommand) Run(ctx context.Context, parsedValues *values.Values) error {
+    settings := &ExportSettings{}
+    if err := parsedValues.DecodeSectionInto(schema.DefaultSlug, settings); err != nil {
+        return err
+    }
+
+    predicate := buildExportPredicate(settings)
+    sections, err := c.helpSystem.Store.Find(ctx, predicate)
+    if err != nil {
+        return err
+    }
+
+    switch settings.Format {
+    case "glazed":
+        // This should not happen if cli.BuildCobraCommand dispatches correctly,
+        // but we handle it by delegating to the Glaze processor.
+        return errors.New("use --output json/csv/table for glazed format, or call via GlazeCommand path")
+    case "files":
+        return exportToFiles(sections, settings)
+    case "sqlite":
+        return exportToSQLite(sections, settings)
+    default:
+        return fmt.Errorf("unknown format: %s", settings.Format)
+    }
+}
+```
+
+**Why this dual-interface approach?**
+- `cli.BuildCobraCommand` inspects which interfaces a command implements. If `GlazeCommand` is present, it wires `--output json/csv/table/yaml` flags and creates a `GlazeProcessor`.
+- For disk-export modes, we bypass the Glaze processor entirely and write files directly.
+- At runtime, the `Run` method checks `--format` and delegates appropriately. The Cobra wiring may need a small adjustment to call `Run` instead of `RunIntoGlazeProcessor` when `--format` is not `glazed`.
+
+#### `exportToFiles` pseudocode (unchanged from prior design)
+
+```go
+func exportToFiles(sections []*model.Section, settings *ExportContentSettings) error {
+    outDir := settings.Output
+    if err := os.MkdirAll(outDir, 0755); err != nil {
+        return err
+    }
+
+    for _, section := range sections {
+        dir := outDir
+        if !settings.Flatten {
+            dir = filepath.Join(outDir, slugify(section.SectionType.String()))
+            if err := os.MkdirAll(dir, 0755); err != nil {
+                return err
+            }
+        }
+
+        path := filepath.Join(dir, section.Slug+".md")
+        data, err := reconstructMarkdown(section)
+        if err != nil {
+            return err
+        }
+        if err := os.WriteFile(path, data, 0644); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+
+func reconstructMarkdown(section *model.Section) ([]byte, error) {
+    // Use a structured map and yaml.Marshal to reconstruct frontmatter
+    frontmatter := map[string]interface{}{
+        "Title":          section.Title,
+        "Slug":           section.Slug,
+        "Short":          section.Short,
+        "SectionType":    section.SectionType.String(),
+        "Topics":         section.Topics,
+        "Flags":          section.Flags,
+        "Commands":       section.Commands,
+        "IsTopLevel":     section.IsTopLevel,
+        "IsTemplate":     section.IsTemplate,
+        "ShowPerDefault": section.ShowPerDefault,
+        "Order":          section.Order,
+    }
+    if section.SubTitle != "" {
+        frontmatter["SubTitle"] = section.SubTitle
+    }
+
+    var buf bytes.Buffer
+    buf.WriteString("---\n")
+    if err := yaml.NewEncoder(&buf).Encode(frontmatter); err != nil {
+        return nil, err
+    }
+    buf.WriteString("---\n")
+    buf.WriteString(section.Content)
+    return buf.Bytes(), nil
+}
+```
+
+#### `exportToSQLite` pseudocode (unchanged from prior design)
+
+```go
+func exportToSQLite(sections []*model.Section, settings *ExportContentSettings) error {
+    dbPath := settings.Output
+    if !strings.HasSuffix(dbPath, ".sqlite") && !strings.HasSuffix(dbPath, ".db") {
+        dbPath += ".sqlite"
+    }
+
+    // Remove existing file to start fresh
+    _ = os.Remove(dbPath)
+
+    // Use the existing store.New constructor
+    exportStore, err := store.New(dbPath)
+    if err != nil {
+        return err
+    }
+    defer exportStore.Close()
+
+    for _, section := range sections {
+        // Upsert creates or updates; since the DB is fresh, it always inserts
+        if err := exportStore.Upsert(ctx, section); err != nil {
+            return err
+        }
+    }
+
+    return nil
+}
+```
+
+**Why reuse `store.New`?**
+- The schema and indexes are created automatically.
+- `Upsert` handles both insert and update semantics.
+- No raw SQL needed, so the implementation stays maintainable.
+
+---
+
+## Wiring the Commands into the Application
+
+The export command must be registered as a subcommand of `glaze help`. The existing `help` command is created inside `help_cmd.SetupCobraRootCommand`. After that call, `rootCmd` has a `help` subcommand. We retrieve it and add the single `export` child.
+
+### Wiring in `cmd/glaze/main.go`
+
+```go
+// In cmd/glaze/main.go, after SetupCobraRootCommand
+
+// Find the help subcommand
+helpCmd, _, err := rootCmd.Find([]string{"help"})
+if err != nil {
+    cobra.CheckErr(err)
+}
+
+// Build the export command
+exportGlazedCmd, err := NewExportCommand(helpSystem)
+cobra.CheckErr(err)
+
+exportCobraCmd, err := cli.BuildCobraCommand(
+    exportGlazedCmd,
+    cli.WithParserConfig(cli.CobraParserConfig{AppName: "glaze"}),
+)
+cobra.CheckErr(err)
+
+helpCmd.AddCommand(exportCobraCmd)
+```
+
+**Why this approach:**
+- It keeps the `pkg/help/cmd` package focused on interactive help behavior.
+- It follows the same pattern used for `serve-help` and `render-site` in `main.go`.
+- It allows each binary to decide whether to expose export functionality.
+
+### Reusable helper for other binaries
+
+To make this available to *any* binary using the glazed help system, provide a helper function:
+
+```go
+// pkg/help/cmd/export.go
+
+func AddExportCommand(helpCmd *cobra.Command, hs *help.HelpSystem) error {
+    exportGlazedCmd, err := NewExportCommand(hs)
+    if err != nil {
+        return err
+    }
+    exportCobraCmd, err := cli.BuildCobraCommand(
+        exportGlazedCmd,
+        cli.WithParserConfig(cli.CobraParserConfig{AppName: "glaze"}),
+    )
+    if err != nil {
+        return err
+    }
+    helpCmd.AddCommand(exportCobraCmd)
+    return nil
+}
+```
+
+Then each binary's `main.go` can call:
+
+```go
+helpCmd, _, _ := rootCmd.Find([]string{"help"})
+help_cmd.AddExportCommand(helpCmd, helpSystem)
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Add `export` command with tabular output
+
+1. **Create `pkg/help/cmd/export.go`**
+   - Define `ExportCommand` struct implementing both `cmds.GlazeCommand` and `cmds.BareCommand`.
+   - Implement `buildExportPredicate` helper.
+   - Implement `RunIntoGlazeProcessor` for `--format glazed` (default).
+   - Wire `--with-content` flag (default `true`) to conditionally include the `content` field.
+
+2. **Add unit tests in `pkg/help/cmd/export_test.go`**
+   - Create an in-memory `HelpSystem`, seed it with test sections.
+   - Run the command with `--output json` and assert `content` is present.
+   - Run with `--with-content=false` and assert `content` is absent.
+   - Run with `--type Example` and assert only example rows are emitted.
+
+3. **Register in `cmd/glaze/main.go`**
+   - Find the `help` subcommand.
+   - Add `export` via `help_cmd.AddExportCommand`.
+
+4. **Validate manually:**
+   ```bash
+   go run ./cmd/glaze help export --output json
+   go run ./cmd/glaze help export --with-content=false --output csv
+   go run ./cmd/glaze help export --type GeneralTopic --output yaml
+   ```
+
+### Phase 2: Add disk-export modes (`files` and `sqlite`)
+
+1. **Extend `ExportCommand.Run`**
+   - Implement `exportToFiles` with directory creation and markdown reconstruction.
+   - Implement `exportToSQLite` using `store.New` and `Upsert`.
+   - Ensure `Run` dispatches based on `--format`.
+
+2. **Add unit tests**
+   - Test `files` mode: assert directory structure and file contents round-trip correctly.
+   - Test `sqlite` mode: assert exported DB can be opened and queried.
+
+3. **Validate manually:**
+   ```bash
+   go run ./cmd/glaze help export --format files --output /tmp/help-files
+   go run ./cmd/glaze help export --format sqlite --output /tmp/help.sqlite
+   sqlite3 /tmp/help.sqlite "SELECT slug, title FROM sections;"
+   ```
+
+### Phase 3: Documentation and cross-binary validation
+
+1. **Documentation**
+   - Add a help section (`.md` file) documenting the export feature.
+   - Update `pkg/doc/` with examples showing `--with-content`, `--format files`, and `--format sqlite`.
+
+2. **Cross-binary validation**
+   - Test in another binary (e.g., `pinocchio` or `parka` if available).
+   - Verify that `AddExportCommand` works without code duplication.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+**For tabular output (`--format glazed`):**
+- Seed an in-memory store with 3 sections of mixed types.
+- Run with no filters and `--output json` → expect 3 rows, each with `content` field present.
+- Run with `--with-content=false` → expect 3 rows, each without `content` field.
+- Run with `--type Example` → expect 1 row.
+- Run with `--topic help` → expect rows where `Topics` contains `"help"`.
+
+**For disk-export (`--format files`):**
+- Seed store, run `--format files --output /tmp/test`.
+- Assert directory exists.
+- Assert each section produces one `.md` file.
+- Parse reconstructed markdown back into a `Section` and assert equality.
+
+**For disk-export (`--format sqlite`):**
+- Seed store, run `--format sqlite --output /tmp/test.sqlite`.
+- Open the DB with `store.New("/tmp/test.sqlite")`.
+- Query all sections and assert count and content match.
+
+### Integration Tests
+
+- Run the full `glaze help export metadata` and `glaze help export content` commands via `go run`.
+- Verify exit code is 0.
+- Verify output files are created and non-empty.
+- Verify SQLite file can be queried with the `sqlite3` CLI.
+
+### Manual Verification Checklist
+
+```bash
+# Export everything (metadata + content) as JSON
+glaze help export --output json
+
+# Export lightweight metadata only
+glaze help export --with-content=false --output csv
+
+# Filter and format
+glaze help export --type Example --output yaml
+
+# Export all content as markdown files
+glaze help export --format files --output ./exported-help
+
+# Export to SQLite
+glaze help export --format sqlite --output ./help.db
+
+# Query the SQLite file
+sqlite3 ./help.db "SELECT slug, title FROM sections WHERE section_type = 0 ORDER BY order_num;"
+```
+
+---
+
+## Risks, Alternatives, and Open Questions
+
+### Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Reconstructed markdown differs slightly from source (whitespace, field ordering) | High | Low | Document that export is round-trippable but not byte-identical. Use canonical YAML ordering. |
+| Large content export slows down or OOMs | Low | Medium | Add `--limit` and `--offset` flags. SQLite mode is naturally streaming. |
+| Binary bloat from new command code | Low | Low | The commands are small; they reuse existing packages. |
+
+### Alternatives Considered
+
+1. **Extend `glaze docs` to read from HelpSystem instead of files.**
+   - Rejected: `docs` is designed for analyzing arbitrary markdown files on disk, not for querying the embedded help system. Its flag surface is different.
+
+2. **Add `--export` flag to existing `glaze help` instead of a subcommand.**
+   - Rejected: The `help` command already has many flags. A subcommand tree (`help export ...`) is clearer and more discoverable.
+
+3. **Use `render-site` for all export needs.**
+   - Rejected: `render-site` produces a React SPA with hashed asset names. It is not suitable for data pipelines or simple file consumption.
+
+4. **Export only to SQLite, not files.**
+   - Rejected: Markdown files are the universal format for documentation pipelines. Users will want them for Git repos, static site generators, and editors.
+
+### Open Questions
+
+1. **Should `--with-content` default to `true` or `false`?**
+   - Decision: Default to `true`. The primary use case is "get everything out of the binary." Users who want lightweight output opt out with `--with-content=false`.
+
+2. **Should we support `--template` for customizing file output?**
+   - Proposal: Allow Go templates for `files` mode naming.
+   - Decision: Defer. Start with sensible defaults.
+
+3. **Should exported files include `Source` or provenance metadata?**
+   - Proposal: Add an `ExportedFrom` field to frontmatter.
+   - Decision: No — keep files clean so they can be re-imported into any binary.
+
+---
+
+## API Reference Summary
+
+### New Types
+
+```go
+// pkg/help/cmd/export.go
+
+type ExportFlags struct {
+    Type    string
+    Topic   string
+    Command string
+    Flag    string
+    Slug    string
+}
+
+func BuildExportPredicate(f ExportFlags) store.Predicate
+```
+
+### New Command
+
+```go
+// pkg/help/cmd/export.go
+
+func NewExportCommand(hs *help.HelpSystem) (*ExportCommand, error)
+
+// Implements both: cmds.GlazeCommand (for --format glazed)
+//                  cmds.BareCommand (for --format files/sqlite)
+```
+
+### Registration Helper
+
+```go
+// pkg/help/cmd/export.go
+
+func AddExportCommand(helpCmd *cobra.Command, hs *help.HelpSystem) error
+```
+
+---
+
+## File References
+
+| File | Role |
+|------|------|
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/model/section.go` | `Section` struct definition |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/model/parse.go` | Markdown frontmatter parser |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/store/store.go` | SQLite store implementation |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/store/query.go` | Predicate query system |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/help.go` | `HelpSystem` facade |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/cmd/cobra.go` | Cobra help command wiring |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/cmds/cmds.go` | Glazed command interfaces |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/cli/cobra.go` | `BuildCobraCommand` function |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/cmd/glaze/main.go` | Application root |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/site/render.go` | Prior art for export logic |
+
+---
+
+## Appendix: Full Command Examples
+
+### Export everything (metadata + content) as JSON
+
+```bash
+glaze help export --output json
+```
+
+Output:
+```json
+[
+  {"id":1,"slug":"help-system","type":"GeneralTopic","title":"Help System","content":"The help system allows...",...},
+  {"id":2,"slug":"markdown-style","type":"GeneralTopic","title":"Markdown Style","content":"Markdown is a lightweight...",...}
+]
+```
+
+### Export lightweight metadata only, as CSV
+
+```bash
+glaze help export --with-content=false --type Example --output csv
+```
+
+Output:
+```csv
+id,slug,type,title,short,topics,flags,commands,is_top_level,show_per_default,order,created_at,updated_at
+3,help-example-1,Example,Show the list of all toplevel topics,...,[],[],[help],false,false,0,...
+```
+
+### Export all content as markdown files
+
+```bash
+glaze help export --format files --output ./my-help
+```
+
+Result:
+```
+./my-help/
+├── general-topics/
+│   └── help-system.md
+├── examples/
+│   └── help-example-1.md
+└── ...
+```
+
+### Export to SQLite and query
+
+```bash
+glaze help export --format sqlite --output ./my-help.sqlite
+sqlite3 ./my-help.sqlite ".schema sections"
+sqlite3 ./my-help.sqlite "SELECT slug, title FROM sections WHERE topics LIKE '%help%';"
+```
+
+### Filtered export: only `json` command documentation
+
+```bash
+glaze help export --command json --format files --output ./json-docs
+glaze help export --command json --with-content=false --output json
+```
+
+---
+
+## Conclusion
+
+This design adds a small, focused, and reusable export capability to the Glazed help system. By leveraging the existing `Store` and predicate APIs, the implementation stays thin and idiomatic. The single `glaze help export` verb with `--with-content=true` by default gives users a complete snapshot with one command, while `--with-content=false`, `--format files`, and `--format sqlite` provide lightweight and archival alternatives. The `AddExportCommand` helper ensures that any binary built on Glazed can opt into this feature with a single function call.

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/design-doc/02-design-serve-external-sources.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/design-doc/02-design-serve-external-sources.md
@@ -1,0 +1,1138 @@
+---
+Title: 'Design: Serve External Help Sources - Multi-Source Help Browser'
+Ticket: GLAZE-HELP-EXPORT
+Status: active
+Topics:
+    - glazed
+    - help-system
+    - server
+    - cli
+    - import
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/doc/topics/29-serve-external-help-sources.md
+      Note: User-facing help topic for external sources
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/cmd/export.go
+      Note: Produces JSON/SQLite consumed by serve loaders
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/loader/paths.go
+      Note: Existing markdown loader to reuse/wrap
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/loader/sources.go
+      Note: ContentLoader implementations for external sources
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/loader/sources_test.go
+      Note: Unit tests for JSON/SQLite/command loaders
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/model/section.go
+      Note: Section and SectionType conversion details
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go
+      Note: ServeCommand to extend with external source flags
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/store/store.go
+      Note: Store.List, Store.Upsert, Store.Clear used by loaders
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T07:35:00-04:00
+WhatFor: Design implementation of multi-source loading for glaze serve, including --from-glazed-cmd convenience loading from other Glazed binaries.
+WhenToUse: Use when implementing or reviewing external-source support for the Glazed help browser server.
+---
+
+
+
+
+# Design: Serve External Help Sources — Multi-Source Help Browser
+
+## Executive Summary
+
+This document designs an extension to `glaze serve` so it can serve help pages from **other tools and external snapshots**, not only from the help system embedded in the `glaze` binary. The command should accept several source types and merge them into one in-memory `HelpSystem` before starting the existing HTTP API and React help browser.
+
+The most important new source is a convenience flag:
+
+```bash
+glaze serve --from-glazed-cmd pinocchio,sqleton,xxx
+```
+
+`--from-glazed-cmd` treats each value as the name or path of a Glazed-compatible binary. For each binary, `glaze serve` automatically runs:
+
+```bash
+<binary> help export --output json
+```
+
+Then it parses the JSON output and inserts the exported help sections into the server's store. This makes cross-package help browsing easy: users do not need to remember the full `help export --output json` invocation for every tool.
+
+The more general form remains available:
+
+```bash
+glaze serve --from-cmd "pinocchio help export --output json"
+```
+
+The final design supports five source families:
+
+1. Embedded docs already loaded into the current binary's `HelpSystem`
+2. Markdown files or directories from positional `paths`
+3. JSON files from `--from-json`
+4. SQLite databases from `--from-sqlite`
+5. Command outputs from `--from-cmd` and the convenience `--from-glazed-cmd`
+
+All list-like inputs must use `fields.TypeStringList` and `[]string` settings fields. The implementation should accept both repeated flags and comma-separated values where Glazed's string-list parsing permits it.
+
+---
+
+## Terminology
+
+| Term | Meaning |
+|------|---------|
+| Help section | A `model.Section` record with slug, title, markdown content, type, topics, commands, flags, and display metadata. |
+| Embedded docs | Help sections loaded at process startup from `pkg/doc` via Go `embed`. |
+| External source | Any help data loaded after startup from a file, database, or command. |
+| Export JSON row | The JSON object produced by `glaze help export --output json`; it is a Glazed row, not necessarily a direct `model.Section` serialization. |
+| Glazed command source | A binary that supports `help export --output json`, loaded through `--from-glazed-cmd`. |
+
+---
+
+## Current-State Architecture
+
+`glaze serve` is implemented by `ServeCommand` in:
+
+```text
+/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go
+```
+
+The command currently has one flag and one positional argument group:
+
+```go
+type ServeSettings struct {
+    Address string   `glazed:"address"`
+    Paths   []string `glazed:"paths"`
+}
+```
+
+The current run flow is:
+
+1. `cmd/glaze/main.go` creates a `help.HelpSystem`.
+2. `doc.AddDocToHelpSystem(helpSystem)` loads embedded Glazed help docs.
+3. `server.NewServeCommand(helpSystem, spaHandler)` receives that already-loaded help system.
+4. `ServeCommand.Run` decodes `--address` and positional `paths`.
+5. If `paths` are provided, it calls `helploader.ReplaceStoreWithPaths(ctx, hs, s.Paths)`, which clears the store and loads markdown from disk.
+6. If no `paths` are provided, it serves the embedded docs already in the store.
+7. `NewServeHandler` exposes `/api/health`, `/api/sections`, and `/api/sections/{slug}`.
+
+The HTTP layer is source-agnostic. Once sections are in `hs.Store`, the API and SPA do not care whether those sections came from embedded markdown, JSON, SQLite, or another binary.
+
+---
+
+## Design Review of the Previous Draft
+
+The previous draft was directionally correct but had several issues that this revision fixes.
+
+### Issue 1: It contradicted itself about embedded docs
+
+The earlier text first said external sources would replace embedded docs, then reconsidered and proposed `--with-embedded=true`. This document resolves that ambiguity:
+
+- `glaze serve` with no sources serves embedded docs exactly as today.
+- If external sources are provided, `--with-embedded=true` means keep embedded docs and merge external sources.
+- If external sources are provided with `--with-embedded=false`, clear the store first and serve only explicit sources.
+
+### Issue 2: It did not include `--from-glazed-cmd`
+
+The earlier draft only had `--from-cmd`, requiring users to type the full export command repeatedly. The revised design adds `--from-glazed-cmd` as the ergonomic default for Glazed-compatible binaries.
+
+### Issue 3: It assumed JSON uses `section_type`
+
+The current `ExportCommand` emits Glazed rows. In `pkg/help/cmd/export.go`, the row key is currently `type`, not `section_type`:
+
+```go
+types.MRP("type", section.SectionType.String())
+```
+
+A robust JSON loader must accept both shapes:
+
+- current export row shape: `type: "GeneralTopic"`
+- direct model shape: `section_type: "GeneralTopic"` or numeric `section_type: 0`
+
+### Issue 4: It treated several list inputs as single strings
+
+The implementation must use `fields.TypeStringList` for all multi-source string inputs. Settings fields must be `[]string`, not `string`, for:
+
+- `Paths`
+- `FromJSON`
+- `FromSQLite`
+- `FromCmd`
+- `FromGlazedCmd`
+
+Loader structs may internally represent a single source or a grouped list, but the public command schema should expose list values.
+
+### Issue 5: It used unsafe/underspecified command waiting pseudocode
+
+The previous `CommandLoader` used `defer cmd.Wait()` while decoding stdout. A real implementation must always check the process exit status after decoding, otherwise a command that writes partial JSON then exits non-zero could be treated incorrectly. This revision spells out the safer flow.
+
+---
+
+## Goals and Non-Goals
+
+### Goals
+
+1. Make `glaze serve` a universal browser for Glazed help pages from many binaries.
+2. Add `--from-glazed-cmd` for the common case where each input is a Glazed binary name.
+3. Keep `--from-cmd` for advanced users who need a full command line.
+4. Load JSON exports, SQLite exports, and markdown directories.
+5. Let users combine several sources in one server instance.
+6. Preserve current behavior when no external source flags or paths are provided.
+7. Use `fields.TypeStringList` for every multi-source string input.
+8. Fail before starting the HTTP server if any source cannot be loaded.
+
+### Non-Goals
+
+- No live reload/watch mode in the MVP.
+- No HTTP URL source in the MVP.
+- No authentication changes to the help server.
+- No schema redesign for `model.Section`.
+- No shell pipeline support inside `--from-glazed-cmd`.
+
+---
+
+## Proposed CLI Surface
+
+### Existing behavior remains valid
+
+```bash
+# Serve embedded docs from the current glaze binary
+glaze serve
+
+# Serve markdown files or directories
+glaze serve ./pkg/doc ./extra-docs
+
+# Serve on another address
+glaze serve --address :18100 ./pkg/doc
+```
+
+### New convenience source: `--from-glazed-cmd`
+
+Use this when each value is a binary that supports the Glazed help export verb.
+
+```bash
+# Comma-separated list, as requested
+glaze serve --from-glazed-cmd pinocchio,sqleton,xxx
+
+# Repeated flag form should also work
+glaze serve \
+  --from-glazed-cmd pinocchio \
+  --from-glazed-cmd sqleton \
+  --from-glazed-cmd xxx
+```
+
+For each binary name, the loader runs:
+
+```bash
+<binary> help export --output json
+```
+
+So the first example expands conceptually to:
+
+```bash
+pinocchio help export --output json
+sqleton help export --output json
+xxx help export --output json
+```
+
+### General command source: `--from-cmd`
+
+Use this when the command is not exactly `<binary> help export --output json`, or when you need extra flags.
+
+```bash
+glaze serve --from-cmd "pinocchio help export --output json --topic database"
+```
+
+This flag also uses `fields.TypeStringList`, so users can pass several commands:
+
+```bash
+glaze serve \
+  --from-cmd "pinocchio help export --output json" \
+  --from-cmd "sqleton help export --output json --with-content=true"
+```
+
+### JSON source: `--from-json`
+
+```bash
+# Load from one JSON file
+glaze serve --from-json ./pinocchio-help.json
+
+# Load from several JSON files
+glaze serve --from-json ./pinocchio-help.json,./sqleton-help.json
+
+# Read from stdin
+glaze help export --output json | glaze serve --from-json -
+```
+
+### SQLite source: `--from-sqlite`
+
+```bash
+# Load one exported DB
+glaze serve --from-sqlite ./pinocchio-help.db
+
+# Load several DBs
+glaze serve --from-sqlite ./pinocchio-help.db,./sqleton-help.db
+```
+
+### Combined source example
+
+```bash
+glaze serve \
+  --from-glazed-cmd pinocchio,sqleton \
+  --from-json ./team-overrides.json \
+  --from-sqlite ./legacy-help.db \
+  ./local-markdown-docs
+```
+
+This produces one help browser containing:
+
+- embedded Glazed docs, only when `--with-embedded=true` is provided,
+- live exports from `pinocchio` and `sqleton`,
+- JSON override docs,
+- archived SQLite docs,
+- local markdown docs.
+
+---
+
+## ServeSettings and Flag Definitions
+
+All string source settings are lists. This is non-negotiable because the main value of this feature is serving multiple packages together.
+
+```go
+type ServeSettings struct {
+    Address       string   `glazed:"address"`
+    Paths         []string `glazed:"paths"`
+    FromJSON      []string `glazed:"from-json"`
+    FromSQLite    []string `glazed:"from-sqlite"`
+    FromCmd       []string `glazed:"from-cmd"`
+    FromGlazedCmd []string `glazed:"from-glazed-cmd"`
+    WithEmbedded  bool     `glazed:"with-embedded"`
+}
+```
+
+Command schema additions:
+
+```go
+cmds.WithFlags(
+    fields.New(
+        "address",
+        fields.TypeString,
+        fields.WithHelp("Address to listen on"),
+        fields.WithDefault(DefaultAddr),
+    ),
+    fields.New(
+        "from-json",
+        fields.TypeStringList,
+        fields.WithHelp("JSON help export files to load; use - for stdin"),
+    ),
+    fields.New(
+        "from-sqlite",
+        fields.TypeStringList,
+        fields.WithHelp("SQLite help export databases to load"),
+    ),
+    fields.New(
+        "from-cmd",
+        fields.TypeStringList,
+        fields.WithHelp("Commands to run; stdout must be a JSON help export"),
+    ),
+    fields.New(
+        "from-glazed-cmd",
+        fields.TypeStringList,
+        fields.WithHelp("Glazed binaries to load by running '<binary> help export --output json'"),
+    ),
+    fields.New(
+        "with-embedded",
+        fields.TypeBool,
+        fields.WithHelp("Include already-loaded embedded docs when external sources are provided"),
+        fields.WithDefault(false),
+    ),
+)
+```
+
+The positional `paths` argument remains a string list:
+
+```go
+cmds.WithArguments(
+    fields.New(
+        "paths",
+        fields.TypeStringList,
+        fields.WithHelp("Markdown files or directories to load"),
+    ),
+)
+```
+
+---
+
+## Source Loading Semantics
+
+### Default behavior
+
+If no external source flags and no positional paths are provided:
+
+```bash
+glaze serve
+```
+
+The command serves the embedded docs already loaded by `cmd/glaze/main.go`. This is exactly the current behavior.
+
+### External source behavior without embedded docs (default)
+
+If any external source is provided and `--with-embedded=false` (the default), the command should clear the store before loading explicit sources. This keeps `glaze serve --from-glazed-cmd pinocchio` focused on Pinocchio docs instead of mixing in Glazed framework docs.
+
+```bash
+glaze serve --from-glazed-cmd pinocchio
+```
+
+Result:
+
+1. Clear embedded Glazed docs.
+2. Load Pinocchio docs.
+3. Serve only Pinocchio docs.
+
+### External source behavior with embedded docs
+
+If any external source is provided and `--with-embedded=true`, the command should **keep** the currently loaded embedded docs and then merge the external sources into the same store.
+
+```bash
+glaze serve --from-glazed-cmd pinocchio
+```
+
+Result:
+
+1. Start with embedded Glazed docs.
+2. Load Pinocchio docs from `pinocchio help export --output json`.
+3. Serve both sets together.
+
+### Loading order
+
+Loaders should run in a deterministic order. Later sources overwrite earlier sources when slugs collide.
+
+Recommended order:
+
+1. Existing embedded docs (only if `--with-embedded=true`, already loaded before `Run`)
+2. Positional markdown `paths`
+3. `--from-json` sources, in normalized list order
+4. `--from-sqlite` sources, in normalized list order
+5. `--from-cmd` sources, in normalized list order
+6. `--from-glazed-cmd` sources, in normalized list order
+
+Why put `--from-glazed-cmd` last? It is the most live/authoritative source for another binary. If a JSON snapshot and a live binary contain the same slug, the live binary should win.
+
+### Collision handling
+
+Use `Store.Upsert(ctx, section)`. If two sources contain the same slug, the later source replaces the earlier section.
+
+The implementation should log collisions, but collisions should not fail the load:
+
+```go
+existing, err := hs.Store.GetBySlug(ctx, section.Slug)
+if err == nil && existing != nil {
+    log.Warn().Str("slug", section.Slug).Str("source", loader.String()).Msg("Replacing existing help section")
+}
+```
+
+---
+
+## ContentLoader Interface
+
+All external sources should be represented by a small common interface.
+
+```go
+type ContentLoader interface {
+    Load(ctx context.Context, hs *help.HelpSystem) error
+    String() string
+}
+```
+
+`Load` inserts sections into the provided help system. It should not clear the store; clearing is orchestrated once by `ServeCommand.Run` based on `--with-embedded`.
+
+`String` returns a human-readable source description for logs and errors.
+
+Recommended package location:
+
+```text
+pkg/help/loader/sources.go
+```
+
+This keeps source loading near the existing markdown path loader while avoiding direct dependency from `pkg/help/server` on low-level parsing details.
+
+---
+
+## Loader Designs
+
+### MarkdownPathLoader
+
+`MarkdownPathLoader` wraps the existing `loader.LoadPaths` function.
+
+```go
+type MarkdownPathLoader struct {
+    Paths []string
+}
+
+func (l *MarkdownPathLoader) Load(ctx context.Context, hs *help.HelpSystem) error {
+    return loader.LoadPaths(ctx, hs, l.Paths)
+}
+
+func (l *MarkdownPathLoader) String() string {
+    return "markdown paths: " + strings.Join(l.Paths, ", ")
+}
+```
+
+Use one grouped loader for all positional paths. The input is already a `[]string`.
+
+### JSONFileLoader
+
+`JSONFileLoader` loads one or more JSON files. It must accept the actual `glaze help export --output json` row format and a direct `model.Section` JSON format.
+
+```go
+type JSONFileLoader struct {
+    Paths []string
+}
+```
+
+The loader should support `-` for stdin. Because stdin can only be consumed once, reject multiple `-` values:
+
+```go
+if count(paths, "-") > 1 {
+    return errors.New("--from-json - may only be used once")
+}
+```
+
+#### JSON input shapes to support
+
+Current export row shape:
+
+```json
+{
+  "slug": "help-system",
+  "type": "GeneralTopic",
+  "title": "Help System",
+  "short": "...",
+  "content": "...",
+  "topics": ["help"],
+  "flags": ["topic"],
+  "commands": ["help"],
+  "is_top_level": true,
+  "show_per_default": true,
+  "order": 0
+}
+```
+
+Direct model shape:
+
+```json
+{
+  "slug": "help-system",
+  "section_type": "GeneralTopic",
+  "title": "Help System",
+  "short": "...",
+  "content": "..."
+}
+```
+
+The implementation should define a small import DTO instead of unmarshaling directly into `model.Section`:
+
+```go
+type sectionImportRow struct {
+    ID             int64           `json:"id,omitempty"`
+    Slug           string          `json:"slug"`
+    Type           json.RawMessage `json:"type,omitempty"`
+    SectionType    json.RawMessage `json:"section_type,omitempty"`
+    Title          string          `json:"title"`
+    SubTitle       string          `json:"sub_title"`
+    Short          string          `json:"short"`
+    Content        string          `json:"content"`
+    Topics         []string        `json:"topics"`
+    Flags          []string        `json:"flags"`
+    Commands       []string        `json:"commands"`
+    IsTopLevel     bool            `json:"is_top_level"`
+    IsTemplate     bool            `json:"is_template"`
+    ShowPerDefault bool            `json:"show_per_default"`
+    Order          int             `json:"order"`
+    CreatedAt      string          `json:"created_at"`
+    UpdatedAt      string          `json:"updated_at"`
+}
+```
+
+Then convert it:
+
+```go
+func (r sectionImportRow) ToSection() (*model.Section, error) {
+    st, err := parseSectionType(r.Type, r.SectionType)
+    if err != nil {
+        return nil, err
+    }
+    return &model.Section{
+        ID:             r.ID,
+        Slug:           r.Slug,
+        SectionType:    st,
+        Title:          r.Title,
+        SubTitle:       r.SubTitle,
+        Short:          r.Short,
+        Content:        r.Content,
+        Topics:         r.Topics,
+        Flags:          r.Flags,
+        Commands:       r.Commands,
+        IsTopLevel:     r.IsTopLevel,
+        IsTemplate:     r.IsTemplate,
+        ShowPerDefault: r.ShowPerDefault,
+        Order:          r.Order,
+        CreatedAt:      r.CreatedAt,
+        UpdatedAt:      r.UpdatedAt,
+    }, nil
+}
+```
+
+`parseSectionType` should accept:
+
+- string values: `"GeneralTopic"`, `"Example"`, `"Application"`, `"Tutorial"`
+- numeric values: `0`, `1`, `2`, `3`
+- missing value: default to `GeneralTopic` only if that is acceptable; otherwise fail clearly. Recommendation: fail for missing type unless compatibility demands a default.
+
+### SQLiteLoader
+
+`SQLiteLoader` loads one or more SQLite databases previously produced by:
+
+```bash
+<binary> help export --format sqlite --output-path ./help.db
+```
+
+```go
+type SQLiteLoader struct {
+    Paths []string
+}
+
+func (l *SQLiteLoader) Load(ctx context.Context, hs *help.HelpSystem) error {
+    for _, path := range l.Paths {
+        sourceStore, err := store.New(path)
+        if err != nil {
+            return fmt.Errorf("open sqlite %s: %w", path, err)
+        }
+        sections, listErr := sourceStore.List(ctx, "")
+        closeErr := sourceStore.Close()
+        if listErr != nil {
+            return fmt.Errorf("list sections from %s: %w", path, listErr)
+        }
+        if closeErr != nil {
+            return fmt.Errorf("close sqlite %s: %w", path, closeErr)
+        }
+        for _, section := range sections {
+            if err := upsertWithCollisionLog(ctx, hs, section, l.String()); err != nil {
+                return err
+            }
+        }
+    }
+    return nil
+}
+```
+
+### CommandJSONLoader
+
+`CommandJSONLoader` runs arbitrary user-provided commands whose stdout is expected to be JSON help export data.
+
+```go
+type CommandJSONLoader struct {
+    Commands []string
+}
+```
+
+This is the advanced form. It should be used when users need custom flags:
+
+```bash
+glaze serve --from-cmd "pinocchio help export --output json --topic orm"
+```
+
+A safe implementation must:
+
+1. Tokenize the command without invoking a shell.
+2. Start the process with `exec.CommandContext`.
+3. Capture stdout and stderr separately.
+4. Decode stdout as JSON.
+5. Wait for the process and check the exit status.
+6. Return stderr in the error message if the command fails.
+
+Pseudocode:
+
+```go
+func runCommandForJSON(ctx context.Context, command string) ([]byte, error) {
+    args, err := tokenizeCommand(command)
+    if err != nil {
+        return nil, err
+    }
+    if len(args) == 0 {
+        return nil, errors.New("empty command")
+    }
+
+    cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+    var stdout bytes.Buffer
+    var stderr bytes.Buffer
+    cmd.Stdout = &stdout
+    cmd.Stderr = &stderr
+
+    err = cmd.Run()
+    if err != nil {
+        return nil, fmt.Errorf("command %q failed: %w; stderr: %s", command, err, stderr.String())
+    }
+    return stdout.Bytes(), nil
+}
+```
+
+This simpler `cmd.Run()` form is preferable to manual `StdoutPipe` unless streaming is required. Help exports are finite and should fit in memory for MVP.
+
+### GlazedCommandLoader
+
+`GlazedCommandLoader` is the ergonomic loader requested by the user. It accepts binary names or executable paths and constructs the export command automatically.
+
+```go
+type GlazedCommandLoader struct {
+    Binaries []string
+}
+
+func (l *GlazedCommandLoader) Load(ctx context.Context, hs *help.HelpSystem) error {
+    for _, binary := range l.Binaries {
+        data, err := runGlazedHelpExport(ctx, binary)
+        if err != nil {
+            return err
+        }
+        if err := importJSONBytes(ctx, hs, data, "glazed command: "+binary); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+```
+
+`runGlazedHelpExport` should not tokenize a full shell command. It should call the binary directly:
+
+```go
+func runGlazedHelpExport(ctx context.Context, binary string) ([]byte, error) {
+    cmd := exec.CommandContext(ctx, binary, "help", "export", "--output", "json")
+    var stdout bytes.Buffer
+    var stderr bytes.Buffer
+    cmd.Stdout = &stdout
+    cmd.Stderr = &stderr
+    if err := cmd.Run(); err != nil {
+        return nil, fmt.Errorf("%s help export failed: %w; stderr: %s", binary, err, stderr.String())
+    }
+    return stdout.Bytes(), nil
+}
+```
+
+This approach avoids shell injection entirely and gives users a short CLI:
+
+```bash
+glaze serve --from-glazed-cmd pinocchio,sqleton,xxx
+```
+
+---
+
+## Loader Construction
+
+`ServeCommand.Run` should build loaders from normalized settings values.
+
+```go
+func buildLoaders(s *ServeSettings) []loader.ContentLoader {
+    var loaders []loader.ContentLoader
+
+    if len(s.Paths) > 0 {
+        loaders = append(loaders, &loader.MarkdownPathLoader{Paths: normalizeStringList(s.Paths)})
+    }
+    if len(s.FromJSON) > 0 {
+        loaders = append(loaders, &loader.JSONFileLoader{Paths: normalizeStringList(s.FromJSON)})
+    }
+    if len(s.FromSQLite) > 0 {
+        loaders = append(loaders, &loader.SQLiteLoader{Paths: normalizeStringList(s.FromSQLite)})
+    }
+    if len(s.FromCmd) > 0 {
+        loaders = append(loaders, &loader.CommandJSONLoader{Commands: normalizeStringList(s.FromCmd)})
+    }
+    if len(s.FromGlazedCmd) > 0 {
+        loaders = append(loaders, &loader.GlazedCommandLoader{Binaries: normalizeStringList(s.FromGlazedCmd)})
+    }
+
+    return loaders
+}
+```
+
+`normalizeStringList` should remove empty values, trim whitespace, and split comma-separated entries if the Glazed field parsing layer does not already do so.
+
+```go
+func normalizeStringList(values []string) []string {
+    var ret []string
+    for _, value := range values {
+        for _, part := range strings.Split(value, ",") {
+            part = strings.TrimSpace(part)
+            if part != "" {
+                ret = append(ret, part)
+            }
+        }
+    }
+    return ret
+}
+```
+
+This explicitly supports the desired syntax:
+
+```bash
+glaze serve --from-glazed-cmd pinocchio,sqleton,xxx
+```
+
+---
+
+## Updated ServeCommand.Run
+
+The server command should orchestrate clearing/merging once, then delegate all source-specific work to loaders.
+
+```go
+func (sc *ServeCommand) Run(ctx context.Context, parsedValues *values.Values) error {
+    s := &ServeSettings{}
+    if err := parsedValues.DecodeSectionInto(schema.DefaultSlug, s); err != nil {
+        return fmt.Errorf("failed to decode serve settings: %w", err)
+    }
+
+    hs := sc.helpSystem
+    if hs.Store == nil {
+        return errors.New("HelpSystem.Store is nil")
+    }
+
+    loaders := buildLoaders(s)
+    hasExplicitSources := len(loaders) > 0
+
+    if hasExplicitSources && !s.WithEmbedded {
+        if err := hs.Store.Clear(ctx); err != nil {
+            return fmt.Errorf("failed to clear embedded help sections: %w", err)
+        }
+    }
+
+    for _, l := range loaders {
+        log.Info().Str("source", l.String()).Msg("Loading help source")
+        if err := l.Load(ctx, hs); err != nil {
+            return fmt.Errorf("failed to load %s: %w", l.String(), err)
+        }
+    }
+
+    count, err := hs.Store.Count(ctx)
+    if err != nil {
+        return fmt.Errorf("failed to count help sections: %w", err)
+    }
+    log.Info().Int64("sections", count).Msg("Loaded help sections")
+
+    deps := HandlerDeps{Store: hs.Store}
+    handler := NewServeHandler(deps, sc.spaHandler)
+    return serveHTTP(s.Address, handler)
+}
+```
+
+Notice the important behavior: explicit sources clear embedded docs by default because `--with-embedded=false`. If the user sets `--with-embedded=true`, we do **not** clear and simply add sources to the store that already contains embedded docs.
+
+---
+
+## JSON Compatibility Design
+
+The import side must support the JSON format actually emitted by `glaze help export --output json`.
+
+Current export rows use these keys:
+
+```go
+types.MRP("id", section.ID)
+types.MRP("slug", section.Slug)
+types.MRP("type", section.SectionType.String())
+types.MRP("title", section.Title)
+types.MRP("short", section.Short)
+types.MRP("topics", section.Topics)
+types.MRP("flags", section.Flags)
+types.MRP("commands", section.Commands)
+types.MRP("is_top_level", section.IsTopLevel)
+types.MRP("show_per_default", section.ShowPerDefault)
+types.MRP("order", section.Order)
+types.MRP("created_at", section.CreatedAt)
+types.MRP("updated_at", section.UpdatedAt)
+```
+
+The loader must therefore not require `section_type`. It should prefer `type` when present, accept `section_type` for future/direct model JSON, and return a clear error if neither can be parsed.
+
+### Optional improvement to export
+
+A future cleanup could rename export's row field from `type` to `section_type` for consistency with `model.Section`. That would be a breaking-ish output change for scripts, so this design does not require it. Instead, the importer handles both.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Add import DTO and JSON parser tests
+
+1. Add an internal `sectionImportRow` DTO in `pkg/help/loader`.
+2. Implement `parseSectionType` accepting `type`, `section_type`, strings, and ints.
+3. Implement `DecodeSectionsJSON(r io.Reader) ([]*model.Section, error)`.
+4. Add tests for:
+   - current export row with `type: "GeneralTopic"`
+   - model-like row with `section_type: "Example"`
+   - model-like row with `section_type: 2`
+   - missing/invalid type
+   - missing slug/title validation
+
+This phase is safer than changing `model.SectionType.MarshalJSON` first, because it avoids changing exported JSON behavior before the importer exists.
+
+### Phase 2: Add ContentLoader implementations
+
+1. Add `ContentLoader` interface.
+2. Add `MarkdownPathLoader`.
+3. Add `JSONFileLoader` with `Paths []string`.
+4. Add `SQLiteLoader` with `Paths []string`.
+5. Add `CommandJSONLoader` with `Commands []string`.
+6. Add `GlazedCommandLoader` with `Binaries []string`.
+7. Add unit tests for each loader.
+
+### Phase 3: Extend ServeCommand
+
+1. Add `FromJSON`, `FromSQLite`, `FromCmd`, `FromGlazedCmd`, and `WithEmbedded` to `ServeSettings`.
+2. Add flags using `fields.TypeStringList` for every string-list source.
+3. Add `normalizeStringList` and `buildLoaders`.
+4. Update `Run` to clear when explicit sources exist and `--with-embedded=false` (the default).
+5. Add integration tests around `/api/health` and `/api/sections`.
+
+### Phase 4: Documentation and manual validation
+
+1. Update `pkg/doc/topics/25-serving-help-over-http.md` or add a dedicated `serve-external-sources` topic.
+2. Update `pkg/doc/topics/28-export-help-entries.md` to mention `--from-glazed-cmd` as the serve-side counterpart.
+3. Run the manual verification checklist below.
+4. Commit.
+
+---
+
+## Testing Strategy
+
+### Unit tests for JSON import
+
+```go
+func TestDecodeSectionsJSON_CurrentExportTypeField(t *testing.T) {
+    input := `[{
+      "slug":"help-system",
+      "title":"Help System",
+      "type":"GeneralTopic",
+      "content":"body"
+    }]`
+    sections, err := DecodeSectionsJSON(strings.NewReader(input))
+    require.NoError(t, err)
+    assert.Equal(t, model.SectionGeneralTopic, sections[0].SectionType)
+}
+```
+
+Also test:
+
+- `section_type: "Tutorial"`
+- `section_type: 3`
+- invalid `type`
+- missing `type` and `section_type`
+- list fields preserved (`topics`, `flags`, `commands`)
+
+### Unit tests for `--from-glazed-cmd`
+
+Use a tiny test helper binary or `go test` helper process pattern. The helper should print valid JSON when invoked as:
+
+```bash
+helper help export --output json
+```
+
+Test that `GlazedCommandLoader{Binaries: []string{helperPath}}` loads the expected section.
+
+### Unit tests for command failure
+
+Verify that stderr is included in the returned error:
+
+```bash
+helper help export --output json
+# exits 1, stderr: "boom"
+```
+
+Expected error includes `boom`.
+
+### Integration tests for `ServeCommand`
+
+- `glaze serve` with no sources serves embedded docs.
+- `glaze serve --with-embedded=false --from-json file.json` serves only file JSON.
+- `glaze serve --from-json file.json` serves only JSON because `--with-embedded` defaults to false.
+- `glaze serve --from-glazed-cmd helper1,helper2` serves both helpers.
+- Repeated flags and comma-separated values produce the same source list.
+- Slug collision uses last-write-wins and logs a warning.
+
+### Manual verification checklist
+
+```bash
+# 1. Export and serve from JSON
+glaze help export --output json > /tmp/glaze-help.json
+glaze serve --from-json /tmp/glaze-help.json --address :18101 &
+curl http://localhost:18101/api/health
+kill %1
+
+# 2. Export and serve from SQLite
+glaze help export --format sqlite --output-path /tmp/glaze-help.db
+glaze serve --from-sqlite /tmp/glaze-help.db --address :18102 &
+curl http://localhost:18102/api/health
+kill %1
+
+# 3. Serve from full command
+glaze serve --from-cmd "glaze help export --output json" --address :18103 &
+curl http://localhost:18103/api/health
+kill %1
+
+# 4. Serve from Glazed command shorthand
+glaze serve --from-glazed-cmd glaze --address :18104 &
+curl http://localhost:18104/api/health
+kill %1
+
+# 5. Serve multiple Glazed commands using comma-separated syntax
+glaze serve --from-glazed-cmd pinocchio,sqleton,xxx --address :18105 &
+curl http://localhost:18105/api/health
+kill %1
+
+# 6. Combine all source types
+glaze serve \
+  --from-glazed-cmd glaze \
+  --from-json /tmp/glaze-help.json \
+  --from-sqlite /tmp/glaze-help.db \
+  ./pkg/doc/topics \
+  --address :18106 &
+curl http://localhost:18106/api/sections?limit=5
+kill %1
+```
+
+---
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| `--from-cmd` command injection | Medium | High | Do not invoke a shell; tokenize and call `exec.CommandContext`. |
+| `--from-glazed-cmd` binary not found | Medium | Low | Return a clear error naming the binary. |
+| Export JSON shape mismatch | Medium | Medium | Import both `type` and `section_type`; add tests from real export output. |
+| Slug collisions hide earlier docs | Medium | Low | Last-write-wins, with warning logs. |
+| Multiple `--from-json -` values consume stdin twice | Low | Medium | Reject more than one stdin JSON source. |
+| Very large exports consume memory | Low | Medium | Accept for MVP; streaming decode can be added later. |
+| Command hangs | Low | High | Use `exec.CommandContext`; consider adding `--source-timeout` later. |
+
+---
+
+## Open Questions
+
+1. Should `--from-glazed-cmd` support extra arguments per binary? Recommendation: no for MVP. Use `--from-cmd` when extra arguments are needed.
+2. Should `--from-glazed-cmd` run `--with-content=true` explicitly? Recommendation: yes if the export command supports it, but it is already the default. The explicit command could be `<binary> help export --with-content=true --output json` for clarity.
+3. Should JSON import skip invalid sections or fail the whole source? Recommendation: fail the source for invalid JSON shape, but skip individual sections only if we explicitly log and count skips. For MVP, fail fast is easier to debug.
+4. Should embedded docs be included by default with external sources? Decision: no. `--with-embedded` defaults to `false`, so explicit external sources replace embedded docs unless the user opts into merging them.
+
+---
+
+## API Reference Summary
+
+### New/changed settings
+
+```go
+type ServeSettings struct {
+    Address       string   `glazed:"address"`
+    Paths         []string `glazed:"paths"`
+    FromJSON      []string `glazed:"from-json"`
+    FromSQLite    []string `glazed:"from-sqlite"`
+    FromCmd       []string `glazed:"from-cmd"`
+    FromGlazedCmd []string `glazed:"from-glazed-cmd"`
+    WithEmbedded  bool     `glazed:"with-embedded"`
+}
+```
+
+### New loaders
+
+```go
+type ContentLoader interface {
+    Load(ctx context.Context, hs *help.HelpSystem) error
+    String() string
+}
+
+type MarkdownPathLoader struct{ Paths []string }
+type JSONFileLoader struct{ Paths []string }
+type SQLiteLoader struct{ Paths []string }
+type CommandJSONLoader struct{ Commands []string }
+type GlazedCommandLoader struct{ Binaries []string }
+```
+
+### New helper functions
+
+```go
+func normalizeStringList(values []string) []string
+func buildLoaders(s *ServeSettings) []loader.ContentLoader
+func DecodeSectionsJSON(r io.Reader) ([]*model.Section, error)
+func parseSectionType(typeRaw, sectionTypeRaw json.RawMessage) (model.SectionType, error)
+func runGlazedHelpExport(ctx context.Context, binary string) ([]byte, error)
+```
+
+---
+
+## File References
+
+| File | Role |
+|------|------|
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go` | `ServeCommand`; add flags, settings, loader orchestration. |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/loader/paths.go` | Existing markdown loading; reuse in `MarkdownPathLoader`. |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/loader/sources.go` | Proposed new file for `ContentLoader` and external source loaders. |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/model/section.go` | Section model and `SectionType`; parser must convert strings/ints. |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/store/store.go` | Store APIs used for SQLite loading and merging. |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/cmd/export.go` | Current JSON row shape produced by `help export --output json`. |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/handlers.go` | HTTP API remains unchanged once store is populated. |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/cmd/glaze/main.go` | Root wiring that preloads embedded docs and installs `serve`. |
+
+---
+
+## Appendix: Full User Workflows
+
+### Browse help from three Glazed binaries
+
+```bash
+glaze serve --from-glazed-cmd pinocchio,sqleton,xxx
+```
+
+This is the main target workflow. Users provide binary names, not full commands.
+
+### Browse one Glazed binary without embedded Glaze docs
+
+```bash
+glaze serve --from-glazed-cmd pinocchio
+```
+
+### Use a custom export command
+
+```bash
+glaze serve --from-cmd "pinocchio help export --output json --topic database"
+```
+
+### Serve an archived SQLite snapshot
+
+```bash
+pinocchio help export --format sqlite --output-path ./pinocchio-help.db
+glaze serve --from-sqlite ./pinocchio-help.db
+```
+
+### Serve local markdown overrides plus live command docs
+
+```bash
+glaze serve \
+  --from-glazed-cmd pinocchio,sqleton \
+  ./company-overrides/help
+```
+
+### Pipe filtered JSON from stdin
+
+```bash
+glaze help export --output json \
+  | jq '[.[] | select(.type == "Example")]' \
+  | glaze serve --from-json -
+```
+
+---
+
+## Conclusion
+
+`--from-glazed-cmd` is the missing ergonomic layer that makes the export/serve loop feel like one feature. Users can now say:
+
+```bash
+glaze serve --from-glazed-cmd pinocchio,sqleton,xxx
+```
+
+and get a single browser for several Glazed-based tools. The general loaders (`--from-json`, `--from-sqlite`, `--from-cmd`, and markdown paths) keep the design flexible, while `--from-glazed-cmd` makes the common case easy.
+
+The implementation should be modest: add list-valued source flags to `ServeCommand`, introduce a `ContentLoader` interface, add robust JSON import for the real export row shape, and run Glazed binaries directly with `exec.CommandContext(binary, "help", "export", "--output", "json")`. The existing HTTP API and React frontend do not need to change.

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/design-doc/02-design-serve-external-sources.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/design-doc/02-design-serve-external-sources.md
@@ -58,10 +58,11 @@ glaze serve --from-glazed-cmd pinocchio,sqleton,xxx
 
 Then it parses the JSON output and inserts the exported help sections into the server's store. This makes cross-package help browsing easy: users do not need to remember the full `help export --output json` invocation for every tool.
 
-The more general form remains available:
+If users need custom export filters, they should export JSON explicitly and then serve the resulting file:
 
 ```bash
-glaze serve --from-cmd "pinocchio help export --output json"
+pinocchio help export --output json --topic database > pinocchio-database-help.json
+glaze serve --from-json pinocchio-database-help.json
 ```
 
 The final design supports five source families:
@@ -70,7 +71,7 @@ The final design supports five source families:
 2. Markdown files or directories from positional `paths`
 3. JSON files from `--from-json`
 4. SQLite databases from `--from-sqlite`
-5. Command outputs from `--from-cmd` and the convenience `--from-glazed-cmd`
+5. Live Glazed binary outputs from the convenience `--from-glazed-cmd`
 
 All list-like inputs must use `fields.TypeStringList` and `[]string` settings fields. The implementation should accept both repeated flags and comma-separated values where Glazed's string-list parsing permits it.
 
@@ -133,7 +134,7 @@ The earlier text first said external sources would replace embedded docs, then r
 
 ### Issue 2: It did not include `--from-glazed-cmd`
 
-The earlier draft only had `--from-cmd`, requiring users to type the full export command repeatedly. The revised design adds `--from-glazed-cmd` as the ergonomic default for Glazed-compatible binaries.
+The earlier draft included `--from-cmd`, but PR review showed that arbitrary command strings are unsafe and difficult to parse correctly with `TypeStringList`. The revised design removes `--from-cmd` entirely and keeps only `--from-glazed-cmd` for live Glazed-compatible binaries.
 
 ### Issue 3: It assumed JSON uses `section_type`
 
@@ -172,7 +173,7 @@ The previous `CommandLoader` used `defer cmd.Wait()` while decoding stdout. A re
 
 1. Make `glaze serve` a universal browser for Glazed help pages from many binaries.
 2. Add `--from-glazed-cmd` for the common case where each input is a Glazed binary name.
-3. Keep `--from-cmd` for advanced users who need a full command line.
+3. Do not support arbitrary command strings; use `--from-glazed-cmd` for live binaries and JSON/SQLite snapshots for custom exports.
 4. Load JSON exports, SQLite exports, and markdown directories.
 5. Let users combine several sources in one server instance.
 6. Preserve current behavior when no external source flags or paths are provided.
@@ -233,22 +234,6 @@ sqleton help export --output json
 xxx help export --output json
 ```
 
-### General command source: `--from-cmd`
-
-Use this when the command is not exactly `<binary> help export --output json`, or when you need extra flags.
-
-```bash
-glaze serve --from-cmd "pinocchio help export --output json --topic database"
-```
-
-This flag also uses `fields.TypeStringList`, so users can pass several commands:
-
-```bash
-glaze serve \
-  --from-cmd "pinocchio help export --output json" \
-  --from-cmd "sqleton help export --output json --with-content=true"
-```
-
 ### JSON source: `--from-json`
 
 ```bash
@@ -302,7 +287,6 @@ type ServeSettings struct {
     Paths         []string `glazed:"paths"`
     FromJSON      []string `glazed:"from-json"`
     FromSQLite    []string `glazed:"from-sqlite"`
-    FromCmd       []string `glazed:"from-cmd"`
     FromGlazedCmd []string `glazed:"from-glazed-cmd"`
     WithEmbedded  bool     `glazed:"with-embedded"`
 }
@@ -327,11 +311,6 @@ cmds.WithFlags(
         "from-sqlite",
         fields.TypeStringList,
         fields.WithHelp("SQLite help export databases to load"),
-    ),
-    fields.New(
-        "from-cmd",
-        fields.TypeStringList,
-        fields.WithHelp("Commands to run; stdout must be a JSON help export"),
     ),
     fields.New(
         "from-glazed-cmd",
@@ -411,8 +390,7 @@ Recommended order:
 2. Positional markdown `paths`
 3. `--from-json` sources, in normalized list order
 4. `--from-sqlite` sources, in normalized list order
-5. `--from-cmd` sources, in normalized list order
-6. `--from-glazed-cmd` sources, in normalized list order
+5. `--from-glazed-cmd` sources, in normalized list order
 
 Why put `--from-glazed-cmd` last? It is the most live/authoritative source for another binary. If a JSON snapshot and a live binary contain the same slug, the live binary should win.
 
@@ -624,59 +602,6 @@ func (l *SQLiteLoader) Load(ctx context.Context, hs *help.HelpSystem) error {
 }
 ```
 
-### CommandJSONLoader
-
-`CommandJSONLoader` runs arbitrary user-provided commands whose stdout is expected to be JSON help export data.
-
-```go
-type CommandJSONLoader struct {
-    Commands []string
-}
-```
-
-This is the advanced form. It should be used when users need custom flags:
-
-```bash
-glaze serve --from-cmd "pinocchio help export --output json --topic orm"
-```
-
-A safe implementation must:
-
-1. Tokenize the command without invoking a shell.
-2. Start the process with `exec.CommandContext`.
-3. Capture stdout and stderr separately.
-4. Decode stdout as JSON.
-5. Wait for the process and check the exit status.
-6. Return stderr in the error message if the command fails.
-
-Pseudocode:
-
-```go
-func runCommandForJSON(ctx context.Context, command string) ([]byte, error) {
-    args, err := tokenizeCommand(command)
-    if err != nil {
-        return nil, err
-    }
-    if len(args) == 0 {
-        return nil, errors.New("empty command")
-    }
-
-    cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-    var stdout bytes.Buffer
-    var stderr bytes.Buffer
-    cmd.Stdout = &stdout
-    cmd.Stderr = &stderr
-
-    err = cmd.Run()
-    if err != nil {
-        return nil, fmt.Errorf("command %q failed: %w; stderr: %s", command, err, stderr.String())
-    }
-    return stdout.Bytes(), nil
-}
-```
-
-This simpler `cmd.Run()` form is preferable to manual `StdoutPipe` unless streaming is required. Help exports are finite and should fit in memory for MVP.
-
 ### GlazedCommandLoader
 
 `GlazedCommandLoader` is the ergonomic loader requested by the user. It accepts binary names or executable paths and constructs the export command automatically.
@@ -740,9 +665,6 @@ func buildLoaders(s *ServeSettings) []loader.ContentLoader {
     }
     if len(s.FromSQLite) > 0 {
         loaders = append(loaders, &loader.SQLiteLoader{Paths: normalizeStringList(s.FromSQLite)})
-    }
-    if len(s.FromCmd) > 0 {
-        loaders = append(loaders, &loader.CommandJSONLoader{Commands: normalizeStringList(s.FromCmd)})
     }
     if len(s.FromGlazedCmd) > 0 {
         loaders = append(loaders, &loader.GlazedCommandLoader{Binaries: normalizeStringList(s.FromGlazedCmd)})
@@ -877,8 +799,7 @@ This phase is safer than changing `model.SectionType.MarshalJSON` first, because
 2. Add `MarkdownPathLoader`.
 3. Add `JSONFileLoader` with `Paths []string`.
 4. Add `SQLiteLoader` with `Paths []string`.
-5. Add `CommandJSONLoader` with `Commands []string`.
-6. Add `GlazedCommandLoader` with `Binaries []string`.
+5. Add `GlazedCommandLoader` with `Binaries []string`.
 7. Add unit tests for each loader.
 
 ### Phase 3: Extend ServeCommand
@@ -969,22 +890,17 @@ glaze serve --from-sqlite /tmp/glaze-help.db --address :18102 &
 curl http://localhost:18102/api/health
 kill %1
 
-# 3. Serve from full command
-glaze serve --from-cmd "glaze help export --output json" --address :18103 &
-curl http://localhost:18103/api/health
-kill %1
-
-# 4. Serve from Glazed command shorthand
+# 3. Serve from Glazed command shorthand
 glaze serve --from-glazed-cmd glaze --address :18104 &
 curl http://localhost:18104/api/health
 kill %1
 
-# 5. Serve multiple Glazed commands using comma-separated syntax
+# 4. Serve multiple Glazed commands using comma-separated syntax
 glaze serve --from-glazed-cmd pinocchio,sqleton,xxx --address :18105 &
 curl http://localhost:18105/api/health
 kill %1
 
-# 6. Combine all source types
+# 5. Combine all source types
 glaze serve \
   --from-glazed-cmd glaze \
   --from-json /tmp/glaze-help.json \
@@ -1001,7 +917,6 @@ kill %1
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|------------|--------|------------|
-| `--from-cmd` command injection | Medium | High | Do not invoke a shell; tokenize and call `exec.CommandContext`. |
 | `--from-glazed-cmd` binary not found | Medium | Low | Return a clear error naming the binary. |
 | Export JSON shape mismatch | Medium | Medium | Import both `type` and `section_type`; add tests from real export output. |
 | Slug collisions hide earlier docs | Medium | Low | Last-write-wins, with warning logs. |
@@ -1013,7 +928,7 @@ kill %1
 
 ## Open Questions
 
-1. Should `--from-glazed-cmd` support extra arguments per binary? Recommendation: no for MVP. Use `--from-cmd` when extra arguments are needed.
+1. Should `--from-glazed-cmd` support extra arguments per binary? Recommendation: no for MVP. Users who need extra arguments should export JSON first and serve it with `--from-json`.
 2. Should `--from-glazed-cmd` run `--with-content=true` explicitly? Recommendation: yes if the export command supports it, but it is already the default. The explicit command could be `<binary> help export --with-content=true --output json` for clarity.
 3. Should JSON import skip invalid sections or fail the whole source? Recommendation: fail the source for invalid JSON shape, but skip individual sections only if we explicitly log and count skips. For MVP, fail fast is easier to debug.
 4. Should embedded docs be included by default with external sources? Decision: no. `--with-embedded` defaults to `false`, so explicit external sources replace embedded docs unless the user opts into merging them.
@@ -1030,7 +945,6 @@ type ServeSettings struct {
     Paths         []string `glazed:"paths"`
     FromJSON      []string `glazed:"from-json"`
     FromSQLite    []string `glazed:"from-sqlite"`
-    FromCmd       []string `glazed:"from-cmd"`
     FromGlazedCmd []string `glazed:"from-glazed-cmd"`
     WithEmbedded  bool     `glazed:"with-embedded"`
 }
@@ -1047,7 +961,6 @@ type ContentLoader interface {
 type MarkdownPathLoader struct{ Paths []string }
 type JSONFileLoader struct{ Paths []string }
 type SQLiteLoader struct{ Paths []string }
-type CommandJSONLoader struct{ Commands []string }
 type GlazedCommandLoader struct{ Binaries []string }
 ```
 
@@ -1094,12 +1007,6 @@ This is the main target workflow. Users provide binary names, not full commands.
 glaze serve --from-glazed-cmd pinocchio
 ```
 
-### Use a custom export command
-
-```bash
-glaze serve --from-cmd "pinocchio help export --output json --topic database"
-```
-
 ### Serve an archived SQLite snapshot
 
 ```bash
@@ -1133,6 +1040,6 @@ glaze help export --output json \
 glaze serve --from-glazed-cmd pinocchio,sqleton,xxx
 ```
 
-and get a single browser for several Glazed-based tools. The general loaders (`--from-json`, `--from-sqlite`, `--from-cmd`, and markdown paths) keep the design flexible, while `--from-glazed-cmd` makes the common case easy.
+and get a single browser for several Glazed-based tools. The general loaders (`--from-json`, `--from-sqlite`, and markdown paths) keep the design flexible, while `--from-glazed-cmd` makes the common case easy.
 
 The implementation should be modest: add list-valued source flags to `ServeCommand`, introduce a `ContentLoader` interface, add robust JSON import for the real export row shape, and run Glazed binaries directly with `exec.CommandContext(binary, "help", "export", "--output", "json")`. The existing HTTP API and React frontend do not need to change.

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/index.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/index.md
@@ -1,7 +1,7 @@
 ---
 Title: 'Add glazed help export verb: export metadata and entries to disk/SQLite'
 Ticket: GLAZE-HELP-EXPORT
-Status: active
+Status: complete
 Topics:
     - glazed
     - help-system
@@ -14,10 +14,11 @@ Owners: []
 RelatedFiles: []
 ExternalSources: []
 Summary: ""
-LastUpdated: 2026-04-28T07:31:06.870604843-04:00
+LastUpdated: 2026-04-28T09:49:29.786093931-04:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 # Add glazed help export verb: export metadata and entries to disk/SQLite
 

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/index.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/index.md
@@ -1,0 +1,60 @@
+---
+Title: 'Add glazed help export verb: export metadata and entries to disk/SQLite'
+Ticket: GLAZE-HELP-EXPORT
+Status: active
+Topics:
+    - glazed
+    - help-system
+    - cli
+    - export
+    - sqlite
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T07:31:06.870604843-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Add glazed help export verb: export metadata and entries to disk/SQLite
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- glazed
+- help-system
+- cli
+- export
+- sqlite
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/reference/01-investigation-diary.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/reference/01-investigation-diary.md
@@ -1,0 +1,772 @@
+---
+Title: Investigation Diary
+Ticket: GLAZE-HELP-EXPORT
+Status: active
+Topics:
+    - glazed
+    - help-system
+    - cli
+    - export
+    - sqlite
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/doc/topics/28-export-help-entries.md
+      Note: Help topic for export verb
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/doc/topics/29-serve-external-help-sources.md
+      Note: Documented external source serving
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/cmd/export.go
+      Note: Implemented ExportCommand
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/cmd/export_test.go
+      Note: Unit tests for export command
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/loader/sources.go
+      Note: Implemented external help source loaders
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/model/section.go
+      Note: Data model exploration
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go
+      Note: To be extended with external sources
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/store/store.go
+      Note: Storage layer exploration
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T07:35:00-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+
+
+
+
+
+
+
+# Diary
+
+## Goal
+
+Capture the research, analysis, and documentation work for designing the Glazed Help Export verb feature. This diary tracks exploration of the codebase, architectural decisions, and the creation of a detailed design document suitable for a new intern.
+
+---
+
+## Step 1: Initialize Ticket and Read Skills
+
+This step established the project scaffolding by creating a docmgr ticket and reading the relevant skill files to understand the workflow, writing style, and deliverable requirements.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create a new docmgr ticket to add glaze help entries / glazed help verb : - export help entry metadata - export help entries to disk THe idea is that I can call any binary that uses the glazed help system and get a list of their metadata / content or export some of these to disk (also as sqlite), so that they are available as file. reate a detailed analysis / design / implementation guide that is very detailed for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet point sand pseudocode and diagrams and api references and file references. It should be very clear and detailed. Store in the ticket and the nupload to remarkable. Keep a diary as you work."
+
+**Assistant interpretation:** The user wants a comprehensive design document and implementation guide for adding export functionality to the Glazed help system, plus ticket bookkeeping and reMarkable upload.
+
+**Inferred user intent:** Produce an evidence-based, intern-friendly design document that can be handed off for implementation, while maintaining proper docmgr tracking and diary records.
+
+### What I did
+- Read `ticket-research-docmgr-remarkable/SKILL.md` to understand the end-to-end workflow.
+- Read `glazed-help-page-authoring/SKILL.md` to understand the help system conventions.
+- Read `diary/SKILL.md` and `diary/references/diary.md` to understand diary formatting requirements.
+- Read `writing-style.md` and `deliverable-checklist.md` for style guidance.
+- Created docmgr ticket `GLAZE-HELP-EXPORT` with title "Add glazed help export verb: export metadata and entries to disk/SQLite".
+- Added design-doc and diary documents to the ticket.
+
+### Why
+- Following the ticket-research skill ensures all deliverables (ticket, docs, validation, upload) are produced systematically.
+- Reading skills first prevents rework and ensures the output matches the user's expectations for detail and format.
+
+### What worked
+- Docmgr ticket creation succeeded immediately.
+- Skills provided clear templates for the diary and design doc structure.
+
+### What didn't work
+- N/A
+
+### What I learned
+- The docmgr workflow expects: ticket → evidence gathering → design doc → diary → bookkeeping → validation → reMarkable upload.
+- The diary format requires strict sections including `What was tricky to build`, `What warrants a second pair of eyes`, and `What should be done in the future` for any code change. Since this turn was research-only, those sections are lighter.
+
+### What was tricky to build
+- N/A (research step)
+
+### What warrants a second pair of eyes
+- N/A (research step)
+
+### What should be done in the future
+- Begin codebase exploration to anchor claims to concrete files.
+- Verify that all file paths referenced in the final design document exist and are current.
+
+### Code review instructions
+- Verify ticket `GLAZE-HELP-EXPORT` exists in docmgr.
+- Check that `design-doc/01-design-...` and `reference/01-investigation-diary.md` were created.
+
+### Technical details
+- Ticket path: `2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite`
+- Commands run:
+  ```bash
+  docmgr ticket create-ticket --ticket GLAZE-HELP-EXPORT --title "..." --topics glazed,help-system,cli,export,sqlite
+  docmgr doc add --ticket GLAZE-HELP-EXPORT --doc-type design-doc --title "..."
+  docmgr doc add --ticket GLAZE-HELP-EXPORT --doc-type reference --title "Investigation Diary"
+  ```
+
+---
+
+## Step 2: Explore the Glazed Help System Codebase
+
+This step mapped the architecture of the Glazed help system by reading key source files. The goal was to understand data models, storage, rendering, and command wiring so the design document could be evidence-based.
+
+### What I did
+- Located the main glazed repository at `/home/manuel/code/wesen/corporate-headquarters/glazed/`.
+- Explored `pkg/help/model/section.go` and `pkg/help/model/parse.go` — the data model and markdown parser.
+- Explored `pkg/help/store/store.go` — the SQLite-backed storage layer.
+- Explored `pkg/help/store/query.go` — the predicate-based query compiler.
+- Explored `pkg/help/help.go` — the `HelpSystem` facade.
+- Explored `pkg/help/cmd/cobra.go` — the Cobra help command implementation.
+- Explored `pkg/help/site/render.go` — prior art for exporting help data (static site generation).
+- Explored `pkg/help/server/types.go` and `pkg/help/server/handlers.go` — the HTTP API for help sections.
+- Explored `pkg/help/loader/paths.go` — how markdown files are loaded from disk into the store.
+- Explored `cmd/glaze/main.go` — application root showing help system initialization.
+- Explored `pkg/cmds/cmds.go` — Glazed command interfaces (`BareCommand`, `GlazeCommand`).
+- Ran `go run ./cmd/glaze help --help` to verify the current help command surface.
+
+### Why
+- The ticket-research skill mandates "evidence-first investigation" and "anchor every major claim to concrete files."
+- Without reading the actual code, the design document would be speculative and potentially misaligned with existing patterns.
+
+### What worked
+- The codebase is well-organized: `model/`, `store/`, `cmd/`, `server/`, `site/` clearly separate concerns.
+- The predicate system in `store/query.go` is reusable and powerful; it can drive export filtering with no modifications.
+- The `store.NewInMemory()` and `store.New(dbPath)` constructors mean SQLite export is almost trivial — just create a new store and upsert sections.
+
+### What didn't work
+- Initially looked at `/home/manuel/code/wesen/glazed/` (an older checkout) before finding the active workspace at `corporate-headquarters/glazed/`.
+
+### What I learned
+- `model.Section` already contains every field needed for metadata export.
+- The `Store` already supports `List`, `Find`, `Count`, `Upsert`, and `Clear`.
+- `render-site` exists and exports to JSON files + React SPA, but there is no simple "dump to files" or "dump to SQLite" path.
+- `SetupCobraRootCommand` creates the `help` subcommand; additional subcommands can be added afterward by finding the command in the Cobra tree.
+- `cmds.GlazeCommand` is ideal for tabular output because `cli.BuildCobraCommand` auto-wires `--output json/csv/table/yaml`.
+- `cmds.BareCommand` is better for file-writing commands because it bypasses the GlazeProcessor output pipeline.
+
+### What was tricky to build
+- Understanding the relationship between `HelpSystem`, `Store`, and the Cobra command took multiple file reads. The flow is:
+  1. `main.go` creates `HelpSystem` → loads embedded docs → calls `SetupCobraRootCommand(hs, rootCmd)`.
+  2. `SetupCobraRootCommand` overrides Cobra's help/usage templates and creates the `help` subcommand.
+  3. The `help` subcommand's `Run` function queries `hs.Store` directly for interactive use.
+  4. Export commands should follow the same pattern but produce files/structured output instead of terminal rendering.
+
+### What warrants a second pair of eyes
+- Confirm that `ExportMetadataCommand` should indeed be a `GlazeCommand` (tabular output) and not a `BareCommand` that writes JSON manually. The `GlazeCommand` path is more consistent with other Glazed CLI tools.
+- Confirm that the `export` subcommand should be added under `help` rather than as a top-level `glaze export-help`. The user explicitly asked for `glaze help` verb, so `glaze help export` is correct.
+
+### What should be done in the future
+- When implementing, verify that `cli.BuildCobraCommand` correctly registers flags from the `ExportMetadataCommand` and `ExportContentCommand` schemas.
+- Test that the `export` subcommand appears in `glaze help --help` and shell completions.
+- Consider whether `buildExportPredicate` should live in `pkg/help/store` as a general utility rather than `pkg/help/cmd`.
+
+### Code review instructions
+- Start reading at `pkg/help/model/section.go` to understand the data model.
+- Then read `pkg/help/store/store.go` and `pkg/help/store/query.go` to understand storage and querying.
+- Then read `pkg/help/cmd/cobra.go` to see how the existing `help` command is structured.
+- Finally read `cmd/glaze/main.go` to see initialization.
+
+### Technical details
+- Key files and their line counts:
+  - `pkg/help/model/section.go` ~120 lines
+  - `pkg/help/model/parse.go` ~120 lines
+  - `pkg/help/store/store.go` ~380 lines
+  - `pkg/help/store/query.go` ~380 lines
+  - `pkg/help/help.go` ~220 lines
+  - `pkg/help/cmd/cobra.go` ~560 lines
+  - `pkg/help/site/render.go` ~380 lines
+  - `cmd/glaze/main.go` ~95 lines
+  - `pkg/cmds/cmds.go` ~280 lines
+- Existing export-like commands:
+  - `glaze docs <files>` — reads markdown files from disk, not from HelpSystem
+  - `glaze render-site` — exports full SPA with JSON payloads
+  - `glaze serve-help` — HTTP API serving JSON
+
+---
+
+## Step 3: Write the Design Document
+
+This step produced the primary deliverable: a comprehensive, intern-friendly design document explaining the Glazed help system from first principles and proposing the export verb implementation.
+
+### What I did
+- Structured the document according to the ticket-research skill's recommended order:
+  1. Executive Summary
+  2. Problem Statement and Scope
+  3. Current-State Architecture
+  4. Gap Analysis
+  5. Proposed Solution
+  6. Detailed Design (Command Implementations)
+  7. Wiring the Commands
+  8. Implementation Phases
+  9. Testing Strategy
+  10. Risks, Alternatives, and Open Questions
+  11. API Reference Summary
+  12. File References
+  13. Appendix: Full Command Examples
+- Wrote prose explanations for every architectural layer (Markdown → Model → Store → HelpSystem → Cobra → main.go).
+- Included an ASCII architecture diagram.
+- Included pseudocode for `buildExportPredicate`, `ExportMetadataCommand`, `ExportContentCommand`, `exportToFiles`, and `exportToSQLite`.
+- Included a comparison table of existing vs. missing functionality.
+- Included explicit file references with absolute paths.
+- Included manual verification commands.
+
+### Why
+- The user requested "very detailed" documentation "for a new intern" with "prose paragraphs and bullet points and pseudocode and diagrams and api references and file references."
+- The ticket-research skill requires "Optimize for onboarding unfamiliar engineers" and "Be explicit, structured, and concrete."
+
+### What worked
+- The layered architecture section makes the system understandable even without prior Go experience.
+- Reusing the existing `store.Predicate` system for filtering means the export commands need minimal new code.
+- The pseudocode is close to real Go, making the handoff to implementation straightforward.
+
+### What didn't work
+- N/A
+
+### What I learned
+- Writing for an intern forces clarity: every abstraction must be explained, every file path must be explicit, and every design decision must be justified.
+- The `GlazeCommand` vs `BareCommand` distinction is a key concept that needed its own primer section.
+
+### What was tricky to build
+- Deciding where to inject the `export` subcommand. Three options were considered:
+  1. Inside `pkg/help/cmd` directly — rejected because `help_cmd` does not depend on `cli.BuildCobraCommand` and should stay focused on interactive help.
+  2. In `cmd/glaze/main.go` directly — viable but creates duplication for other binaries.
+  3. A helper `AddExportCommands` in `pkg/help/cmd` that accepts a `*cobra.Command` — chosen because it balances reusability with separation of concerns.
+
+### What warrants a second pair of eyes
+- The design proposes `ExportMetadataCommand` as a `GlazeCommand` (tabular output) and `ExportContentCommand` as a `BareCommand` (file I/O). Verify this split feels natural to other maintainers.
+- The design suggests `export content --format sqlite` reuses `store.New()`. Verify that FTS table creation (build-tag dependent) does not cause issues when opening an exported DB on a system without FTS5.
+
+### What should be done in the future
+- After implementation, update the design document with actual code snippets replacing the pseudocode.
+- Add a section on performance considerations if exporting very large help systems.
+- Document the `AddExportCommands` helper in the Glazed help authoring skill.
+
+### Code review instructions
+- Read the design document from top to bottom. It is self-contained.
+- Verify every file reference points to an existing file.
+- Check that the proposed CLI surface (`glaze help export metadata`, `glaze help export content`) matches the user's intent.
+
+---
+
+## Step 4: Validate and Upload to reMarkable
+
+This step completed the ticket workflow by validating documentation quality with docmgr doctor and uploading the final document bundle to reMarkable.
+
+### What I did
+- Added YAML frontmatter to both the design document and diary (docmgr requires `---` delimiters).
+- Related 7 source files to the design document and 2 source files to the diary.
+- Updated the ticket changelog with 3 entries covering ticket initialization, codebase exploration, and design completion.
+- Ran `docmgr doctor --ticket GLAZE-HELP-EXPORT --stale-after 30`.
+- Resolved vocabulary warnings by adding `export`, `help-system`, and `sqlite` to the topics vocabulary.
+- Re-ran `docmgr doctor` — all checks passed.
+- Verified `remarquee status` and `remarquee cloud account --non-interactive`.
+- Ran dry-run bundle upload successfully.
+- Executed real bundle upload: `GLAZE-HELP-EXPORT: Help Export Verb Design.pdf` → `/ai/2026/04/28/GLAZE-HELP-EXPORT`.
+- Verified remote listing: `remarquee cloud ls /ai/2026/04/28/GLAZE-HELP-EXPORT --long --non-interactive`.
+
+### Why
+- The ticket-research skill mandates validation (`docmgr doctor`) and reMarkable delivery as required steps before handoff.
+- Without frontmatter, docmgr cannot relate files or validate documents.
+
+### What worked
+- `docmgr doctor` passed cleanly after adding vocabulary entries.
+- reMarkable upload succeeded on the first real attempt.
+- The bundle contains both the design document and the diary with a table of contents.
+
+### What didn't work
+- Initial `docmgr doc relate` failed because the written documents lacked YAML frontmatter. Fixed by prepending frontmatter blocks.
+- Initial `docmgr doctor` reported unknown topics. Fixed by adding vocabulary entries.
+
+### What I learned
+- docmgr strictly requires `---` frontmatter delimiters even if the file is Markdown.
+- The `remarquee upload bundle` command produces a single PDF with ToC from multiple markdown files.
+
+### What was tricky to build
+- N/A (bookkeeping step)
+
+### What warrants a second pair of eyes
+- Verify the uploaded PDF renders correctly on the reMarkable device (headings, code blocks, table of contents).
+
+### What should be done in the future
+- When the feature is implemented, update the design document with actual code snippets and mark implementation phases as complete.
+- Add the `AddExportCommands` helper usage to the Glazed help authoring skill documentation.
+
+### Code review instructions
+- Check `docmgr doctor --ticket GLAZE-HELP-EXPORT` passes.
+- Check `remarquee cloud ls /ai/2026/04/28/GLAZE-HELP-EXPORT` shows the uploaded PDF.
+
+### Technical details
+- Validation: `docmgr doctor --ticket GLAZE-HELP-EXPORT --stale-after 30` → ✅ All checks passed
+- Upload path: `/ai/2026/04/28/GLAZE-HELP-EXPORT`
+- Uploaded file: `GLAZE-HELP-EXPORT: Help Export Verb Design.pdf`
+- Bundle contents:
+  - `01-design-glazed-help-export-verb-metadata-and-content-export-to-disk-and-sqlite.md` (~42 KB)
+  - `01-investigation-diary.md` (~13 KB)
+
+---
+
+## Session Summary
+
+| Deliverable | Path | Status |
+|-------------|------|--------|
+| Ticket | `GLAZE-HELP-EXPORT` | ✅ Created |
+| Design Document | `design-doc/01-design-...` | ✅ Written |
+| Investigation Diary | `reference/01-investigation-diary.md` | ✅ Written |
+| File Relations | 9 source files related | ✅ Complete |
+| Changelog | 3 entries | ✅ Updated |
+| Validation | `docmgr doctor` | ✅ Passed |
+| reMarkable Upload | `/ai/2026/04/28/GLAZE-HELP-EXPORT` | ✅ Verified |
+
+---
+
+## Step 5: Simplify to Single Verb with `--with-content=true` by Default
+
+This step revised the design based on user feedback: collapse the two-subcommand structure (`export metadata` + `export content`) into a single `glaze help export` verb, and make `--with-content` default to `true`.
+
+### Prompt Context
+
+**User prompt (verbatim):** "update the ticket to have a single verb, and to have --with-content be true by default"
+
+**Assistant interpretation:** The user wants the CLI surface simplified from two subcommands to one, with content included by default in tabular output.
+
+**Inferred user intent:** Reduce cognitive overhead — one command does everything, and the default behavior gives a complete snapshot.
+
+### What I did
+- Updated the Executive Summary to describe a single `glaze help export` verb.
+- Updated Scope to reflect the single command with `--with-content`, `--format files`, and `--format sqlite`.
+- Rewrote the Proposed Solution section: removed `export metadata` and `export content` subcommands; introduced `glaze help export` with `--format glazed` (default), `--format files`, and `--format sqlite`.
+- Added `--with-content` flag (bool, default `true`) to the tabular mode.
+- Rewrote the Command Implementations section: replaced `ExportMetadataCommand` + `ExportContentCommand` with a single `ExportCommand` that implements both `GlazeCommand` and `BareCommand`, dispatching based on `--format`.
+- Simplified Wiring: `AddExportCommands` → `AddExportCommand` (singular).
+- Condensed Implementation Phases from 4 to 3.
+- Updated Testing Strategy, Manual Verification Checklist, API Reference, Appendix Examples, and Conclusion to match the single-verb design.
+- Updated Open Questions to reflect that `--with-content=true` is now the decided default.
+
+### Why
+- A single verb is simpler to discover and document.
+- `--with-content=true` by default means `glaze help export --output json` is a one-shot complete backup.
+- Users who want lightweight output opt out explicitly (`--with-content=false`).
+
+### What worked
+- The unified `ExportCommand` design is elegant: one struct, two interface implementations, runtime dispatch via `--format`.
+- The Glazed framework supports this pattern because `cli.BuildCobraCommand` can wire both `GlazeCommand` (for `--format glazed`) and fall back to `BareCommand.Run` for file modes.
+
+### What didn't work
+- N/A
+
+### What I learned
+- `cmds.GlazeCommand` and `cmds.BareCommand` can be implemented by the same struct. The Cobra wiring layer dispatches based on which interface methods are present and the runtime flag values.
+- Defaulting booleans to `true` in Glazed is straightforward: `fields.WithDefault(true)`.
+
+### What was tricky to build
+- Determining how `cli.BuildCobraCommand` would dispatch between `RunIntoGlazeProcessor` and `Run` at runtime. The design documents that `Run` checks `--format` and either errors (if called incorrectly for glazed mode) or dispatches to file/SQLite export. The Cobra command's `Run` function may need a small wrapper to choose the correct path based on the parsed `--format` flag.
+
+### What warrants a second pair of eyes
+- Verify that `cli.BuildCobraCommand` can handle a command implementing both `GlazeCommand` and `BareCommand` without ambiguity. If not, a thin wrapper command that delegates may be needed.
+- Verify that `--with-content` interacts correctly with the GlazeProcessor's field filtering (users may `--select` to exclude `content` even when `--with-content=true`).
+
+### What should be done in the future
+- When implementing, write a small spike to confirm that `cli.BuildCobraCommand` handles the dual-interface command correctly.
+- If the framework does not support dual-interface dispatch cleanly, create a thin `exportCobraWrapper` that reads `--format` and calls either the Glaze processor path or the bare Run path.
+
+### Code review instructions
+- Re-read the design document sections: "Proposed Solution", "Detailed Design: Command Implementations", and "Implementation Phases".
+- Verify that all examples in the Appendix use `glaze help export` (not `glaze help export metadata` or `glaze help export content`).
+
+### Technical details
+- Key changes in the design document:
+  - `glaze help export metadata` → `glaze help export --with-content=false`
+  - `glaze help export content --format files` → `glaze help export --format files`
+  - `glaze help export content --format sqlite` → `glaze help export --format sqlite`
+  - `ExportMetadataCommand` + `ExportContentCommand` → single `ExportCommand`
+  - `AddExportCommands()` → `AddExportCommand()`
+
+---
+
+## Session Summary
+
+| Deliverable | Path | Status |
+|-------------|------|--------|
+| Ticket | `GLAZE-HELP-EXPORT` | ✅ Created |
+| Design Document | `design-doc/01-design-...` | ✅ Written |
+| Investigation Diary | `reference/01-investigation-diary.md` | ✅ Written |
+| File Relations | 9 source files related | ✅ Complete |
+| Changelog | 3 entries | ✅ Updated |
+| Validation | `docmgr doctor` | ✅ Passed |
+| reMarkable Upload | `/ai/2026/04/28/GLAZE-HELP-EXPORT` | ✅ Verified |
+
+---
+
+## Step 6: Implement `glaze help export` Command
+
+This step implemented the `glaze help export` verb as designed. The command was built as a single `ExportCommand` implementing `cmds.BareCommand`, with `--format glazed` (default) producing tabular output via the GlazeProcessor, and `--format files`/`sqlite` writing to disk.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Add tasks to the export ticket. Then work on them task by task, committing at appropriate intervals, keeping a diary as you work."
+
+**Assistant interpretation:** The user wants concrete implementation tasks added to the ticket, followed by actual coding work with git commits and diary updates.
+
+**Inferred user intent:** Move from design to working code, with proper task tracking and version control.
+
+### What I did
+- Added 6 implementation tasks to `tasks.md`:
+  1. Create `ExportCommand` with tabular output
+  2. Add disk-export modes (`files`/`sqlite`)
+  3. Add unit tests
+  4. Wire into `cmd/glaze/main.go`
+  5. Add documentation help section
+  6. Validate and commit
+- Created `pkg/help/cmd/export.go` (~290 lines) with:
+  - `ExportCommand` struct implementing `cmds.BareCommand`
+  - Added glazed section to schema for `--output json/csv/table/yaml` flags
+  - `Run()` method dispatching on `--format`: `glazed` → processor, `files`/`sqlite` → file I/O
+  - `buildExportPredicate()` with support for `--type`, `--topic`, `--command`, `--flag`, `--slug`
+  - `exportToFiles()` with `--flatten-dirs` support
+  - `exportToSQLite()` using `store.New()` and `Upsert`
+  - `reconstructMarkdown()` for round-trippable `.md` files
+  - `AddExportCommand()` helper for wiring into any binary
+- Wired into `cmd/glaze/main.go` by finding the `help` subcommand and calling `help_cmd.AddExportCommand`.
+- Created `pkg/help/cmd/export_test.go` (~270 lines) with 11 tests:
+  - Filter tests: no filters, by type, topic, command, flag, slug, multiple slugs
+  - Export tests: files mode (with/without flatten), sqlite mode, markdown reconstruction
+- Fixed flag name conflicts discovered during integration:
+  - `--output` → `--output-path` (conflicted with glazed `--output` format flag)
+  - `--flatten` → `--flatten-dirs` (conflicted with glazed `--flatten` nested fields flag)
+- Committed in two focused commits:
+  1. `391a62f` — feat: add glaze help export verb with tabular, files, and sqlite modes
+  2. `81f52fc` — test: add unit tests for glaze help export command
+
+### Why
+- The design document specified a single `ExportCommand` with `--with-content=true` by default. Implementing it as `BareCommand` with a manually added glazed section keeps the code simple while still providing all GlazeProcessor features.
+- The flag renames (`--output-path`, `--flatten-dirs`) were necessary because the glazed section already defines `--output` (output format) and `--flatten` (flatten nested objects).
+
+### What worked
+- The command works end-to-end:
+  - `glaze help export --output json` → JSON array with content (default)
+  - `glaze help export --with-content=false --output csv` → lightweight CSV
+  - `glaze help export --format files --output-path ./exported` → `.md` files in typed subdirs
+  - `glaze help export --format sqlite --output-path ./help.sqlite` → queryable SQLite DB
+- All 11 unit tests pass.
+- The entire repo test suite passes (all packages green).
+- Lint passes with 0 issues (golangci-lint, gosec, govulncheck).
+
+### What didn't work
+- Initial attempt had `--output` and `--flatten` flags that conflicted with the glazed section's flags. The error was: `Flag 'output' already exists`. Fixed by renaming to `--output-path` and `--flatten-dirs`.
+- Initial `export.go` had unused `fmt` import. Fixed by removing it.
+- Initial `export.go` had `cli` undefined in `AddExportCommand` because the import was missing. Fixed by adding `github.com/go-go-golems/glazed/pkg/cli`.
+- Initial test file had `from "..."` (Python syntax) instead of proper Go import. Fixed.
+- Lint caught unchecked error returns from `exportStore.Close()` and `enc.Close()`. Fixed with `_ = ...` and defer wrappers.
+
+### What I learned
+- The glazed section already provides `--output` (format choice: table/json/csv/yaml/etc.) and `--flatten` (flatten nested objects). Any command that adds a glazed section to its schema must avoid naming conflicts with these flags.
+- `settings.NewGlazedSchema()` returns a `schema.Section` that can be merged into the command's schema via `cmds.WithSchema(schema.NewSchema(schema.WithSections(glazedSection)))`.
+- `BuildCobraCommand` for `BareCommand` does NOT automatically call the GlazeProcessor. To get tabular output, I manually extract the glazed section values from `parsedValues` and call `settings.SetupTableProcessor()` + `settings.SetupProcessorOutput()`.
+- The `yaml.v3` encoder does not preserve Go map insertion order, so reconstructed frontmatter fields appear in alphabetical order. This is acceptable for round-tripping.
+
+### What was tricky to build
+- Understanding how to wire the glazed section into a `BareCommand`. The key insight: `BuildCobraCommand` parses ALL sections in the schema (including the glazed section) into `parsedValues`, but only calls `Run()`. Inside `Run()`, I manually create the processor from the glazed section values. This gives me full control over when the processor is used (only for `--format glazed`).
+- The `exportToFiles` directory structure: default is `outputDir/{type}/{slug}.md`, with `--flatten-dirs` putting everything in `outputDir/{slug}.md`. The `slugify()` helper converts section type names to lowercase kebab-case for directory names.
+
+### What warrants a second pair of eyes
+- Verify the `--output-path` flag name feels natural. Alternatives: `--dest`, `--target`, `--out`.
+- Verify that `reconstructMarkdown()` produces valid frontmatter that `model.ParseSectionFromMarkdown()` can parse. The round-trip test confirms this, but edge cases (empty topics, special characters in titles) should be tested.
+
+### What should be done in the future
+- Add a help section `.md` file documenting the export feature (Task 5 in tasks.md).
+- Test `AddExportCommand` in another binary (e.g., parka) to verify cross-binary compatibility.
+- Consider adding `--limit` and `--offset` flags for large help systems.
+
+### Code review instructions
+- Start reading at `pkg/help/cmd/export.go`.
+- Check `Run()` dispatch logic: `glazed` → `runGlazed()`, `files` → `exportToFiles()`, `sqlite` → `exportToSQLite()`.
+- Verify `buildExportPredicate()` handles all filter combinations correctly.
+- Run `go test ./pkg/help/cmd/...` to validate all tests pass.
+
+### Technical details
+- Commit 1: `391a62f` — `pkg/help/cmd/export.go` (290 lines), `cmd/glaze/main.go` (+6 lines)
+- Commit 2: `81f52fc` — `pkg/help/cmd/export_test.go` (274 lines)
+- Commands validated:
+  ```bash
+  go run ./cmd/glaze help export --help
+  go run ./cmd/glaze help export --output json
+  go run ./cmd/glaze help export --with-content=false --output csv
+  go run ./cmd/glaze help export --format files --output-path /tmp/exported
+  go run ./cmd/glaze help export --format sqlite --output-path /tmp/help.sqlite
+  ```
+- Test results: 11/11 pass, full suite pass, lint 0 issues
+
+---
+
+## Step 7: Add Help Documentation Topic and Cross-References
+
+This step completed Task 5 by creating a new Glazed help topic that documents the `glaze help export` command, and updating related help topics with cross-references.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Update documentation / add new export documentation page as well."
+
+**Assistant interpretation:** The user wants the export feature to be discoverable through the Glazed help system itself, with a dedicated help topic and cross-references in related docs.
+
+**Inferred user intent:** Users should be able to run `glaze help export-help-entries` to learn about the export command, just as they can run `glaze help serve-help-over-http` to learn about the server.
+
+### What I did
+- Read the `glazed-help-page-authoring` skill to confirm conventions for Glazed help topics.
+- Read `how-to-write-good-documentation-pages.md` for style guidance (present tense, active voice, troubleshooting tables, See Also sections).
+- Read existing help topics (`01-help-system.md`, `25-serving-help-over-http.md`, `26-export-help-as-static-website.md`, `14-writing-help-entries.md`) for tone and structure reference.
+- Created `pkg/doc/topics/28-export-help-entries.md` (~250 lines) with:
+  - Frontmatter: `GeneralTopic`, `IsTopLevel: true`, `ShowPerDefault: true`
+  - Topics: `help`, `export`, `cli`, `sqlite`, `json`, `documentation`
+  - Commands: `help`, `export`
+  - Flags: all export command flags for discoverability
+  - Content sections: Why it exists, Basic usage, Export formats (tabular/files/SQLite), Filtering, Practical examples, How it's wired, Troubleshooting, See Also
+  - Troubleshooting table with 7 common problems
+  - See Also cross-references to 5 related help topics
+- Updated `01-help-system.md`:
+  - Added a paragraph in the overview mentioning export capability
+  - Added a `See Also` section with cross-references (the doc previously had none)
+- Updated `25-serving-help-over-http.md`:
+  - Added `glaze help export-help-entries` to `See Also`
+- Updated `26-export-help-as-static-website.md`:
+  - Added `glaze help export-help-entries` to `See Also`
+- Committed: `2a5603d` — `docs: add export-help-entries topic and cross-references`
+
+### Why
+- The Glazed help system is self-documenting. Every feature should have a help topic that explains what it does, why you'd use it, and how to troubleshoot it.
+- Cross-references in `01-help-system.md` help users discover the export feature from the main help overview.
+- Cross-references in `serve-help-over-http` and `export-help-static-website` connect the three delivery mechanisms (live server, static site, export to files/SQLite).
+
+### What worked
+- The new topic renders correctly: `glaze help export-help-entries` displays the full content.
+- The topic is discoverable via `glaze help export --output json | jq '.[] | select(.slug == "export-help-entries")'` — it appears in the exported list.
+- All help topic tests pass.
+- The cross-reference links in `01-help-system.md` render as proper markdown links in the terminal output.
+
+### What didn't work
+- N/A
+
+### What I learned
+- Glazed help topics follow a strict convention: YAML frontmatter with exact field names, no top-level `#` heading in body content, and `SectionType` must be one of `GeneralTopic`, `Example`, `Application`, `Tutorial`.
+- The `IsTopLevel: true` and `ShowPerDefault: true` flags control whether the section appears in the main help listing and the top-level help page.
+- Topics are automatically loaded from `pkg/doc/` via `//go:embed *` in `pkg/doc/doc.go`, so adding a new `.md` file in `pkg/doc/topics/` is sufficient — no Go code changes needed.
+
+### What was tricky to build
+- Ensuring the frontmatter `Flags` list did not conflict with Glazed's flag parsing. The `Flags` field in frontmatter is for metadata filtering only; it does not register actual CLI flags.
+- Balancing comprehensiveness with brevity. The export command has many flags and three modes; the doc needs to cover them all without becoming overwhelming.
+
+### What warrants a second pair of eyes
+- Verify the troubleshooting table covers the most common failure modes. Are there other errors users might encounter?
+- Verify the `See Also` cross-references are sufficient. Should `simple-query-dsl` or `user-query-dsl` be linked too?
+
+### What should be done in the future
+- When new export features are added (e.g., `--limit`/`--offset`, new formats), update `28-export-help-entries.md`.
+- Consider adding an `Example` section type that shows a concrete `glaze help export` invocation with explanation, complementing the `GeneralTopic` reference doc.
+
+### Code review instructions
+- Read `pkg/doc/topics/28-export-help-entries.md` from top to bottom.
+- Verify `glaze help export-help-entries` renders correctly.
+- Check that `01-help-system.md`, `25-serving-help-over-http.md`, and `26-export-help-as-static-website.md` have consistent See Also sections.
+
+### Technical details
+- New file: `pkg/doc/topics/28-export-help-entries.md` (248 lines)
+- Modified files:
+  - `pkg/doc/topics/01-help-system.md` (+10 lines: export mention + See Also)
+  - `pkg/doc/topics/25-serving-help-over-http.md` (+1 line: See Also)
+  - `pkg/doc/topics/26-export-help-as-static-website.md` (+1 line: See Also)
+- Commit: `2a5603d` — `docs: add export-help-entries topic and cross-references`
+- Section count increased from 70 to 71.
+
+---
+
+## Step 8: Design Serve External Sources Feature
+
+This step created a design document for extending `glaze serve` to load help content from external sources: JSON exports, SQLite databases, external CLI commands, and markdown directories. This turns `glaze serve` into a universal help aggregator.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Add a design document to the ticket that allows the serve verb to take a set of cli verbs / a sqlite db / a json / a directory of markdown files, and serve these instead of the embedded help system? Basically it's a way to allow glaze to serve other packages help pages, and now that we have export, it can call the external verbs with `help export` and use that to load into memory to serve."
+
+**Assistant interpretation:** The user wants `glaze serve` to consume the outputs of `glaze help export` (and other binaries' `help export`), enabling cross-binary help browsing.
+
+**Inferred user intent:** Create a design for a multi-source help browser that leverages the newly built export functionality.
+
+### What I did
+- Read the current `ServeCommand` implementation in `pkg/help/server/serve.go` to understand the loading lifecycle.
+- Read `pkg/help/server/handlers.go` to confirm the API layer is source-agnostic.
+- Read `pkg/help/loader/paths.go` to understand existing markdown loading.
+- Read `pkg/help/model/section.go` to identify the `SectionType` JSON marshaling gap.
+- Read `pkg/help/store/store.go` to confirm `List`, `Upsert`, and `Clear` APIs.
+- Created `design-doc/02-design-serve-external-sources.md` (~750 lines, ~32 KB) with:
+  - Executive Summary explaining the export→serve pipeline
+  - Problem Statement showing the current limitation (serve only embedded docs)
+  - Current-State Architecture review of ServeCommand, HelpSystem, Store, Loader
+  - Gap Analysis table comparing current vs. needed capabilities
+  - Proposed Solution with CLI surface, ContentLoader interface, four loader implementations
+  - Detailed Design for each loader (MarkdownPathLoader, JSONFileLoader, SQLiteLoader, CommandLoader)
+  - SectionType JSON marshaling design (MarshalJSON/UnmarshalJSON)
+  - Implementation Phases (4 phases)
+  - Testing Strategy with unit and integration test plans
+  - Risks, Alternatives, and Open Questions
+  - API Reference and File References
+  - Appendix with full command examples
+
+### Why
+- The export feature is only half of the story. Export produces files; serve needs to consume them.
+- A `ContentLoader` interface provides a clean extension point for future source types (HTTP URLs, S3, etc.).
+- The design keeps all existing behavior unchanged (backward compatible) while adding powerful new capabilities.
+
+### What worked
+- The `ContentLoader` interface is simple and maps cleanly to the existing `HelpSystem` API.
+- The HTTP handlers require no changes — they only interact with `Store`, which is populated before the server starts.
+- The `--with-embedded` flag (default `true`) provides intuitive behavior: adding external sources doesn't remove built-in docs.
+
+### What didn't work
+- N/A
+
+### What I learned
+- `glaze serve` currently replaces (not merges) embedded docs when paths are provided. The new design uses `--with-embedded` to give users control.
+- `model.SectionType` has no JSON marshaling methods, so exported JSON uses integer values (0, 1, 2, 3). The design proposes string marshaling for readability and compatibility.
+- The `store.New(path)` constructor opens an existing SQLite database, making it trivial to read exported databases.
+
+### What was tricky to build
+- Designing the `--from-cmd` loader securely. Using `exec.CommandContext` directly (not through a shell) prevents injection, but means users cannot use shell features like pipes. This is the right tradeoff for safety.
+- Deciding whether to load embedded docs by default when external sources are provided. I chose `--with-embedded=true` as the default because the common case is "show me glaze's docs PLUS parka's docs."
+
+### What warrants a second pair of eyes
+- Verify that the `SectionType` JSON string format (`"GeneralTopic"`, `"Example"`, etc.) is the right choice. Should we use lowercase kebab-case (`"general-topic"`) instead?
+- Verify the command tokenization approach for `--from-cmd`. A simple quote-aware tokenizer is proposed; is this sufficient?
+
+### What should be done in the future
+- Implement the four phases in the design document.
+- Add `MarshalJSON`/`UnmarshalJSON` to `SectionType` first (Phase 1), since it affects the export format too.
+- Consider adding a `--watch` flag to reload sources when files change.
+- Consider HTTP URL support for `--from-json https://example.com/help.json`.
+
+### Code review instructions
+- Read `design-doc/02-design-serve-external-sources.md` from top to bottom.
+- Verify the `ContentLoader` interface is minimal and correct.
+- Check that each loader implementation handles errors appropriately.
+- Review the CLI surface: are the flag names intuitive?
+
+### Technical details
+- New design document: `design-doc/02-design-serve-external-sources.md` (~750 lines, ~32 KB)
+- Key design decisions:
+  - `ContentLoader` interface with `Load(ctx, hs)` and `String()` methods
+  - Four implementations: `MarkdownPathLoader`, `JSONFileLoader`, `SQLiteLoader`, `CommandLoader`
+  - `--with-embedded` flag (default `true`) controls whether embedded docs are included
+  - `SectionType` gets `MarshalJSON`/`UnmarshalJSON` for string-based JSON representation
+  - Last-write-wins for slug collisions across sources
+- Related files documented:
+  - `pkg/help/server/serve.go`
+  - `pkg/help/model/section.go`
+  - `pkg/help/loader/paths.go`
+  - `pkg/help/store/store.go`
+  - `pkg/help/cmd/export.go`
+
+---
+
+## Step 9: Implement Serve External Sources and `--from-glazed-cmd`
+
+This step revised the external-source design based on user feedback and implemented the feature in code. The user specifically requested `--from-glazed-cmd` as a convenience shorthand and clarified that `--with-embedded` should default to `false`.
+
+### Prompt Context
+
+**User prompt (verbatim):** "We should support \"--from-glazed-cmd\"as well, where we assume that the command is a glazed command that supports help export --output json, to make it easier. For example: glaze serve --from-glazed-cmd pinocchio,sqleton,xxx all strings should be parameter StringList so that we can serve multiple pages together. Update the document (and review it as well, it was written by a colleague we took over for, and they might not have been careful) upload to remarkable once done"
+
+**Follow-up prompt (verbatim):** "with-embedded = default false. Add tasks, then work on the tasks one by one, committing at appropriate intervals, and keeping a diary as you work."
+
+**Assistant interpretation:** The user wanted both design correction and actual implementation, with task tracking, commits, diary entries, validation, and reMarkable upload.
+
+### What I did
+- Reviewed and rewrote `design-doc/02-design-serve-external-sources.md` to:
+  - Add `--from-glazed-cmd` as the ergonomic shorthand.
+  - Set `--with-embedded=false` as the default.
+  - Correct the JSON import design to match the actual `help export --output json` row shape (`type`, not `section_type`).
+  - Make all external source settings `[]string` / `fields.TypeStringList`.
+  - Clarify that arbitrary `--from-cmd` values should not be comma-split because commands may contain commas in arguments.
+- Added tasks 31-36 to `tasks.md` and checked off 31-35 after implementation and tests.
+- Implemented `pkg/help/loader/sources.go` with `ContentLoader`, JSON/SQLite/command/glazed-command loaders, JSON import helpers, and normalization utilities.
+- Implemented `pkg/help/loader/sources_test.go` covering list normalization, JSON decoding, JSON file loading, SQLite loading, command loading, and tokenization.
+- Extended `pkg/help/server/serve.go` with list-valued source flags and loader orchestration.
+- Added server tests for loader construction and command comma handling.
+- Added `pkg/doc/topics/29-serve-external-help-sources.md` and cross-references from related help docs.
+- Committed implementation and docs in two commits:
+  - `19c91f3` — `feat: load serve help from external sources`
+  - `7d70af7` — `docs: document serve external help sources`
+
+### Why
+- `--from-glazed-cmd pinocchio,sqleton,xxx` is the common user workflow; requiring full `--from-cmd "pinocchio help export --output json"` commands would make the feature annoying to use.
+- `--with-embedded=false` by default keeps external-source serving focused: asking for Pinocchio docs should not automatically mix in Glazed framework docs.
+- A dedicated loader package keeps `ServeCommand` small and makes future sources (URLs, watch mode) easier to add.
+
+### What worked
+- `go test ./pkg/help/...` passes.
+- Full pre-commit test/lint/security hooks passed during commit.
+- Manual verification passed:
+  - `glaze serve --from-glazed-cmd /tmp/glaze-serve-test --address :18117` served 71 sections.
+  - `glaze serve --from-json /tmp/one-help.json --address :18118` served exactly 1 section, confirming `--with-embedded=false` default.
+- The new help topic renders correctly with `glaze help serve-external-help-sources`.
+
+### What didn't work
+- Initial command loader normalization comma-split `--from-cmd` values, which broke commands containing JSON/commas. Fixed by adding `NormalizeCommandList`, while retaining comma splitting for paths, JSON files, SQLite files, and `--from-glazed-cmd`.
+
+### What I learned
+- The actual export JSON row field is `type`, not `section_type`, because `ExportCommand.runGlazed` emits `types.MRP("type", section.SectionType.String())`.
+- `--from-cmd` and `--from-glazed-cmd` need different normalization rules: arbitrary commands must be preserved; binary lists can be comma-split.
+- The current serve architecture made this feature straightforward because HTTP handlers only require a populated `Store`.
+
+### What was tricky to build
+- Handling both real export JSON and possible future/direct model JSON safely. The importer now accepts `type` and `section_type`, with string or numeric section types.
+- Ensuring the command loader checks process exit status and includes stderr in errors.
+
+### What warrants a second pair of eyes
+- Review the simple quote-aware command tokenizer. It avoids shell execution but may not cover every shell quoting edge case.
+- Review the decision to fail on missing section type instead of defaulting to `GeneralTopic`.
+
+### What should be done in the future
+- Add an optional `--source-timeout` flag for slow or hanging external commands.
+- Consider URL sources (`--from-json https://...`) later.
+- Consider a source manifest format for large multi-tool documentation portals.
+
+### Code review instructions
+- Start with `pkg/help/loader/sources.go`.
+- Review `DecodeSectionsJSON`, `CommandJSONLoader`, and `GlazedCommandLoader` carefully.
+- Then review `pkg/help/server/serve.go` to verify `--with-embedded=false` clears the store before loading explicit sources.
+- Run `go test ./pkg/help/...`.
+
+### Technical details
+- Implementation commit: `19c91f3`
+- Documentation commit: `7d70af7`
+- Key manual checks:
+  ```bash
+  /tmp/glaze-serve-test serve --from-glazed-cmd /tmp/glaze-serve-test --address :18117
+  curl http://127.0.0.1:18117/api/health
+  # {"ok":true,"sections":71}
+
+  /tmp/glaze-serve-test help export --slug export-help-entries --output json >/tmp/one-help.json
+  /tmp/glaze-serve-test serve --from-json /tmp/one-help.json --address :18118
+  curl http://127.0.0.1:18118/api/health
+  # {"ok":true,"sections":1}
+  ```
+
+---
+
+## Session Summary
+
+| Deliverable | Path | Status |
+|-------------|------|--------|
+| Ticket | `GLAZE-HELP-EXPORT` | ✅ Created |
+| Design Documents | `design-doc/01-design-...` + `design-doc/02-design-...` | ✅ Written |
+| Investigation Diary | `reference/01-investigation-diary.md` | ✅ Written + Updated |
+| Implementation | `pkg/help/cmd/export.go` | ✅ Committed (`391a62f`) |
+| Tests | `pkg/help/cmd/export_test.go` | ✅ Committed (`81f52fc`) |
+| Docs | `pkg/doc/topics/28-export-help-entries.md` + cross-references | ✅ Committed (`2a5603d`) |
+| File Relations | 10+ source files related | ✅ Complete |
+| Changelog | 8 entries | ✅ Updated |
+| Validation | `docmgr doctor` | ✅ Passed |
+| reMarkable Upload | `/ai/2026/04/28/GLAZE-HELP-EXPORT` | ✅ Verified |

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/reference/01-investigation-diary.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/reference/01-investigation-diary.md
@@ -756,6 +756,58 @@ This step revised the external-source design based on user feedback and implemen
 
 ---
 
+## Step 10: Address PR #558 Code Review Comments
+
+This step addressed the automated review comments on GitHub PR #558 and removed `--from-cmd` entirely as requested.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Address the code review comments from https://github.com/go-go-golems/glazed/pull/558, remove the --from-cmd entirely,"
+
+**Assistant interpretation:** The user wanted all PR review findings fixed, and explicitly wanted the arbitrary command source removed rather than adjusted.
+
+### What I did
+- Fetched PR #558 review comments with `gh`.
+- Removed `--from-cmd` from `ServeSettings`, `NewServeCommand`, loader construction, tests, and user docs.
+- Removed `CommandJSONLoader`, `NormalizeCommandList`, `runCommandForJSON`, and the quote-aware tokenizer from `pkg/help/loader/sources.go`.
+- Updated `pkg/doc/topics/29-serve-external-help-sources.md` and `design-doc/02-design-serve-external-sources.md` so supported source types are markdown paths, JSON, SQLite, and `--from-glazed-cmd` only.
+- Fixed invalid `--type` handling in `glaze help export`: unknown section types now return an explicit error instead of broadening the export.
+- Hardened `--format files` output against path traversal by validating section slugs and resolving output paths under the selected directory.
+- Added tests for invalid type errors and unsafe slug rejection.
+- Cherry-picked the fix onto the PR branch and committed: `12f0e28` — `fix: address help export and serve review feedback`.
+
+### Why
+- Arbitrary command strings do not fit safely with `fields.TypeStringList`, because the parser comma-splits values before loader code can preserve the original command.
+- Removing `--from-cmd` avoids ambiguous parsing and shell-tokenization edge cases. Users who need custom export flags can run `<binary> help export ... > file.json` and serve it with `--from-json`.
+- Path traversal and silent invalid filters are correctness/security issues in scripted export workflows.
+
+### What worked
+- `go test ./pkg/help/...` passes.
+- Pre-commit test/lint/security hooks passed on commit.
+- Manual checks confirmed `glaze serve --help` no longer exposes `--from-cmd` and invalid `--type tutorial` exits with an error.
+
+### What didn't work
+- I initially made the fix in the corporate-headquarters `main` worktree, then cherry-picked the resulting commit onto the actual PR branch worktree (`task/add-glazed-help-export`). The PR branch now has the fix as `12f0e28`.
+
+### What warrants a second pair of eyes
+- Review `safeSectionFilePath`; it intentionally rejects slugs containing `/` or `\\` rather than trying to sanitize them.
+- Verify that removing `--from-cmd` from docs is sufficient and there are no downstream examples expecting it.
+
+### Technical details
+- Review comments addressed:
+  - P1: `--from-cmd` StringList comma-splitting issue — resolved by removing `--from-cmd` entirely.
+  - P1: file export slug path traversal — resolved by `safeSectionFilePath` and tests.
+  - P2: invalid `--type` silently broadens exports — resolved by returning an explicit error.
+- Validation commands:
+  ```bash
+  go test ./pkg/help/... -count=1
+  go build -o /tmp/glaze-pr558-fix ./cmd/glaze
+  /tmp/glaze-pr558-fix serve --help | grep from-cmd  # exit 1
+  /tmp/glaze-pr558-fix help export --type tutorial --output json  # exit 1
+  ```
+
+---
+
 ## Session Summary
 
 | Deliverable | Path | Status |

--- a/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/tasks.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-EXPORT--add-glazed-help-export-verb-export-metadata-and-entries-to-disk-sqlite/tasks.md
@@ -1,0 +1,40 @@
+# Tasks
+
+## TODO
+
+- [x] Add implementation tasks to ticket
+- [x] Task 1: Create `pkg/help/cmd/export.go` — ExportCommand with tabular output (`--format glazed`)
+- [x] Define `ExportCommand` implementing `cmds.BareCommand`
+- [x] Add glazed section to schema for `--output json/csv/table/yaml` flags
+- [x] Implement `Run()` with `--format glazed` path: create processor, emit rows
+- [x] Support `--with-content` flag (default `true`)
+- [x] Support filter flags (`--type`, `--topic`, `--command`, `--flag`, `--slug`)
+- [x] Implement `buildExportPredicate` helper
+- [x] Add `AddExportCommand` helper for wiring into any binary
+- [x] Task 2: Add disk-export modes (`--format files` and `--format sqlite`)
+- [x] Implement `exportToFiles` with directory creation and markdown reconstruction
+- [x] Implement `exportToSQLite` using `store.New` and `Upsert`
+- [x] Support `--flatten` flag for files mode
+- [x] Task 3: Add unit tests
+- [x] Test tabular output with `--with-content=true` (default)
+- [x] Test tabular output with `--with-content=false`
+- [x] Test filtering by type, topic, command, flag, slug
+- [x] Test `--format files` round-trip (export then re-parse)
+- [x] Test `--format sqlite` (open DB and query)
+- [x] Task 4: Wire into `cmd/glaze/main.go`
+- [x] Find `help` subcommand and add `export` via `AddExportCommand`
+- [x] Verify `glaze help export --help` shows correct flags
+- [x] Task 5: Add documentation help section
+- [x] Create `pkg/doc/help-export.md` with usage examples
+- [x] Verify it loads into the help system
+- [x] Task 6: Validate and commit
+- [x] Run `go test ./pkg/help/cmd/...`
+- [x] Run `go run ./cmd/glaze help export --help`
+- [x] Manual verification checklist
+- [x] Commit each task separately
+- [x] Task 31: Update serve external sources design review: add --from-glazed-cmd and --with-embedded=false default
+- [x] Task 32: Implement robust JSON section import for real help export rows (type/section_type compatibility)
+- [x] Task 33: Implement ContentLoader source loaders for markdown paths, JSON, SQLite, arbitrary command, and glazed command shorthand
+- [x] Task 34: Extend ServeCommand flags/settings/run flow with --from-json, --from-sqlite, --from-cmd, --from-glazed-cmd, --with-embedded=false
+- [x] Task 35: Add unit/integration tests for loaders and ServeCommand source loading
+- [x] Task 36: Update docs/diary/changelog, validate, commit, and upload updated bundle to reMarkable

--- a/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/README.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/README.md
@@ -1,0 +1,21 @@
+# Enhance Glazed Help Web Server: Full-Featured Browser with Advanced Search, Cross-References, and Offline Support
+
+This is the document workspace for ticket GLAZE-HELP-WEB.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GLAZE-HELP-WEB --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GLAZE-HELP-WEB --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GLAZE-HELP-WEB --field Status --value review`

--- a/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/changelog.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/changelog.md
@@ -1,0 +1,51 @@
+# Changelog
+
+## 2026-04-28
+
+- Initial workspace created
+
+
+## 2026-04-28
+
+Step 1: Initialized ticket and created design-doc and diary documents
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-glazed-help-export/glazed/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/design-doc/01-design-glazed-help-web-server-enhancement-full-featured-browser-with-screens-and-user-stories.md — Created design document
+
+
+## 2026-04-28
+
+Step 2: Explored existing web stack (Go server, React SPA, TUI)
+
+### Related Files
+
+- /home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go — Explored server architecture
+
+
+## 2026-04-28
+
+Step 3: Wrote comprehensive design document with user stories, ASCII mockups, API enhancements, and implementation phases
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-glazed-help-export/glazed/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/design-doc/01-design-glazed-help-web-server-enhancement-full-featured-browser-with-screens-and-user-stories.md — Completed design doc
+
+
+## 2026-04-28
+
+Step 4: Validated docs with docmgr doctor and uploaded bundle to reMarkable
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-glazed-help-export/glazed/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/design-doc/01-design-glazed-help-web-server-enhancement-full-featured-browser-with-screens-and-user-stories.md — Final delivery
+
+
+## 2026-04-28
+
+Step 4: Added Appendix A — complete React component hierarchy with props, CSS parts, and state for designer reference
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-glazed-help-export/glazed/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/design-doc/01-design-glazed-help-web-server-enhancement-full-featured-browser-with-screens-and-user-stories.md — Added component hierarchy appendix
+

--- a/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/design-doc/01-design-glazed-help-web-server-enhancement-full-featured-browser-with-screens-and-user-stories.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/design-doc/01-design-glazed-help-web-server-enhancement-full-featured-browser-with-screens-and-user-stories.md
@@ -1,0 +1,1759 @@
+---
+Title: 'Design: Glazed Help Web Server Enhancement — Full-Featured Browser with Screens and User Stories'
+Ticket: GLAZE-HELP-WEB
+Status: active
+Topics:
+    - glazed
+    - help-system
+    - web
+    - react
+    - server
+    - ui
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/server/handlers.go
+      Note: API route handlers
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go
+      Note: HTTP server command and handler composition
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/server/types.go
+      Note: Request/response types
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/ui/model.go
+      Note: TUI model for feature parity benchmark
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/web/static.go
+      Note: SPA static file handler
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/web/src/App.tsx
+      Note: Root React component
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/web/src/services/api.ts
+      Note: RTK Query API slice
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T08:00:00-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+
+
+
+
+
+
+# Design: Glazed Help Web Server Enhancement
+
+## Executive Summary
+
+This document describes the design for enhancing the Glazed help web server from its current minimal state into a **full-featured help browser**. The existing `glaze serve-help` command already starts an HTTP server and serves a React SPA, but the frontend is basic: a searchable sidebar list and a markdown content viewer. This design adds advanced search, cross-references, topic browsing, command coverage maps, and offline support — turning the help browser into a genuine documentation platform.
+
+The enhancements are organized around **user stories** derived from real use cases, then translated into **screen designs** with ASCII mockups, **API contracts**, and an **implementation plan**. The document is written for a new intern and explains every part of the system from first principles.
+
+---
+
+## Problem Statement and Scope
+
+### What exists today?
+
+The Glazed help system provides three ways to consume documentation:
+
+1. **Terminal:** `glaze help <topic>`, `glaze help --ui` (Bubble Tea TUI)
+2. **HTTP server:** `glaze serve-help` (React SPA at `localhost:8088`)
+3. **Static export:** `glaze render-site` (static SPA files for hosting)
+
+The web frontend (React) currently supports:
+- Sidebar list of all sections with search filtering
+- Type filter buttons (All, Topic, Example, App, Tutorial)
+- Click-to-view markdown content rendering
+- Client-side routing (`#/sections/:slug`)
+- Server API: `GET /api/health`, `GET /api/sections`, `GET /api/sections/:slug`
+
+### What is missing?
+
+While functional, the current web browser is a **read-only list viewer**. It lacks the affordances users expect from modern documentation platforms:
+
+- **No full-text search.** The search box only filters the already-loaded list by title, short description, topics, and slug. It does not search the body content.
+- **No cross-references.** When reading about `json` command help, there is no "See Also" list linking to related topics, examples, or tutorials.
+- **No topic browsing.** Users cannot explore all sections tagged with `database` or see a tag cloud.
+- **No command coverage map.** There is no way to see which commands have documentation and which do not.
+- **No DSL query support.** The terminal TUI supports the Glazed query DSL (`type:example AND topic:database`), but the web UI does not.
+- **No deep linking to anchors.** URLs only go to sections, not to headings within sections.
+- **No offline support.** The SPA requires a live server (or pre-built static JSON). There is no service worker caching.
+- **No print/export from the browser.** Users cannot download a section as PDF or print a formatted page.
+- **No dark mode or accessibility features.** The retro styling is fun but lacks contrast modes and keyboard navigation.
+
+### Scope of this ticket
+
+This ticket covers the **design and phased implementation** of the following enhancements:
+
+1. **Enhanced Search** — Full-text search over content, with highlighting and query DSL support.
+2. **Cross-Reference Panel** — "See Also" sidebar showing related sections by topic, command, and flag.
+3. **Topic Browser** — Dedicated topic/tag exploration screen with a tag cloud.
+4. **Command Coverage Map** — Dashboard showing which CLI commands have help coverage.
+5. **Deep Linking** — Hash-based anchor links to headings within sections.
+6. **Offline Support** — Service worker with cache-first strategy for static assets and JSON data.
+7. **Print/Export** — Browser-native print styles and "Download as Markdown" button.
+8. **Accessibility & Theming** — Keyboard shortcuts, focus management, and dark mode toggle.
+
+### Out of scope
+
+- Rewriting the Go backend storage layer (the existing `store.Store` is sufficient).
+- Replacing the TUI (`glaze help --ui`) — it remains a separate interface.
+- Multi-language i18n support.
+- User authentication or edit-in-browser.
+
+---
+
+## Current-State Architecture
+
+Before designing enhancements, we must understand the existing stack. This section explains every layer.
+
+### Layer 1: The Go HTTP Server
+
+The `glaze serve-help` command starts an HTTP server with two routes:
+
+```
+GET /api/*   → REST API (JSON)
+GET /*       → React SPA (index.html + static assets)
+```
+
+**File reference:** `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go`
+
+The server is created by `NewServeCommand`, which implements `cmds.BareCommand`. It:
+1. Loads help sections into the `HelpSystem` store (embedded docs by default, or from explicit paths).
+2. Creates an `http.Handler` that multiplexes `/api` to the API handler and everything else to the SPA handler.
+3. Listens on `:8088` (configurable via `--address`).
+
+**Key code:**
+```go
+func NewServeHandler(deps HandlerDeps, spaHandler http.Handler) http.Handler {
+    apiHandler := NewHandler(deps)
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        cleanPath := stdpath.Clean("/" + r.URL.Path)
+        if strings.HasPrefix(cleanPath, "/api/") {
+            apiHandler.ServeHTTP(w, r)
+            return
+        }
+        spaHandler.ServeHTTP(w, r)
+    })
+}
+```
+
+### Layer 2: The REST API
+
+The API is defined in `pkg/help/server/handlers.go` and `types.go`.
+
+**Endpoints:**
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/health` | GET | Health check + section count |
+| `/api/sections` | GET | List all sections (summary shape) |
+| `/api/sections/search` | GET | Search sections (same as `/api/sections` with `?q=...`) |
+| `/api/sections/:slug` | GET | Get one section (full detail shape) |
+
+**Response types:**
+
+```go
+// SectionSummary — list results
+type SectionSummary struct {
+    ID         int64    `json:"id"`
+    Slug       string   `json:"slug"`
+    Type       string   `json:"type"`       // "GeneralTopic" | "Example" | ...
+    Title      string   `json:"title"`
+    Short      string   `json:"short"`
+    Topics     []string `json:"topics"`
+    IsTopLevel bool     `json:"isTopLevel"`
+}
+
+// SectionDetail — full content
+type SectionDetail struct {
+    ID         int64    `json:"id"`
+    Slug       string   `json:"slug"`
+    Type       string   `json:"type"`
+    Title      string   `json:"title"`
+    Short      string   `json:"short"`
+    Topics     []string `json:"topics"`
+    Flags      []string `json:"flags"`
+    Commands   []string `json:"commands"`
+    IsTopLevel bool     `json:"isTopLevel"`
+    Content    string   `json:"content"`    // Full markdown body
+}
+```
+
+**File references:**
+- `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/handlers.go`
+- `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/types.go`
+
+### Layer 3: The React SPA
+
+The frontend is a Vite + React + TypeScript application located at `/home/manuel/code/wesen/corporate-headquarters/glazed/web/`.
+
+**Tech stack:**
+- **Build tool:** Vite (with `@vitejs/plugin-react`)
+- **Router:** `react-router-dom` (HashRouter — `HashRouter` means routes use `#/sections/slug` instead of `/sections/slug`, which avoids needing server-side route fallback)
+- **State management:** Redux Toolkit + RTK Query (for API caching)
+- **Styling:** CSS with data-part attributes (BEM-like naming without classes)
+- **Markdown rendering:** Custom `MarkdownContent` component
+
+**File references:**
+- Entry: `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/main.tsx`
+- Root component: `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/App.tsx`
+- API layer: `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/services/api.ts`
+- Store: `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/store.ts`
+- Types: `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/types/index.ts`
+
+**Component inventory:**
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| `AppLayout` | `components/AppLayout/AppLayout.tsx` | Two-pane layout (sidebar + content) |
+| `TitleBar` | `components/TitleBar/TitleBar.tsx` | Header bar with title |
+| `MenuBar` | `components/MenuBar/MenuBar.tsx` | Retro menu bar (File, Edit, View, Help) |
+| `SearchBar` | `components/SearchBar/SearchBar.tsx` | Text input with magnifying glass icon |
+| `TypeFilter` | `components/TypeFilter/TypeFilter.tsx` | Row of filter buttons |
+| `SectionList` | `components/SectionList/SectionList.tsx` | Scrollable list of `SectionCard` |
+| `SectionCard` | `components/SectionList/SectionCard.tsx` | Clickable summary with badge and title |
+| `SectionView` | `components/SectionView/SectionView.tsx` | Full section rendering |
+| `SectionHeader` | `components/SectionView/SectionHeader.tsx` | Title, slug, tags |
+| `MarkdownContent` | `components/Markdown/MarkdownContent.tsx` | Markdown body renderer |
+| `EmptyState` | `components/EmptyState/EmptyState.tsx` | Placeholder when no section selected |
+| `StatusBar` | `components/StatusBar/StatusBar.tsx` | Footer with result count |
+| `Badge` | `components/Badge/Badge.tsx` | Small pill labels for type/topic/command/flag |
+
+### Layer 4: The TUI (Terminal UI)
+
+For comparison, the terminal UI (`glaze help --ui`) provides:
+- Real-time search with DSL support
+- Glamour-rendered markdown
+- Clipboard copy (`y`)
+- Keyboard shortcuts (`/` search, `?` help, `ctrl+h` DSL cheatsheet)
+
+**File reference:** `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/ui/model.go`
+
+The TUI is richer in some ways (DSL search, clipboard) but lacks the spatial layout and hyperlinking of a web browser.
+
+### Architecture Diagram (Current State)
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         User Interaction                                 │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────────────────┐ │
+│  │ Terminal    │  │ Browser     │  │ Static Site (render-site)       │ │
+│  │ glaze help  │  │ localhost   │  │ HTML + JSON files               │ │
+│  │ --ui        │  │ :8088       │  │ (no live server)                │ │
+│  └──────┬──────┘  └──────┬──────┘  └─────────────────────────────────┘ │
+│         │                │                                             │
+│         ▼                ▼                                             │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │                        help.HelpSystem                            │  │
+│  │  ┌─────────────────────────────────────────────────────────────┐ │  │
+│  │  │                      store.Store                             │ │  │
+│  │  │  (SQLite — sections table with full-text search optional)    │ │  │
+│  │  └─────────────────────────────────────────────────────────────┘ │  │
+│  └──────────────────────────────────────────────────────────────────┘  │
+│         │                           │                                   │
+│         ▼                           ▼                                   │
+│  ┌──────────────┐          ┌──────────────────┐                        │
+│  │ Bubble Tea   │          │ Go HTTP Server   │                        │
+│  │ TUI Model    │          │ (pkg/help/server)│                        │
+│  │ (pkg/help/ui)│          │                  │                        │
+│  └──────────────┘          │  /api/health     │                        │
+│                            │  /api/sections   │                        │
+│                            │  /api/sections/  │                        │
+│                            │    :slug         │                        │
+│                            └────────┬─────────┘                        │
+│                                     │                                  │
+│                                     ▼                                  │
+│                            ┌──────────────────┐                        │
+│                            │ React SPA        │                        │
+│                            │ (web/src/App.tsx)│                        │
+│                            │                  │                        │
+│                            │  Sidebar (list)  │                        │
+│                            │  Content (view)  │                        │
+│                            └──────────────────┘                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Appendix A: Current React Component Hierarchy (Designer Reference)
+
+This appendix is a **complete inventory of the current React component tree** for the Glazed Help Browser web app. It is intended as a starting point for web designers: every component is listed with its props, state dependencies (hooks / Redux), CSS `data-part` attributes, and file location. Use this to understand the layout before proposing redesigns.
+
+### High-Level Layout
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  MenuBar (decorative)                                                       │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─ Sidebar (280px) ──────────────────────┐  ┌─ Content ──────────────────┐  │
+│  │                                         │  │                           │  │
+│  │  TitleBar("📁 Sections")                │  │  TitleBar("📄 Doc...")    │  │
+│  │  ┌─ SearchBar ──────────────────────┐   │  │                           │  │
+│  │  │ 🔍  [Search input]               │   │  │  Loading / Error /        │  │
+│  │  └─────────────────────────────────┘   │  │  SectionView / EmptyState   │  │
+│  │  [All][Topic][Example][App][Tut]       │  │                           │  │
+│  │                                         │  │                           │  │
+│  │  SectionList                            │  │                           │  │
+│  │  ├─ SectionCard (active)                │  │                           │  │
+│  │  ├─ SectionCard                         │  │                           │  │
+│  │  └─ ...                                 │  │                           │  │
+│  │                                         │  │                           │  │
+│  │  StatusBar("24 sections")               │  │                           │  │
+│  │                                         │  │                           │  │
+│  └─────────────────────────────────────────┘  └───────────────────────────┘  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Component Tree (Hierarchical)
+
+```
+App (root)
+├── MenuBar (not currently rendered in App.tsx, but exists)
+└── AppLayout
+    ├── sidebar (prop: ReactNode)
+    │   ├── TitleBar
+    │   ├── <div> — search + filter wrapper
+    │   │   ├── SearchBar
+    │   │   └── TypeFilter
+    │   ├── SectionList
+    │   │   └── SectionCard[]
+    │   │       └── Badge (inside each card)
+    │   └── StatusBar
+    └── content (prop: ReactNode)
+        ├── TitleBar
+        ├── Loading placeholder (inline)
+        ├── Error placeholder (inline)
+        ├── SectionView (conditionally rendered)
+        │   ├── SectionHeader
+        │   │   └── Badge[]
+        │   └── MarkdownContent
+        └── EmptyState (conditionally rendered)
+```
+
+---
+
+### Component Inventory
+
+#### `App` — Root Component
+
+**File:** `web/src/App.tsx`
+
+**Local State (useState):**
+| State | Type | Initial | Purpose |
+|-------|------|---------|---------|
+| `search` | `string` | `''` | Search query text |
+| `filter` | `FilterValue` | `'All'` | Active type filter |
+
+**Router Hooks:**
+- `useLocation()` — to read current URL and extract active slug
+- `useNavigate()` — to push `#/sections/:slug` on selection
+- `matchPath('/sections/:slug', location.pathname)` — parses active slug
+
+**RTK Query Hooks:**
+| Hook | Data | Purpose |
+|------|------|---------|
+| `useListSectionsQuery()` | `ListSectionsResponse` | Load all section summaries |
+| `useGetSectionQuery(slug, { skip })` | `SectionDetail` | Load full content for active section |
+
+**Computed:**
+- `activeSlug: string | null` — extracted from URL
+- `filtered: SectionSummary[]` — client-side filter by `filter` + `search`
+
+**Callback:**
+- `handleSelect(slug: string)` — navigates to `#/sections/${slug}`
+
+**Layout:** Renders `AppLayout` with `sidebar` and `content` props.
+
+---
+
+#### `AppLayout` — Two-Pane Layout Container
+
+**File:** `web/src/components/AppLayout/AppLayout.tsx`
+
+**Props:**
+| Prop | Type | Description |
+|------|------|-------------|
+| `sidebar` | `ReactNode` | Left pane content (sidebar) |
+| `content` | `ReactNode` | Right pane content (main view) |
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `app-layout` | `[data-part='app-layout']` | `display: flex`, `flex: 1`, `padding: 8px`, `gap: 1px` |
+| `app-layout-sidebar` | `[data-part='app-layout-sidebar']` | `width: 280px`, `border: 2px solid #000`, `box-shadow: 2px 2px 0 #000` |
+| `app-layout-content` | `[data-part='app-layout-content']` | `flex: 1`, `border: 2px solid #000`, `box-shadow: 2px 2px 0 #000` |
+
+**CSS File:** `web/src/components/AppLayout/styles/app-layout.css`
+
+---
+
+#### `MenuBar` — Retro Menu Bar (Decorative)
+
+**File:** `web/src/components/MenuBar/MenuBar.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | `'Glazed Help Browser'` | App title shown at right |
+
+**Static Items:** `['File', 'Edit', 'View', 'Help']` + Apple logo (``)
+
+**Note:** Currently **not rendered** in `App.tsx`. It exists as a component but is unused. The design proposes making it functional (View → Dark Mode, etc.).
+
+**CSS `data-part` attributes:**
+| Part | Selector |
+|------|----------|
+| `menubar` | `[data-part='menubar']` |
+| `menubar-item` | `[data-part='menubar-item']` |
+| `menubar-apple` | `[data-part='menubar-apple']` |
+| `menubar-title` | `[data-part='menubar-title']` |
+
+**CSS File:** `web/src/components/MenuBar/styles/menubar.css`
+
+---
+
+#### `TitleBar` — Window Title Bar
+
+**File:** `web/src/components/TitleBar/TitleBar.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | (required) | Centered title text |
+| `icon` | `React.ReactNode` | `undefined` | Optional icon in left box |
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `titlebar` | `[data-part='titlebar']` | `height: 22px`, `border-bottom: 2px solid #000` |
+| `titlebar-icon` | `[data-part='titlebar-icon']` | `width: 20px`, `border-right: 2px solid #000` |
+| `titlebar-icon-box` | `[data-part='titlebar-icon-box']` | `11px × 11px` square box |
+| `titlebar-ruler` | `[data-part='titlebar-ruler']` | Flex container with stripe lines |
+| `titlebar-stripe` | `[data-part='titlebar-stripe']` | 1px black horizontal stripe pattern |
+| `titlebar-title` | `[data-part='titlebar-title']` | `font-size: 12px`, `font-weight: 700` |
+
+**CSS File:** `web/src/components/TitleBar/styles/titlebar.css`
+
+---
+
+#### `SearchBar` — Search Input
+
+**File:** `web/src/components/SearchBar/SearchBar.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `string` | (required) | Current search text |
+| `onChange` | `(value: string) => void` | (required) | Called on every keystroke |
+| `placeholder` | `string` | `'Search…'` | Input placeholder |
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `searchbar` | `[data-part='searchbar']` | `border: 2px inset #999` |
+| `searchbar-icon` | `[data-part='searchbar-icon']` | Magnifying glass emoji, `padding: 0 6px` |
+| `searchbar-input` | `[data-part='searchbar-input']` | `border: none`, `outline: none`, `font-size: 12px` |
+
+**CSS File:** `web/src/components/SearchBar/styles/searchbar.css`
+
+---
+
+#### `TypeFilter` — Section Type Filter Buttons
+
+**File:** `web/src/components/TypeFilter/TypeFilter.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `FilterValue` | (required) | Currently selected filter |
+| `onChange` | `(value: FilterValue) => void` | (required) | Called when a button is clicked |
+
+**Filter Values:** `'All' | 'GeneralTopic' | 'Example' | 'Application' | 'Tutorial'`
+
+**Button Labels:**
+| Value | Label |
+|-------|-------|
+| `All` | All |
+| `GeneralTopic` | Topic |
+| `Example` | Example |
+| `Application` | App |
+| `Tutorial` | Tutorial |
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `typefilter` | `[data-part='typefilter']` | `display: flex`, `gap: 4px` |
+| `typefilter-button` | `[data-part='typefilter-button']` | `padding: 2px 8px`, `font-size: 10px`, `border: 1px solid #999` |
+
+**Active State:** `[aria-pressed='true']` → `font-weight: 700`, `border: 2px solid #000`, `background: #000`, `color: #fff`
+
+**CSS File:** `web/src/components/TypeFilter/styles/typefilter.css`
+
+---
+
+#### `SectionList` — Scrollable List Container
+
+**File:** `web/src/components/SectionList/SectionList.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `sections` | `SectionSummary[]` | (required) | Array of sections to display |
+| `activeSlug` | `string \| null` | (required) | Currently selected slug (for highlighting) |
+| `onSelect` | `(slug: string) => void` | (required) | Called when a card is clicked |
+
+**Renders:** `SectionCard` for each section in `sections`.
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `section-list` | `[data-part~='section-list']` | `flex: 1`, `overflow-y: auto` |
+| `section-list-item` | `[data-part~='section-list-item']` | Individual card wrapper |
+
+**CSS File:** `web/src/components/SectionList/styles/section-list.css`
+
+---
+
+#### `SectionCard` — Individual Section Summary Card
+
+**File:** `web/src/components/SectionList/SectionCard.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `section` | `SectionSummary` | (required) | Section data to display |
+| `isActive` | `boolean` | (required) | Whether this card is selected |
+| `onClick` | `() => void` | (required) | Click handler |
+
+**Displays:**
+- Type `Badge` (top-left)
+- `◆ TOP` indicator (if `section.isTopLevel`)
+- Title (`stripMarkdown(section.title)`)
+- Short description (`stripMarkdown(section.short)`, clamped to 2 lines)
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `section-card` | `[data-part~='section-card']` | Card root (combined with `section-list-item`) |
+| `section-card-meta` | `[data-part~='section-card-meta']` | Badge row, `display: flex`, `gap: 6px` |
+| `section-card-top-badge` | `[data-part~='section-card-top-badge']` | `◆ TOP` text, `font-size: 9px`, `color: #999` |
+| `section-card-title` | `[data-part~='section-card-title']` | `font-weight: 700`, `font-size: 12px` |
+| `section-card-short` | `[data-part~='section-card-short']` | `font-size: 10px`, `color: #777`, 2-line clamp |
+
+**Active State:** `[aria-selected='true']` → `background: #000`, `color: #fff`
+
+**Odd rows:** `:nth-child(odd)` → `background: #f5f5f5`
+
+**CSS File:** `web/src/components/SectionList/styles/section-list.css`
+
+---
+
+#### `StatusBar` — Footer Count Bar
+
+**File:** `web/src/components/StatusBar/StatusBar.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `count` | `number` | (required) | Number of sections shown |
+| `version` | `string` | `'v0.1'` | Version string (right side) |
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `statusbar` | `[data-part='statusbar']` | `border-top: 2px solid #000`, `padding: 5px 10px`, `display: flex`, `justify-content: space-between` |
+| `statusbar-count` | `[data-part='statusbar-count']` | `font-size: 10px` |
+| `statusbar-version` | `[data-part='statusbar-version']` | `font-size: 10px` |
+
+**CSS File:** `web/src/components/StatusBar/styles/statusbar.css`
+
+---
+
+#### `SectionView` — Full Section Content Viewer
+
+**File:** `web/src/components/SectionView/SectionView.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `section` | `SectionDetail` | (required) | Full section data (including `content`) |
+
+**Renders:**
+- `SectionHeader` (title, slug, tags)
+- `MarkdownContent` (rendered markdown body)
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `section-view` | `[data-part='section-view']` | `max-width: 680px`, `margin: 0 auto`, `padding: 28px 32px 60px` |
+| `section-view-body` | `[data-part='section-view-body']` | `border-top: 2px solid #000`, `padding-top: 20px` |
+
+**CSS File:** `web/src/components/SectionView/styles/section-view.css`
+
+---
+
+#### `SectionHeader` — Title, Slug, and Tag Badges
+
+**File:** `web/src/components/SectionView/SectionHeader.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `section` | `SectionDetail` | (required) | Full section data |
+
+**Displays:**
+- Slug (monospace pill: `section.slug`)
+- Title (`h1`: `section.title`)
+- Short description (`p`: `section.short`)
+- Tags: type `Badge`, topic `Badge`s, command `Badge`s, flag `Badge`s
+- Flags are capped at 4 visible + `+N` overflow indicator
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `section-header` | `[data-part='section-header']` | `margin-bottom: 24px` |
+| `section-header-slug` | `[data-part='section-header-slug']` | `font-size: 10px`, `font-family: var(--font-mono)`, `background: #f0f0f0`, `border: 1px solid #ccc` |
+| `section-header-heading` | `[data-part='section-header-heading']` | `font-size: 24px`, `font-weight: 700` |
+| `section-header-subtitle` | `[data-part='section-header-subtitle']` | `font-size: 12px`, `color: #555` |
+| `section-header-tags` | `[data-part='section-header-tags']` | `display: flex`, `gap: 5px`, `flex-wrap: wrap` |
+
+**CSS File:** `web/src/components/SectionView/styles/section-view.css`
+
+---
+
+#### `MarkdownContent` — Markdown Renderer
+
+**File:** `web/src/components/Markdown/MarkdownContent.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `content` | `string` | (required) | Raw markdown string |
+
+**Renderer:** `react-markdown` with `remark-gfm` plugin (GitHub Flavored Markdown).
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `markdown-content` | `[data-part='markdown-content']` | None (inherits from `section-view`) |
+
+**CSS File:** `web/src/components/Markdown/styles/markdown.css`
+
+---
+
+#### `EmptyState` — Placeholder When No Section Selected
+
+**File:** `web/src/components/EmptyState/EmptyState.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | `'Select a section from the list.'` | Placeholder text |
+
+**Displays:** Open book emoji (`📖`) + label text.
+
+**CSS `data-part` attributes:**
+| Part | Selector |
+|------|----------|
+| `empty-state` | `[data-part='empty-state']` |
+| `empty-state-icon` | `[data-part='empty-state-icon']` |
+| `empty-state-label` | `[data-part='empty-state-label']` |
+
+**CSS File:** `web/src/components/EmptyState/styles/empty-state.css`
+
+---
+
+#### `Badge` — Coloured Tag Pill
+
+**File:** `web/src/components/Badge/Badge.tsx`
+
+**Props:**
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `text` | `string` | (required) | Label text |
+| `variant` | `BadgeVariant` | `'topic'` | `'type' \| 'topic' \| 'command' \| 'flag'` |
+
+**Type Badge Colours:**
+| Section Type | Label | Color |
+|--------------|-------|-------|
+| `GeneralTopic` | Topic | `#4a7c59` |
+| `Example` | Example | `#b8860b` |
+| `Application` | App | `#4a6a8c` |
+| `Tutorial` | Tutorial | `#8c4a6a` |
+
+**Other Variant Colours:**
+| Variant | Color |
+|---------|-------|
+| `topic` | `#000` |
+| `command` | `#4a7c59` |
+| `flag` | `#8c4a6a` |
+
+**CSS `data-part` attributes:**
+| Part | Selector | Styles |
+|------|----------|--------|
+| `badge` | `[data-part='badge']` | `display: inline-block`, `padding: 1px 7px`, `border: 1.5px solid var(--badge-color)`, `border-radius: 2px`, `font-size: 10px` |
+
+**CSS Variables:** `--badge-color`, `--badge-weight`
+
+**CSS File:** `web/src/components/Badge/styles/badge.css`
+
+---
+
+### State Management (Redux / RTK Query)
+
+**Store File:** `web/src/store.ts`
+
+**Current Slices:**
+| Slice | Reducer Path | Purpose |
+|-------|-------------|---------|
+| `helpApi` | `'helpApi'` | RTK Query auto-generated reducer for API caching |
+
+**No custom slices exist yet.** The design proposes adding:
+- `uiSlice` — dark mode, sidebar visibility, active screen
+- `searchSlice` — query string, search history, active filters
+- `offlineSlice` — cached section IDs, sync status
+
+**API Endpoints (RTK Query):**
+| Endpoint | Hook | Returns | Cache Tags |
+|----------|------|---------|------------|
+| `GET /api/health` | `useHealthCheckQuery` | `HealthResponse` | — |
+| `GET /api/sections` | `useListSectionsQuery` | `ListSectionsResponse` | `Section` list + per-slug |
+| `GET /api/sections/:slug` | `useGetSectionQuery` | `SectionDetail` | `Section:{slug}` |
+
+**API File:** `web/src/services/api.ts`
+
+---
+
+### TypeScript Data Types
+
+**File:** `web/src/types/index.ts`
+
+```typescript
+interface SectionSummary {
+  id: number;
+  slug: string;
+  type: string;        // "GeneralTopic" | "Example" | "Application" | "Tutorial"
+  title: string;
+  short: string;
+  topics: string[];
+  isTopLevel: boolean;
+}
+
+interface SectionDetail extends SectionSummary {
+  flags: string[];
+  commands: string[];
+  content: string;     // Full markdown body
+}
+
+interface ListSectionsResponse {
+  sections: SectionSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+interface HealthResponse {
+  ok: boolean;
+  sections: number;
+}
+
+type SectionType = 'GeneralTopic' | 'Example' | 'Application' | 'Tutorial';
+type FilterValue = 'All' | SectionType;
+```
+
+---
+
+### Global CSS Variables and Theme
+
+**File:** `web/src/styles/global.css`
+
+**Layout Variables:**
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `--layout-sidebar-width` | `280px` | Sidebar fixed width |
+
+**Typography Variables:**
+| Variable | Value |
+|----------|-------|
+| `--font-ui` | `'Chicago_', 'Geneva', 'Charcoal', 'Lucida Grande', 'Helvetica Neue', sans-serif` |
+| `--font-mono` | `'Monaco', 'Courier New', monospace` |
+| `--font-size-sm` | `11px` |
+| `--font-size-base` | `13px` |
+| `--font-size-lg` | `15px` |
+| `--font-size-xl` | `18px` |
+
+**Color Variables:**
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `--color-bg` | `#ffffff` | Page background |
+| `--color-fg` | `#000000` | Text color |
+| `--color-sidebar-bg` | `#ffffff` | Sidebar background |
+| `--color-sidebar-fg` | `#000000` | Sidebar text |
+| `--color-accent` | `#000000` | Accent / selection |
+| `--color-border` | `#000000` | Borders |
+| `--color-selection-bg` | `#000000` | Selection background |
+| `--color-selection-fg` | `#ffffff` | Selection text |
+
+**Aesthetic:** Classic Mac / System 7. Background is a grey dot pattern (`#a8a8a8` with 2px black dots). Windows have thick black borders (`2px solid #000`) and hard drop shadows (`box-shadow: 2px 2px 0 #000`).
+
+---
+
+### File Tree (Web Frontend)
+
+```
+web/src/
+├── main.tsx                 # Entry point: ReactDOM.createRoot + HashRouter + Provider
+├── App.tsx                  # Root component: state, filtering, layout wiring
+├── store.ts                 # Redux store: RTK Query reducer only
+├── styles/
+│   └── global.css           # CSS variables, resets, scrollbar, selection styles
+├── types/
+│   └── index.ts             # TypeScript interfaces mirroring Go types
+├── services/
+│   └── api.ts               # RTK Query API slice (3 endpoints)
+├── components/
+│   ├── AppLayout/
+│   │   ├── AppLayout.tsx    # Two-pane layout container
+│   │   ├── parts.ts         # data-part constants
+│   │   └── styles/
+│   │       └── app-layout.css
+│   ├── TitleBar/
+│   │   ├── TitleBar.tsx     # Window title bar with stripes
+│   │   ├── parts.ts
+│   │   └── styles/
+│   │       └── titlebar.css
+│   ├── MenuBar/
+│   │   ├── MenuBar.tsx      # Retro menu bar (decorative, unused)
+│   │   ├── parts.ts
+│   │   └── styles/
+│   │       └── menubar.css
+│   ├── SearchBar/
+│   │   ├── SearchBar.tsx    # Search input with magnifying glass
+│   │   ├── parts.ts
+│   │   └── styles/
+│   │       └── searchbar.css
+│   ├── TypeFilter/
+│   │   ├── TypeFilter.tsx   # Filter button row
+│   │   ├── parts.ts
+│   │   └── styles/
+│   │       └── typefilter.css
+│   ├── SectionList/
+│   │   ├── SectionList.tsx  # Scrollable list container
+│   │   ├── SectionCard.tsx  # Individual card
+│   │   ├── parts.ts
+│   │   └── styles/
+│   │       └── section-list.css
+│   ├── SectionView/
+│   │   ├── SectionView.tsx  # Full content viewer
+│   │   ├── SectionHeader.tsx # Title, slug, tags
+│   │   ├── parts.ts
+│   │   └── styles/
+│   │       └── section-view.css
+│   ├── Markdown/
+│   │   ├── MarkdownContent.tsx # react-markdown wrapper
+│   │   ├── parts.ts
+│   │   └── styles/
+│   │       └── markdown.css
+│   ├── EmptyState/
+│   │   ├── EmptyState.tsx   # Placeholder when nothing selected
+│   │   ├── parts.ts
+│   │   └── styles/
+│   │       └── empty-state.css
+│   ├── StatusBar/
+│   │   ├── StatusBar.tsx    # Bottom count bar
+│   │   ├── parts.ts
+│   │   └── styles/
+│   │       └── statusbar.css
+│   └── Badge/
+│       ├── Badge.tsx        # Coloured tag pill
+│       ├── parts.ts
+│       └── styles/
+│           └── badge.css
+```
+
+---
+
+## Needs and Affordances Analysis
+
+An **affordance** is what a user interface "offers" — what actions it makes possible. This section lists every need we want the help browser to serve, then maps each need to concrete affordances.
+
+### Need 1: Find Information Quickly
+
+**User goal:** "I need to learn about the `json` command's output flags."
+
+**Current affordances:**
+- Terminal: `glaze help --query "json AND flag:output"` or `glaze help json`
+- Web: Type "json" in search box, scroll list, click section
+
+**Missing affordances:**
+- Full-text search inside markdown content (not just titles/topics)
+- Search result snippets showing context around matches
+- Keyboard shortcut (`/`) to focus search from anywhere
+- Search history / recent queries
+
+### Need 2: Explore Related Content
+
+**User goal:** "I'm reading about `json` command help. What examples exist? What tutorials?"
+
+**Current affordances:**
+- Terminal: None (must run new queries)
+- Web: None (must manually search)
+
+**Missing affordances:**
+- "See Also" panel showing sections with overlapping topics/commands/flags
+- Bidirectional cross-references (if A links to B, B knows about A)
+- Topic cluster visualization
+
+### Need 3: Browse by Category
+
+**User goal:** "Show me all tutorials." or "Show me everything about `database`."
+
+**Current affordances:**
+- Terminal: `glaze help --tutorials` or `glaze help --topic database`
+- Web: Type filter buttons (Topic, Example, App, Tutorial) — but only one at a time, and no topic browsing
+
+**Missing affordances:**
+- Topic index page with tag cloud
+- Multi-select type filtering (e.g., "Examples AND Tutorials")
+- Hierarchical topic browsing
+
+### Need 4: Assess Documentation Coverage
+
+**User goal:** "As a maintainer, I want to see which commands lack help sections."
+
+**Current affordances:**
+- None
+
+**Missing affordances:**
+- Coverage dashboard showing commands vs. documented commands
+- Coverage percentage by section type
+- "Undocumented commands" list
+
+### Need 5: Read Comfortably
+
+**User goal:** "I'm reading a long tutorial on my laptop at night."
+
+**Current affordances:**
+- Web: Basic markdown rendering
+
+**Missing affordances:**
+- Dark mode toggle
+- Font size adjustment
+- Table of contents for long sections
+- Anchor links to headings
+- Print-friendly layout
+
+### Need 6: Access Documentation Offline
+
+**User goal:** "I'm on a plane and need to refer to the glazed docs."
+
+**Current affordances:**
+- Static export (`render-site`) works offline if files are saved locally
+- Live server (`serve-help`) requires network
+
+**Missing affordances:**
+- Service worker caching all sections after first visit
+- "Save for offline" per-section toggle
+- Offline indicator when disconnected
+
+### Need 7: Share and Reference
+
+**User goal:** "I want to send a link to a specific paragraph in the docs."
+
+**Current affordances:**
+- Web: Links to sections (`#/sections/help-system`)
+
+**Missing affordances:**
+- Anchor links to headings within sections (`#/sections/help-system#query-dsl`)
+- Copy-link-to-heading button on hover
+- Social sharing metadata (OpenGraph tags)
+
+### Need 8: Export from the Browser
+
+**User goal:** "I want to download this section as a markdown file."
+
+**Current affordances:**
+- Terminal: Not applicable
+- Web: None (user would copy-paste)
+
+**Missing affordances:**
+- "Download as Markdown" button
+- "Print this page" with custom print styles
+
+---
+
+## User Stories
+
+Based on the needs analysis, here are detailed user stories organized by persona.
+
+### Persona: New User (Developer)
+
+> **Story 1.1:** As a new developer using `glaze`, I want to search for "json output format" and see results from section titles, short descriptions, topics, and full content — so that I can find relevant documentation even if I don't know the exact command name.
+
+> **Story 1.2:** As a new developer, I want search results to show a snippet of text around the matching term — so that I can decide which result is relevant without clicking each one.
+
+> **Story 1.3:** As a new developer, I want to press `/` anywhere in the web app to focus the search box — so that I don't have to reach for my mouse.
+
+### Persona: Power User (Maintainer)
+
+> **Story 2.1:** As a maintainer, I want to see a "See Also" panel when viewing a section — so that I can discover related examples, tutorials, and topics without running separate searches.
+
+> **Story 2.2:** As a maintainer, I want a topic browser that shows all topics as a tag cloud — so that I can explore the documentation graphically and find under-documented areas.
+
+> **Story 2.3:** As a maintainer, I want a coverage dashboard showing which CLI commands have zero help sections — so that I can prioritize documentation work.
+
+> **Story 2.4:** As a maintainer, I want to use the query DSL in the web UI (`type:example AND topic:database`) — so that I can perform complex filtered searches the same way I do in the terminal.
+
+### Persona: End User (Operator)
+
+> **Story 3.1:** As an operator reading docs at night, I want to toggle dark mode — so that the bright white background does not strain my eyes.
+
+> **Story 3.2:** As an operator reading a long tutorial, I want a table of contents sidebar showing all headings — so that I can jump to specific sections without scrolling.
+
+> **Story 3.3:** As an operator, I want to click a link icon that appears when hovering over a heading — so that I can copy a deep link to that exact paragraph.
+
+> **Story 3.4:** As an operator, I want to download the current section as a markdown file — so that I can save it to my notes or include it in a runbook.
+
+### Persona: Offline User
+
+> **Story 4.1:** As a user who has previously visited the help site, I want the site to work when I disconnect from the network — so that I can continue reading cached documentation.
+
+> **Story 4.2:** As an offline user, I want a visual indicator showing which content is available offline — so that I know whether I can trust the page to load.
+
+---
+
+## Screen Designs with ASCII Mockups
+
+This section describes every screen in the enhanced help browser, with ASCII art showing layout and widgets.
+
+### Screen 1: Home / Browse View (Enhanced)
+
+The current home view is a two-pane layout. The enhanced version adds a **command palette** (`Cmd+K` or `Ctrl+K`), keyboard shortcuts, and a **coverage indicator** in the status bar.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│    File  Edit  View  Help                              Glazed Help Browser │  ← MenuBar
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─ Sidebar (320px) ──────────────────────┐  ┌─ Content ──────────────────┐  │
+│  │                                         │  │                           │  │
+│  │  📁 Sections                    [?]    │  │                           │  │
+│  │  ┌─────────────────────────────────┐   │  │    Select a section       │  │
+│  │  │ 🔍 Search...            ⌘K     │   │  │    from the sidebar       │  │
+│  │  └─────────────────────────────────┘   │  │    to view its content.   │  │
+│  │                                         │  │                           │  │
+│  │  [All] [Topic] [Example] [App] [Tut]   │  │    Press ⌘K to search     │  │
+│  │                                         │  │    across all sections.   │  │
+│  │  ┌─ SectionCard (active) ──────────┐   │  │                           │  │
+│  │  │ [Topic]  ◆ TOP                   │   │  │                           │  │
+│  │  │ Help System                      │   │  │                           │  │
+│  │  │ Overview of the glazed help sys… │   │  │                           │  │
+│  │  └─────────────────────────────────┘   │  │                           │  │
+│  │  ┌─ SectionCard ───────────────────┐   │  │                           │  │
+│  │  │ [Example]                        │   │  │                           │  │
+│  │  │ help-example-1                   │   │  │                           │  │
+│  │  │ Show the list of all toplevel... │   │  │                           │  │
+│  │  └─────────────────────────────────┘   │  │                           │  │
+│  │  ┌─ SectionCard ───────────────────┐   │  │                           │  │
+│  │  │ [GeneralTopic]                   │   │  │                           │  │
+│  │  │ Markdown Style                   │   │  │                           │  │
+│  │  │ Guide to markdown formatting...  │   │  │                           │  │
+│  │  └─────────────────────────────────┘   │  │                           │  │
+│  │                                         │  │                           │  │
+│  │  ─── 24 sections ───                    │  │                           │  │
+│  │                                         │  │                           │  │
+│  └─────────────────────────────────────────┘  └───────────────────────────┘  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Widgets on this screen:**
+- **MenuBar:** Retro Macintosh-style menu. Currently decorative. Enhancement: make "View" functional (toggle dark mode, toggle sidebar, zoom).
+- **SearchBar:** Text input with `⌘K` shortcut hint. Enhancement: pressing `⌘K` or `/` focuses it; supports DSL queries.
+- **TypeFilter:** Toggle buttons. Enhancement: allow multi-select (e.g., Example + Tutorial).
+- **SectionList + SectionCard:** Scrollable list. Enhancement: virtual scrolling for large lists (>500 sections).
+- **StatusBar:** Shows section count. Enhancement: add coverage percentage and offline indicator.
+
+### Screen 2: Section View with Cross-References
+
+When a section is selected, the content pane shows the full markdown. The enhanced version adds a **right sidebar** for cross-references and a **table of contents**.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│    File  Edit  View  Help                              Glazed Help Browser │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─ Sidebar (280px) ──────────────────┐  ┌─ Content ─────────────────────┐  │
+│  │                                     │  │  📄 Help System — glaze help  │  │
+│  │  🔍 json                            │  │     help-system               │  │
+│  │                                     │  │                               │  │
+│  │  [All] [Topic] [Example] [App]      │  │  Type: GeneralTopic           │  │
+│  │                                     │  │  Topics: help, documentation  │  │
+│  │  ┌─ SectionCard ─────────────────┐  │  │  Commands: help               │  │
+│  │  │ [Example]  ◆ TOP              │  │  │                               │  │
+│  │  │ JSON Output Example            │  │  │  ┌─ Table of Contents ─────┐  │  │
+│  │  │ How to format JSON output...   │  │  │  │ 1. Overview             │  │  │
+│  │  └────────────────────────────────┘  │  │  │ 2. Query DSL            │  │  │
+│  │  ┌─ SectionCard (active) ───────┐  │  │  │ 3. See Also             │  │  │
+│  │  │ [GeneralTopic]                │  │  │  └─────────────────────────┘  │  │
+│  │  │ Help System  ← active         │  │  │                               │  │
+│  │  │ Overview of the glazed...     │  │  │  The help system allows...    │  │
+│  │  └────────────────────────────────┘  │  │                               │  │
+│  │                                     │  │  ## Overview                  │  │
+│  │                                     │  │                               │  │
+│  │                                     │  │  The Glazed help system...    │  │
+│  │                                     │  │                               │  │
+│  └─────────────────────────────────────┘  │                               │  │
+│                                           │  ## Query DSL                 │  │
+│  ┌─ Right Sidebar (240px) ─────────────┐  │                               │  │
+│  │                                      │  │  The query DSL supports...    │  │
+│  │  🔗 See Also                         │  │                               │  │
+│  │  ──────────────────────────────────  │  │  ## See Also                  │  │
+│  │  By Topic:                           │  │                               │  │
+│  │  • markdown-style (Topic)            │  │  • markdown-style             │  │
+│  │  • writing-help-entries (Tutorial)   │  │  • writing-help-entries       │  │
+│  │                                      │  │  • serve-help-over-http       │  │
+│  │  By Command:                         │  │                               │  │
+│  │  • help --ui (TUI)                   │  │                               │  │
+│  │  • help --query (DSL)                │  │                               │  │
+│  │                                      │  │                               │  │
+│  │  By Flag:                            │  │                               │  │
+│  │  • --long-help                       │  │                               │  │
+│  │                                      │  │                               │  │
+│  │  [📥 Download Markdown]              │  │                               │  │
+│  │  [🖨️ Print]                          │  │                               │  │
+│  └──────────────────────────────────────┘  └───────────────────────────────┘  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Widgets on this screen:**
+- **SectionHeader:** Title, slug, type badge, topic/command/flag tags. Enhancement: add "Copy link" button.
+- **TableOfContents:** Extracted from markdown headings (`##`, `###`). Clicking scrolls to heading. Updates URL hash.
+- **MarkdownContent:** Rendered markdown. Enhancement: heading hover shows anchor link icon; code blocks have copy button.
+- **CrossReferencePanel (right sidebar):**
+  - "By Topic" — sections sharing any topic with current section
+  - "By Command" — sections documenting the same commands
+  - "By Flag" — sections documenting the same flags
+  - "Download Markdown" — reconstructs and downloads the `.md` file
+  - "Print" — triggers browser print with custom styles
+
+### Screen 3: Search Results with Snippets
+
+When the user types a query, the sidebar transforms into a search results list with highlighted snippets.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│    File  Edit  View  Help                              Glazed Help Browser │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─ Sidebar (320px) ──────────────────────┐  ┌─ Content ──────────────────┐  │
+│  │                                         │  │                           │  │
+│  │  🔍 "json output"               [×]    │  │    Select a result        │  │
+│  │  ┌─────────────────────────────────┐   │  │    to view details.       │  │
+│  │  │ 3 results in 24 sections       │   │  │                           │  │
+│  │  └─────────────────────────────────┘   │  │                           │  │
+│  │                                         │  │                           │  │
+│  │  ┌─ SearchResult ──────────────────┐   │  │                           │  │
+│  │  │ [Example]                        │   │  │                           │  │
+│  │  │ JSON Output Example              │   │  │                           │  │
+│  │  │ ...how to use the <mark>json</mark> │   │  │                           │  │
+│  │  │ command with <mark>output</mark>... │   │  │                           │  │
+│  │  │                                  │   │  │                           │  │
+│  │  │ Score: 92%  •  Topics: json, ex… │   │  │                           │  │
+│  │  └─────────────────────────────────┘   │  │                           │  │
+│  │                                         │  │                           │  │
+│  │  ┌─ SearchResult ──────────────────┐   │  │                           │  │
+│  │  │ [GeneralTopic]                   │   │  │                           │  │
+│  │  │ Help System                      │   │  │                           │  │
+│  │  │ ...the <mark>json</mark> formatter│   │  │                           │  │
+│  │  │ supports custom <mark>output</mark>│   │  │                           │  │
+│  │  │ templates...                     │   │  │                           │  │
+│  │  │                                  │   │  │                           │  │
+│  │  │ Score: 67%  •  Topics: help      │   │  │                           │  │
+│  │  └─────────────────────────────────┘   │  │                           │  │
+│  │                                         │  │                           │  │
+│  └─────────────────────────────────────────┘  └───────────────────────────┘  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Widgets on this screen:**
+- **SearchBar:** Shows current query with clear button (`×`).
+- **ResultCount:** "N results in M sections."
+- **SearchResult:** Enhanced `SectionCard` with:
+  - Highlighted snippet showing matching text with `<mark>` tags
+  - Relevance score (if FTS ranking is available)
+  - Topic/command/flag metadata chips
+
+### Screen 4: Topic Browser
+
+A dedicated screen accessible via the menu or a "Browse Topics" button. Shows all topics as a tag cloud and lets users drill into topic clusters.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│    File  Edit  View  Help                              Glazed Help Browser │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─ Content (full width) ─────────────────────────────────────────────────┐  │
+│  │                                                                         │  │
+│  │  🏷️ Topic Browser                                                       │  │
+│  │                                                                         │  │
+│  │  ┌─ Tag Cloud ───────────────────────────────────────────────────────┐  │  │
+│  │  │                                                                    │  │  │
+│  │  │   database    json      csv      templates    markdown            │  │  │
+│  │  │      help    output    flags      commands      yaml              │  │  │
+│  │  │   sorting    tables    http       server        ui                │  │  │
+│  │  │                                                                    │  │  │
+│  │  │  (font size = number of sections tagged)                          │  │  │
+│  │  └────────────────────────────────────────────────────────────────────┘  │  │
+│  │                                                                         │  │
+│  │  ┌─ Selected Topic: "json" ──────────────────────────────────────────┐  │  │
+│  │  │                                                                    │  │  │
+│  │  │  5 sections tagged with "json":                                    │  │  │
+│  │  │                                                                    │  │  │
+│  │  │  ┌─ SectionCard ───────────────────────────────────────────────┐  │  │  │
+│  │  │  │ [Example]  JSON Output Example                                │  │  │  │
+│  │  │  │ [GeneralTopic]  JSON Command Reference                        │  │  │  │
+│  │  │  │ [Tutorial]  Working with JSON Data                            │  │  │  │
+│  │  │  │ [Application]  JSON Pipeline Tutorial                         │  │  │  │
+│  │  │  │ [Example]  JSON to CSV Conversion                             │  │  │  │
+│  │  │  └──────────────────────────────────────────────────────────────┘  │  │  │
+│  │  │                                                                    │  │  │
+│  │  │  Related topics: output, csv, yaml, templates                      │  │  │
+│  │  └────────────────────────────────────────────────────────────────────┘  │  │
+│  │                                                                         │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Widgets on this screen:**
+- **TagCloud:** Each topic is a clickable tag. Font size proportional to section count. Color indicates density.
+- **TopicDetailPanel:** Appears when a topic is clicked. Shows all sections with that topic, grouped by type.
+- **RelatedTopics:** Shows topics that co-occur with the selected topic (Jaccard similarity or simple co-occurrence count).
+
+### Screen 5: Coverage Dashboard
+
+A maintainer-focused screen showing documentation coverage metrics.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│    File  Edit  View  Help                              Glazed Help Browser │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─ Content (full width) ─────────────────────────────────────────────────┐  │
+│  │                                                                         │  │
+│  │  📊 Documentation Coverage Dashboard                                   │  │
+│  │                                                                         │  │
+│  │  ┌─ Metrics ─────────────────────────────────────────────────────────┐  │  │
+│  │  │  Total sections:        24                                         │  │  │
+│  │  │  General Topics:        8  (████░░░░░░  33%)                       │  │  │
+│  │  │  Examples:              6  (██████░░░░  25%)                       │  │  │
+│  │  │  Applications:          4  (████░░░░░░  17%)                       │  │  │
+│  │  │  Tutorials:             6  (██████░░░░  25%)                       │  │  │
+│  │  │                                                                      │  │  │
+│  │  │  Commands documented:   12 / 18  (████████████░░░░░░  67%)         │  │  │
+│  │  │  Flags documented:      24 / 45  (████████████░░░░░░░░░░░░  53%)   │  │  │
+│  │  │  Top-level sections:    10 / 24  (████████████░░░░░░  42%)         │  │  │
+│  │  └────────────────────────────────────────────────────────────────────┘  │  │
+│  │                                                                         │  │
+│  │  ┌─ Undocumented Commands ────────────────────────────────────────────┐  │  │
+│  │  │  These commands have no associated help sections:                    │  │  │
+│  │  │                                                                      │  │  │
+│  │  │  • yaml     • csv      • html      • markdown                       │  │  │
+│  │  │                                                                      │  │  │
+│  │  │  [Create help section for yaml]  [Create help section for csv]      │  │  │
+│  │  └────────────────────────────────────────────────────────────────────┘  │  │
+│  │                                                                         │  │
+│  │  ┌─ Topic Coverage Heatmap ───────────────────────────────────────────┐  │  │
+│  │  │                                                                      │  │  │
+│  │  │  database ████████░░  json ██████████  csv ████░░░░░░               │  │  │
+│  │  │  templates ██████░░░░  http █████░░░░░░  ui ██████████              │  │  │
+│  │  │                                                                      │  │  │
+│  │  └────────────────────────────────────────────────────────────────────┘  │  │
+│  │                                                                         │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Widgets on this screen:**
+- **CoverageMetrics:** Bar charts showing section type distribution and coverage ratios.
+- **UndocumentedCommandsList:** List of commands with zero associated help sections. Each has a "Create" button that generates a template markdown file.
+- **TopicHeatmap:** Grid showing topic density. Darker = more sections.
+
+### Screen 6: Command Palette (Modal)
+
+Triggered by `Cmd+K` or `Ctrl+K`. A fuzzy-search modal that overlays any screen.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  ... rest of app dimmed ...                                                 │
+│                                                                             │
+│         ┌─ Command Palette ──────────────────────────────────────┐          │
+│         │                                                        │          │
+│         │  🔍  Type a command or search...                       │          │
+│         │  ────────────────────────────────────────────────────  │          │
+│         │  Recent                                               │          │
+│         │  → JSON Output Example                                │          │
+│         │  → Help System                                        │          │
+│         │  → Markdown Style                                     │          │
+│         │                                                        │          │
+│         │  Commands                                             │          │
+│         │  → Go to Topic Browser      ⌘T                        │          │
+│         │  → Go to Coverage Dashboard ⌘D                        │          │
+│         │  → Toggle Dark Mode         ⌘⇧D                       │          │
+│         │  → Toggle Sidebar           ⌘B                        │          │
+│         │                                                        │          │
+│         │  Search Results                                         │          │
+│         │  → JSON Output Example      Example  •  json, output   │          │
+│         │  → JSON Command Reference   Topic    •  json, help     │          │
+│         │                                                        │          │
+│         │  ─── 2 results ───                                    │          │
+│         │                                                        │          │
+│         └────────────────────────────────────────────────────────┘          │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Widgets on this screen:**
+- **CommandPaletteInput:** Fuzzy-search input. Supports `>` prefix for commands (e.g., `>dark` for "Toggle Dark Mode").
+- **RecentList:** Last 5 visited sections.
+- **CommandList:** App-level commands (navigate to screens, toggle features).
+- **ResultList:** Fuzzy-matched sections from the full list.
+
+### Screen 7: Dark Mode
+
+The entire app supports a dark color scheme toggled via View menu or `Cmd+Shift+D`.
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│    File  Edit  View  Help                              Glazed Help Browser │
+│  (dark blue background, light text)                                         │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  ┌─ Sidebar ──────────────────────────────┐  ┌─ Content ──────────────────┐  │
+│  │ (dark gray bg, white text)             │  │ (dark gray bg, white text)│  │
+│  │                                         │  │                           │  │
+│  │  📁 Sections                    [?]    │  │  📄 Help System            │  │
+│  │  ┌─────────────────────────────────┐   │  │  (light headings, dim     │  │
+│  │  │ 🔍 Search...            ⌘K     │   │  │   body text, code blocks  │  │
+│  │  └─────────────────────────────────┘   │  │   with dark syntax hl)    │  │
+│  │  ...                                   │  │                           │  │
+│  └─────────────────────────────────────────┘  └───────────────────────────┘  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Proposed API Enhancements
+
+The current API is minimal. The following endpoints and query parameters are proposed.
+
+### New Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `GET /api/sections/search` | GET | Full-text search with `?q=` query param. Returns results with `snippet` field containing highlighted excerpt. |
+| `GET /api/topics` | GET | List all unique topics with section counts. |
+| `GET /api/commands` | GET | List all unique commands with associated section counts. |
+| `GET /api/coverage` | GET | Coverage metrics: total sections, commands documented/undocumented, flags documented/undocumented. |
+
+### Enhanced Existing Endpoints
+
+**`GET /api/sections/:slug`** — Add `?related=true` parameter to include a `related` array in the response:
+
+```json
+{
+  "id": 1,
+  "slug": "help-system",
+  "title": "Help System",
+  "content": "...",
+  "related": {
+    "by_topic": [
+      {"slug": "markdown-style", "title": "Markdown Style", "type": "GeneralTopic"}
+    ],
+    "by_command": [
+      {"slug": "help-example-1", "title": "Show the list of all toplevel topics", "type": "Example"}
+    ],
+    "by_flag": []
+  }
+}
+```
+
+### Pseudocode for New Handlers
+
+```go
+// pkg/help/server/handlers.go additions
+
+func (h *Handler) handleSearch(w http.ResponseWriter, r *http.Request) {
+    ctx := r.Context()
+    q := r.URL.Query().Get("q")
+    if q == "" {
+        writeError(w, http.StatusBadRequest, "bad_request", "missing q parameter")
+        return
+    }
+
+    // Use FTS if available, fallback to LIKE search
+    var sections []*model.Section
+    var err error
+    if h.deps.Store.HasFTS() {
+        sections, err = h.deps.Store.SearchFTS(ctx, q)
+    } else {
+        sections, err = h.deps.Store.Find(ctx, store.Or(
+            store.TitleContains(q),
+            store.ContentContains(q),
+        ))
+    }
+
+    if err != nil {
+        writeError(w, http.StatusInternalServerError, "internal_error", "search failed")
+        return
+    }
+
+    // Generate snippets (simplified)
+    results := make([]SearchResult, len(sections))
+    for i, s := range sections {
+        results[i] = SearchResult{
+            SectionSummary: SummaryFromModel(s),
+            Snippet: generateSnippet(s.Content, q),
+        }
+    }
+
+    writeJSON(w, http.StatusOK, SearchResponse{
+        Results: results,
+        Total:   len(results),
+    })
+}
+
+func (h *Handler) handleTopics(w http.ResponseWriter, r *http.Request) {
+    ctx := r.Context()
+    topics, err := h.deps.Store.ListTopics(ctx)
+    if err != nil {
+        writeError(w, http.StatusInternalServerError, "internal_error", "failed to list topics")
+        return
+    }
+    writeJSON(w, http.StatusOK, topics)
+}
+
+func (h *Handler) handleCoverage(w http.ResponseWriter, r *http.Request) {
+    ctx := r.Context()
+    total, _ := h.deps.Store.Count(ctx)
+    commands, _ := h.deps.Store.ListCommands(ctx)
+    flags, _ := h.deps.Store.ListFlags(ctx)
+
+    // This requires the store to know about "all commands" — which comes from
+    // cobra command introspection, not the help store. For v1, we can only
+    // report "commands that have at least one section".
+    writeJSON(w, http.StatusOK, CoverageResponse{
+        TotalSections:      int(total),
+        CommandsWithDocs:   len(commands),
+        // FlagsWithDocs, etc.
+    })
+}
+```
+
+---
+
+## Frontend Architecture Plan
+
+### State Management Expansion
+
+The current Redux store only has the RTK Query API slice. We need additional slices for:
+
+1. **UI slice:** dark mode, sidebar visibility, active screen (browse, topic, coverage)
+2. **Search slice:** query string, search history, active filters
+3. **Offline slice:** cached section IDs, sync status, last fetch timestamp
+
+```typescript
+// web/src/slices/uiSlice.ts
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface UIState {
+  darkMode: boolean;
+  sidebarVisible: boolean;
+  activeScreen: 'browse' | 'topics' | 'coverage';
+}
+
+const initialState: UIState = {
+  darkMode: false,
+  sidebarVisible: true,
+  activeScreen: 'browse',
+};
+
+export const uiSlice = createSlice({
+  name: 'ui',
+  initialState,
+  reducers: {
+    toggleDarkMode: (state) => { state.darkMode = !state.darkMode; },
+    toggleSidebar: (state) => { state.sidebarVisible = !state.sidebarVisible; },
+    setActiveScreen: (state, action: PayloadAction<UIState['activeScreen']>) => {
+      state.activeScreen = action.payload;
+    },
+  },
+});
+```
+
+### Component Additions
+
+| Component | Purpose | Screen |
+|-----------|---------|--------|
+| `CommandPalette` | Modal fuzzy search + commands | Global |
+| `TableOfContents` | Heading list with anchor links | Section View |
+| `CrossReferencePanel` | Related sections sidebar | Section View |
+| `TagCloud` | Topic browser visual | Topic Browser |
+| `TopicDetailPanel` | Sections for selected topic | Topic Browser |
+| `CoverageDashboard` | Metrics and charts | Coverage |
+| `UndocumentedList` | Commands needing docs | Coverage |
+| `OfflineIndicator` | Network status badge | Global |
+| `DarkModeToggle` | Theme switcher | Global |
+| `HeadingAnchor` | Hover link icon on headings | Markdown Content |
+
+### Routing Expansion
+
+Current routes (HashRouter):
+- `/#/` — Home (browse)
+- `/#/sections/:slug` — Section view
+
+Proposed routes:
+- `/#/` — Home (browse)
+- `/#/sections/:slug` — Section view
+- `/#/sections/:slug#:anchor` — Section view scrolled to anchor
+- `/#/topics` — Topic browser
+- `/#/topics/:topic` — Topic detail
+- `/#/coverage` — Coverage dashboard
+- `/#/search?q=...` — Search results (shareable URL)
+
+### Service Worker (Offline Support)
+
+Use Vite PWA plugin or a custom service worker:
+
+```javascript
+// sw.js — Cache-first strategy for API responses
+const CACHE_NAME = 'glazed-help-v1';
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.url.includes('/api/')) {
+    event.respondWith(
+      caches.match(event.request).then((cached) => {
+        // Return cached if available, otherwise fetch and cache
+        if (cached) return cached;
+        return fetch(event.request).then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          return response;
+        });
+      })
+    );
+  }
+});
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Enhanced Search
+
+**Backend:**
+- Add `GET /api/sections/search?q=...` endpoint with FTS support (if build tag enabled).
+- Add `snippet` generation for search results.
+
+**Frontend:**
+- Enhance `SearchBar` to support DSL queries (`type:example AND topic:database`).
+- Create `SearchResult` component with snippet highlighting.
+- Add `Cmd+K` shortcut and `CommandPalette` modal.
+
+**Validation:**
+- Search "json" and see results from content, not just titles.
+- Search `type:example` and see only examples.
+
+### Phase 2: Cross-References and Deep Linking
+
+**Backend:**
+- Add `?related=true` to `GET /api/sections/:slug`.
+- Implement topic/command/flag co-occurrence queries in the store.
+
+**Frontend:**
+- Create `CrossReferencePanel` right sidebar.
+- Create `TableOfContents` from markdown headings.
+- Add anchor links to headings (`HeadingAnchor`).
+- Update routing to support `#anchor` hashes.
+
+**Validation:**
+- View "Help System" section and see "See Also" panel populated.
+- Click a heading anchor link and verify URL updates and scrolls.
+
+### Phase 3: Topic Browser and Coverage Dashboard
+
+**Backend:**
+- Add `GET /api/topics` endpoint.
+- Add `GET /api/coverage` endpoint.
+
+**Frontend:**
+- Create `TagCloud`, `TopicDetailPanel`, `CoverageDashboard`, `UndocumentedList`.
+- Add navigation items to MenuBar (View → Topic Browser, View → Coverage).
+- Add route handlers for `/#/topics` and `/#/coverage`.
+
+**Validation:**
+- Click "View → Topic Browser" and see tag cloud.
+- Click a topic and see related sections.
+- Visit Coverage dashboard and see bar charts.
+
+### Phase 4: Dark Mode and Accessibility
+
+**Frontend:**
+- Add `uiSlice` with dark mode toggle.
+- Implement CSS custom properties for theming (`--bg-primary`, `--text-primary`, etc.).
+- Add `DarkModeToggle` to MenuBar or Command Palette.
+- Add keyboard shortcuts (`Cmd+Shift+D`, `Cmd+B` for sidebar).
+- Add `aria-label`, `role`, and focus management.
+
+**Validation:**
+- Toggle dark mode; verify all screens invert correctly.
+- Tab through interface; verify focus rings visible.
+
+### Phase 5: Offline Support
+
+**Frontend:**
+- Add service worker with cache-first strategy.
+- Add `OfflineIndicator` component showing sync status.
+- Add `offline` slice to Redux tracking cached sections.
+
+**Validation:**
+- Load site, then disconnect network.
+- Verify already-visited sections still load.
+- Verify offline indicator appears.
+
+### Phase 6: Print and Export from Browser
+
+**Frontend:**
+- Add `@media print` CSS styles hiding sidebar and showing clean content.
+- Add "Download Markdown" button to `CrossReferencePanel`.
+- Add "Print" button triggering `window.print()`.
+
+**Validation:**
+- Click "Print" and verify browser print preview shows clean layout.
+- Click "Download Markdown" and verify `.md` file downloads with correct frontmatter.
+
+---
+
+## Testing Strategy
+
+### Backend Tests
+
+- `TestHandleSearch` — assert search returns results with snippets.
+- `TestHandleTopics` — assert topic list is deduplicated and counted.
+- `TestHandleCoverage` — assert metrics match seeded data.
+- `TestGetSectionWithRelated` — assert `related` object contains expected sections.
+
+### Frontend Tests
+
+- **Component tests** (Vitest + React Testing Library):
+  - `SearchBar` — typing triggers search, `/` focuses input.
+  - `CommandPalette` — `Cmd+K` opens, fuzzy search works, Enter selects.
+  - `CrossReferencePanel` — renders related sections grouped by type.
+  - `TagCloud` — clicking tag calls onChange with correct topic.
+  - `DarkModeToggle` — toggles class on document body.
+
+- **Integration tests**:
+  - Search flow: type query → see results → click result → view section.
+  - Topic flow: navigate to topics → click tag → see sections → click section.
+  - Offline flow: load section → go offline → reload section → content still visible.
+
+### End-to-End Tests
+
+- Start `glaze serve-help`.
+- Open browser at `http://localhost:8088`.
+- Execute user stories manually and verify each acceptance criterion.
+
+---
+
+## Risks, Alternatives, and Open Questions
+
+### Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| FTS5 not available in all builds | Medium | Medium | Fallback to `LIKE` search; document limitation |
+| Large help systems slow down browser | Medium | High | Virtual scrolling, pagination, lazy loading |
+| Service worker cache grows unbounded | Low | Medium | Implement cache eviction (LRU, max age) |
+| Dark mode CSS is hard to maintain | Low | Low | Use CSS custom properties; test with Storybook |
+
+### Alternatives Considered
+
+1. **Use Next.js or Astro instead of Vite+React.**
+   - Rejected: The current Vite setup is simple and the SPA is small. SSR would complicate the Go embedding story.
+
+2. **Use a third-party documentation framework (Docusaurus, Nextra).**
+   - Rejected: We need tight integration with the Glazed help section model and the ability to serve from a Go binary. Third-party frameworks are designed for file-based content.
+
+3. **Implement search entirely client-side.**
+   - Rejected: For large help systems (>1000 sections), client-side search is slow and memory-intensive. Server-side FTS is more scalable.
+
+### Open Questions
+
+1. **Should the coverage dashboard require cobra command introspection?**
+   - The help store knows which commands *have* sections, but not which commands *exist* in the binary. We may need to pass the `cobra.Command` tree to the server for true coverage metrics.
+   - **Decision:** Phase 3 v1 will show "commands with docs" only. Full coverage (commands without docs) is Phase 3 v2.
+
+2. **Should search snippets use server-side or client-side highlighting?**
+   - Server-side: more accurate, can use FTS offsets. Client-side: simpler, works with fallback search.
+   - **Decision:** Server-side for FTS builds, client-side fallback for non-FTS builds.
+
+3. **Should the service worker cache the entire help system or just visited pages?**
+   - Full cache: better offline experience but large initial download. Visit-based: smaller but gaps in offline coverage.
+   - **Decision:** Start with visit-based (cache sections as user visits them). Add "Download all for offline" button later.
+
+---
+
+## File References
+
+### Go Backend
+
+| File | Role |
+|------|------|
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go` | HTTP server command and handler composition |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/handlers.go` | API route handlers |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/types.go` | Request/response types |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/server/middleware.go` | CORS middleware |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/store/store.go` | SQLite store |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/store/query.go` | Predicate query system |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/help/store/fts5.go` | FTS5 full-text search (build tag gated) |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/pkg/web/static.go` | SPA static file handler |
+
+### React Frontend
+
+| File | Role |
+|------|------|
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/main.tsx` | Entry point with HashRouter |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/App.tsx` | Root component |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/store.ts` | Redux store configuration |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/services/api.ts` | RTK Query API slice |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/types/index.ts` | TypeScript interfaces |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/components/AppLayout/AppLayout.tsx` | Two-pane layout |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/components/SearchBar/SearchBar.tsx` | Search input |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/components/SectionList/SectionList.tsx` | Section list |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/components/SectionView/SectionView.tsx` | Section content viewer |
+| `/home/manuel/code/wesen/corporate-headquarters/glazed/web/src/components/Markdown/MarkdownContent.tsx` | Markdown renderer |
+
+---
+
+## Conclusion
+
+This design transforms the Glazed help web server from a simple list viewer into a **full-featured documentation browser**. The enhancements are grounded in concrete user stories and organized into six implementation phases. Each phase adds measurable value while building on the existing architecture:
+
+- **Phase 1** (Search) makes finding information fast.
+- **Phase 2** (Cross-references + Deep Linking) makes reading contextual.
+- **Phase 3** (Topics + Coverage) makes exploration and maintenance easy.
+- **Phase 4** (Dark Mode + Accessibility) makes reading comfortable for everyone.
+- **Phase 5** (Offline) makes the docs available anywhere.
+- **Phase 6** (Print/Export) makes the docs portable.
+
+The ASCII mockups provide a shared visual language for designers and developers. The API contracts and pseudocode give implementers a clear path forward. The file references anchor every decision to the existing codebase.

--- a/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/index.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/index.md
@@ -1,0 +1,62 @@
+---
+Title: 'Enhance Glazed Help Web Server: Full-Featured Browser with Advanced Search, Cross-References, and Offline Support'
+Ticket: GLAZE-HELP-WEB
+Status: active
+Topics:
+    - glazed
+    - help-system
+    - web
+    - react
+    - server
+    - ui
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T07:43:32.259523703-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Enhance Glazed Help Web Server: Full-Featured Browser with Advanced Search, Cross-References, and Offline Support
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- glazed
+- help-system
+- web
+- react
+- server
+- ui
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/reference/01-investigation-diary.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/reference/01-investigation-diary.md
@@ -1,0 +1,309 @@
+---
+Title: Investigation Diary
+Ticket: GLAZE-HELP-WEB
+Status: active
+Topics:
+    - glazed
+    - help-system
+    - web
+    - react
+    - server
+    - ui
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/pkg/help/server/serve.go
+      Note: Server architecture exploration
+    - Path: ../../../../../../../../../../code/wesen/corporate-headquarters/glazed/web/src/App.tsx
+      Note: Frontend capabilities exploration
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T08:00:00-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+
+# Diary
+
+## Goal
+
+Capture the research, analysis, and documentation work for designing the enhanced Glazed Help Web Server. This diary tracks exploration of the existing web stack (Go HTTP server, React SPA, TUI), identification of gaps, and the creation of a comprehensive design document with user stories, screen designs, and ASCII mockups.
+
+---
+
+## Step 1: Initialize Ticket and Read Skills
+
+This step established the project scaffolding by creating a docmgr ticket and reading the relevant skill files to understand the workflow, writing style, and deliverable requirements.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Then, since you are then already deep in the glazed system, also write a new docmgr ticket to add a webserver to the glazed verb to serve help entries, and write out all the different needs and affordances the site would service and offer, and then design a set of user stories. Then, use that knowledge to make a list of screens, how they work, potentially even with ASCII screenshots of the widgets / functionality. reate a detailed analysis / design / implementation guide that is very detailed for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet point sand pseudocode and diagrams and api references and file references. It should be very clear and detailed. Store in the ticket and the nupload to remarkable."
+
+**Assistant interpretation:** The user wants a comprehensive design document for enhancing the Glazed help web server, including needs analysis, user stories, screen designs with ASCII mockups, and an implementation guide. The document should be intern-friendly and evidence-based.
+
+**Inferred user intent:** Produce a detailed, visually-oriented design document that can guide implementation of a full-featured help browser web application, building on the existing `serve-help` and `render-site` infrastructure.
+
+### What I did
+- Created docmgr ticket `GLAZE-HELP-WEB` with title "Enhance Glazed Help Web Server: Full-Featured Browser with Advanced Search, Cross-References, and Offline Support".
+- Added design-doc and diary documents to the ticket.
+
+### Why
+- The previous ticket (`GLAZE-HELP-EXPORT`) established the docmgr workflow. This ticket applies the same rigor to a new feature area.
+- The user explicitly requested user stories, screen designs, and ASCII mockups — deliverables that require careful structuring.
+
+### What worked
+- Ticket creation succeeded immediately.
+- The existing vocabulary already contained `glazed`, `help-system`, `web`, `react`, `server`, `ui`.
+
+### What didn't work
+- N/A
+
+### What I learned
+- Reusing the same workflow pattern (ticket → docs → evidence → writing → validation → upload) is efficient.
+
+### What was tricky to build
+- N/A (initialization step)
+
+### What warrants a second pair of eyes
+- N/A
+
+### What should be done in the future
+- Explore the existing web codebase to understand current capabilities and limitations.
+
+### Code review instructions
+- Verify ticket `GLAZE-HELP-WEB` exists in docmgr.
+
+### Technical details
+- Ticket path: `2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support`
+
+---
+
+## Step 2: Explore Existing Web Stack
+
+This step mapped the current web architecture by reading the Go HTTP server, React SPA, and TUI code. The goal was to understand what already exists so the design could build on it rather than replace it.
+
+### What I did
+- Read `pkg/help/server/serve.go` — the `ServeCommand` that starts the HTTP server, composes API + SPA handlers, supports mounting under prefixes.
+- Read `pkg/help/server/handlers.go` — the API handlers for health, sections list, and section detail.
+- Read `pkg/help/server/types.go` — the Go response types (`SectionSummary`, `SectionDetail`, `ListSectionsResponse`).
+- Read `pkg/help/server/middleware.go` — CORS middleware.
+- Read `pkg/help/server/serve_test.go` — tests confirming SPA serving, prefix mounting, and store replacement.
+- Read `pkg/web/static.go` — the `NewSPAHandler` that serves embedded Vite assets with SPA fallback.
+- Read `web/src/main.tsx` — React entry point with `HashRouter` and Redux `Provider`.
+- Read `web/src/App.tsx` — root component wiring search, type filter, section list, and section view.
+- Read `web/src/services/api.ts` — RTK Query API slice with server/static mode detection.
+- Read `web/src/store.ts` — Redux store with RTK Query reducer.
+- Read `web/src/types/index.ts` — TypeScript interfaces mirroring Go types.
+- Read `web/src/components/AppLayout/AppLayout.tsx` — two-pane layout.
+- Read `web/src/components/SearchBar/SearchBar.tsx` — basic text input.
+- Read `web/src/components/TypeFilter/TypeFilter.tsx` — filter buttons.
+- Read `web/src/components/SectionList/SectionList.tsx` and `SectionCard.tsx` — list and card rendering.
+- Read `web/src/components/SectionView/SectionView.tsx` and `SectionHeader.tsx` — content viewer.
+- Read `web/src/components/MenuBar/MenuBar.tsx` — retro menu bar (currently decorative).
+- Read `web/vite.config.ts` — Vite config with API proxy, HashRouter base path.
+- Read `pkg/help/ui/model.go` — the Bubble Tea TUI model for comparison.
+
+### Why
+- The ticket-research skill mandates "evidence-first investigation."
+- The user specifically asked for screen designs — without understanding the existing components, the designs would be disconnected from reality.
+
+### What worked
+- The codebase is well-organized with clear separation between Go backend (`pkg/help/server/`), React frontend (`web/src/`), and shared types.
+- The existing API is minimal but clean — easy to extend.
+- The TUI (`pkg/help/ui/model.go`) provides a good benchmark for what interactive features are already possible in the terminal (search, copy, DSL, help screen).
+
+### What didn't work
+- `web/src/components/Markdown/MarkdownContent.tsx` was not readable due to file access issues, but its interface is clear from `SectionView.tsx`.
+
+### What I learned
+- The React app uses **HashRouter** (`/#/sections/:slug`) to avoid needing server-side route fallback. This is important for the static export (`render-site`) which has no live server.
+- The API layer already supports **static mode** — when `window.__GLAZE_SITE_CONFIG__.mode === 'static'`, it reads `.json` files instead of calling `/api`. This means new API endpoints must also have static JSON equivalents.
+- The TUI supports DSL search, clipboard copy, and keyboard shortcuts — all features the web UI currently lacks.
+- The `MenuBar` is purely decorative. Making it functional (View → Topic Browser, View → Coverage) is a natural enhancement.
+- The SectionCard shows type badge, top-level diamond, title, and short description. It does not show topics/commands/flags inline — those are only in the detail view.
+
+### What was tricky to build
+- Understanding the relationship between `serve-help` (live server) and `render-site` (static export) was important. Both use the same React SPA, but `render-site` pre-generates JSON files and sets `mode: 'static'`. Any new API endpoint must be mirrored in `pkg/help/site/render.go` for static mode compatibility.
+
+### What warrants a second pair of eyes
+- Confirm that the proposed new API endpoints (`/api/topics`, `/api/coverage`, `/api/sections/search` with snippets) are feasible given the existing store schema.
+- Confirm that static mode JSON generation in `render-site` can be extended to include the new data shapes.
+
+### What should be done in the future
+- When implementing Phase 3 (Coverage Dashboard), determine how to get the full list of commands from the Cobra tree into the help system. The store only knows about commands that have help sections.
+
+### Code review instructions
+- Start reading at `pkg/help/server/serve.go` to understand server startup.
+- Then read `web/src/App.tsx` to see current frontend capabilities.
+- Then read `pkg/help/ui/model.go` to see what the TUI already does (benchmark for web parity).
+
+### Technical details
+- Key files and their roles:
+  - `pkg/help/server/serve.go` (~170 lines) — Server command, handler composition, graceful shutdown
+  - `pkg/help/server/handlers.go` (~200 lines) — API routes: health, list, get
+  - `pkg/help/server/types.go` (~120 lines) — Request/response structs
+  - `pkg/web/static.go` (~60 lines) — SPA static file serving with fallback
+  - `web/src/App.tsx` (~90 lines) — Root component with sidebar + content
+  - `web/src/services/api.ts` (~120 lines) — RTK Query with server/static dual mode
+  - `pkg/help/ui/model.go` (~580 lines) — TUI with search, view, help, cheatsheet states
+
+---
+
+## Step 3: Write the Design Document
+
+This step produced the primary deliverable: a comprehensive design document with needs analysis, user stories, screen designs with ASCII mockups, API enhancements, frontend architecture, and implementation phases.
+
+### What I did
+- Wrote a "Needs and Affordances Analysis" section mapping 7 user needs to concrete UI affordances.
+- Wrote 11 user stories organized by persona: New User, Power User, Operator, Offline User.
+- Designed 7 screens with ASCII mockups:
+  1. Home / Browse View (enhanced)
+  2. Section View with Cross-References
+  3. Search Results with Snippets
+  4. Topic Browser
+  5. Coverage Dashboard
+  6. Command Palette (Modal)
+  7. Dark Mode
+- Wrote API enhancement proposals with new endpoints and response shapes.
+- Wrote frontend architecture plan: new Redux slices, component inventory, routing expansion, service worker pseudocode.
+- Defined 6 implementation phases: Enhanced Search → Cross-References → Topics/Coverage → Dark Mode/Accessibility → Offline Support → Print/Export.
+- Included testing strategy, risks, alternatives, and open questions.
+
+### Why
+- The user explicitly requested "all the different needs and affordances," "user stories," "list of screens," and "ASCII screenshots of the widgets / functionality."
+- The ticket-research skill requires "Optimize for onboarding unfamiliar engineers" and "Include pseudocode and minimal API sketches where useful."
+
+### What worked
+- The ASCII mockups make the designs concrete and reviewable without requiring a designer or prototype tool.
+- The user story format ("As a [persona], I want [goal], so that [benefit]") makes acceptance criteria clear.
+- The phased implementation plan keeps each deliverable small enough for a single intern sprint.
+
+### What didn't work
+- The Coverage Dashboard design assumes we can enumerate all commands in the binary. The current store only knows commands with help sections. This is documented as an open question.
+
+### What I learned
+- The existing web app already uses a clean component architecture (`parts.ts` + `styles/*.css` per component). New components should follow this pattern.
+- The HashRouter means deep linking to anchors must use the hash portion carefully: `/#/sections/slug#anchor`. React Router's `useLocation` can parse this.
+- Static mode (`render-site`) complicates new API endpoints because they must also be pre-rendered as JSON files. This is a constraint on the backend design.
+
+### What was tricky to build
+- Designing the Command Palette required balancing three use cases in one modal: (1) fuzzy search over sections, (2) app-level commands (toggle dark mode, navigate screens), (3) recent history. The `>` prefix convention (like VS Code) cleanly separates commands from search.
+- The Cross-Reference Panel needed a clear grouping strategy. Grouping by "By Topic", "By Command", "By Flag" maps directly to the `Section` struct fields and is easy to explain.
+
+### What warrants a second pair of eyes
+- Verify that the proposed new API endpoints do not break static mode compatibility. Each new endpoint needs a corresponding JSON file generation in `pkg/help/site/render.go`.
+- Verify the ASCII mockups are readable on the reMarkable device (monospace font, limited width).
+
+### What should be done in the future
+- Create Storybook stories for each new component before implementation.
+- Define exact CSS custom property names for the dark mode theme.
+- Decide on a client-side search library for the fallback path (e.g., Fuse.js, Minisearch) if FTS is not available.
+
+### Code review instructions
+- Read the design document from top to bottom. It is self-contained.
+- Verify every file reference points to an existing file.
+- Check that the screen designs match the existing component architecture.
+
+### Technical details
+---
+
+## Step 4: Document Current React Component Hierarchy for Designers
+
+This step added a comprehensive component inventory appendix to the design document, providing web designers with a complete reference of the existing React component tree, props, state, CSS parts, and file structure.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Make a list of the current react component / design component hierarchy and their props and slices so that I can provide to the web designer a screenshot and the layout of components so that they have a proper starting point. Update the server docmgr ticket document and upload to remarkable"
+
+**Assistant interpretation:** The user wants a designer-facing reference document that maps out every existing React component with its props, state, CSS data-part attributes, and layout relationships, so a web designer can understand the current UI before proposing changes.
+
+**Inferred user intent:** Produce a single-source-of-truth component specification that bridges engineering implementation and design work.
+
+### What I did
+- Read every React component file in `web/src/components/`:
+  - `AppLayout`, `TitleBar`, `MenuBar`, `SearchBar`, `TypeFilter`, `SectionList`, `SectionCard`, `SectionView`, `SectionHeader`, `MarkdownContent`, `EmptyState`, `StatusBar`, `Badge`
+- Read every `parts.ts` file to extract `data-part` attribute names.
+- Read every `styles/*.css` file to document layout, color, and typography rules.
+- Read `App.tsx` to map the full component tree and state flow.
+- Read `store.ts`, `services/api.ts`, and `types/index.ts` to document state management and data shapes.
+- Read `styles/global.css` to document CSS custom properties and the System 7 aesthetic.
+- Wrote "Appendix A: Current React Component Hierarchy (Designer Reference)" with:
+  - Visual layout ASCII diagram
+  - Hierarchical component tree
+  - Per-component inventory: file path, props table, state/hooks table, CSS data-part attributes, CSS file reference
+  - State management section (Redux slices, RTK Query endpoints)
+  - TypeScript data types table
+  - Global CSS variables table
+  - Complete file tree
+
+### Why
+- Designers need to understand the existing component surface before proposing changes.
+- The `data-part` attribute system (BEM-like without classes) is unconventional; documenting it prevents designers from proposing class-based approaches that don't fit.
+- The System 7 aesthetic is specific (Chicago font, dot-pattern background, thick borders, hard shadows); designers need to know these constraints.
+
+### What worked
+- Reading all components revealed that `MenuBar` exists but is **not rendered** in `App.tsx` — an important discovery for the design.
+- The component architecture is very consistent: every component has `Component.tsx`, `parts.ts`, and `styles/component.css`.
+- The `Badge` component uses CSS custom properties (`--badge-color`, `--badge-weight`) set via inline `style` — a pattern designers should know about for theming.
+
+### What didn't work
+- N/A
+
+### What I learned
+- The current web app has **13 components** across **8 component directories**.
+- **Zero custom Redux slices** — all state is either local `useState` in `App.tsx` or RTK Query cache.
+- The `EmptyState` has a configurable `label` prop but `App.tsx` uses the default.
+- `SectionCard` uses `stripMarkdown()` from `utils/text` — markdown is stripped from titles/shorts in the list view.
+- The `TypeFilter` uses `[aria-pressed='true']` for active state — accessible but designer-relevant.
+
+### What was tricky to build
+- Organizing the information for a designer audience (not an engineer audience). The design doc's existing sections are implementation-focused; this appendix needed to be visual and scannable. The solution was: ASCII layout → tree → per-component tables → state/types/CSS reference.
+
+### What warrants a second pair of eyes
+- Verify that all `data-part` selectors and CSS rules are accurately transcribed.
+- Verify that the component tree matches the actual JSX nesting in `App.tsx`.
+
+### What should be done in the future
+- Add Storybook stories for each component so designers can interact with them in isolation.
+- Create a Figma/component library that mirrors the `parts.ts` naming convention.
+
+### Code review instructions
+- Verify the component tree in the appendix matches `App.tsx` line-by-line.
+- Verify all `data-part` values match their `parts.ts` files.
+
+### Technical details
+- Components documented: 13
+- CSS files read: 10
+- `parts.ts` files read: 8
+- Props tables: 13
+- Data-part attributes listed: 35+
+- Global CSS variables: 12
+- RTK Query endpoints: 3
+
+---
+
+## Session Summary
+
+| Deliverable | Path | Status |
+|-------------|------|--------|
+| Ticket | `GLAZE-HELP-WEB` | ✅ Created |
+| Design Document | `design-doc/01-design-...` | ✅ Written + Component Appendix added |
+| Investigation Diary | `reference/01-investigation-diary.md` | ✅ Written |
+| File Relations | 9 source files related | ✅ Complete |
+| Changelog | 4 entries | ✅ Updated |
+| Validation | `docmgr doctor` | ✅ Passed |
+| reMarkable Upload | `/ai/2026/04/28/GLAZE-HELP-WEB` | ✅ Verified |
+
+### Technical details
+- Design document path: `glazed/ttmp/2026/04/28/GLAZE-HELP-WEB--.../design-doc/01-design-glazed-help-web-server-enhancement-full-featured-browser-with-screens-and-user-stories.md`
+- Document length: ~75 KB, ~1600 lines (after component appendix)
+- Sections: 14 major sections + 1 appendix
+- ASCII mockups: 7 screens
+- User stories: 11
+- New API endpoints proposed: 3
+- Implementation phases: 6
+- Components documented: 13
+- File references: 30+ absolute paths

--- a/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/tasks.md
+++ b/ttmp/2026/04/28/GLAZE-HELP-WEB--enhance-glazed-help-web-server-full-featured-browser-with-advanced-search-cross-references-and-offline-support/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+## TODO
+
+- [ ] Add tasks here
+

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -79,6 +79,16 @@ topics:
       description: Generating a static site artifact from structured source content
     - slug: static-render
       description: Static website rendering and export workflows for Glazed help content
+    - slug: export
+      description: Export functionality and data extraction
+    - slug: help-system
+      description: Glazed help system and help entries
+    - slug: sqlite
+      description: SQLite database storage
+    - slug: server
+      description: HTTP server and backend services
+    - slug: ui
+      description: User interface and frontend components
 docTypes:
     - slug: index
       description: Ticket index

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -128,3 +128,5 @@ intent:
 status:
     - slug: active
       description: In progress / active work
+    - slug: complete
+      description: Completed ticket


### PR DESCRIPTION
This pull request introduces two major new capabilities to the Glazed help
system: exporting help content to disk and serving it from these external
sources.

Key changes include:

- **New `help export` Command:**
  - Adds a `glaze help export` subcommand.
  - Exports the entire help system's content, including sections, topics, and
    metadata.
  - Supports exporting to a directory of markdown files or a single SQLite
    database.

- **Serve from External Sources:**
  - The `glaze help serve` command is enhanced to load help content from an
    exported source.
  - A new loader implementation can read from either a directory structure or
    an SQLite database generated by the `export` command.
  - This decouples help content generation from the serving process, allowing for
    pre-built, static help artifacts.

- **Documentation:**
  - Adds extensive design documents, user guides, and reference material for
    the new features.