### PR TITLE
config: Scrub local git env vars for robust git root discovery

### DIFF
--- a/pkg/config/plan_sources.go
+++ b/pkg/config/plan_sources.go
@@ -125,6 +125,13 @@ func WorkingDirFile(name string) SourceSpec {
 	}
 }
 
+// GitRootFile discovers an optional config file relative to the Git worktree
+// containing the current process working directory. Discovery intentionally
+// ignores Git's local repository environment variables (the variables reported
+// by `git rev-parse --local-env-vars`, such as GIT_DIR and GIT_WORK_TREE) so
+// callers launched from Git hooks still discover the repository for their cwd
+// rather than the repository whose hook invoked them. General Git configuration
+// variables such as GIT_SSH_COMMAND and GIT_TRACE are preserved.
 func GitRootFile(name string) SourceSpec {
 	name = strings.TrimSpace(name)
 	return SourceSpec{
@@ -149,13 +156,47 @@ func GitRootFile(name string) SourceSpec {
 	}
 }
 
+// gitRoot returns the top-level worktree for the current working directory.
+// It scrubs only Git's local repository environment variables before invoking
+// git so inherited hook state cannot override cwd-based repository discovery.
 func gitRoot(ctx context.Context) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel")
+	cmd.Env = scrubGitLocalEnv(os.Environ())
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+func scrubGitLocalEnv(env []string) []string {
+	ret := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && gitLocalEnvVars[key] {
+			continue
+		}
+		ret = append(ret, entry)
+	}
+	return ret
+}
+
+var gitLocalEnvVars = map[string]bool{
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
+	"GIT_CONFIG":                       true,
+	"GIT_CONFIG_COUNT":                 true,
+	"GIT_CONFIG_PARAMETERS":            true,
+	"GIT_DIR":                          true,
+	"GIT_GRAFT_FILE":                   true,
+	"GIT_IMPLICIT_WORK_TREE":           true,
+	"GIT_INDEX_FILE":                   true,
+	"GIT_NO_REPLACE_OBJECTS":           true,
+	"GIT_OBJECT_DIRECTORY":             true,
+	"GIT_PREFIX":                       true,
+	"GIT_REPLACE_REF_BASE":             true,
+	"GIT_SHALLOW_FILE":                 true,
+	"GIT_COMMON_DIR":                   true,
+	"GIT_WORK_TREE":                    true,
 }
 
 func fileExists(path string) bool {


### PR DESCRIPTION
This change makes the discovery of the git repository root more robust,
particularly when the program is executed from within a git hook.

**Problem:**
When running `git rev-parse --show-toplevel`, git respects environment variables
like `GIT_DIR` and `GIT_WORK_TREE`. If our tool is invoked from a git hook,
these variables are set by the parent git process and may not correspond to the
current working directory's repository, leading to incorrect root path
detection.

**Solution:**
- Before invoking `git rev-parse`, we now scrub the environment of local git
  repository variables (those listed by `git rev-parse --local-env-vars`).
- This forces `git` to determine the repository root based on the current
  working directory (CWD), ignoring any inherited hook state.
- A new function, `GitRootFile`, is introduced to utilize this improved logic
  for discovering configuration files relative to the git root.