### PR TITLE
Fix serving embedded help server in external packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/go-go-golems/glazed
 
 go 1.25.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	dagger.io/dagger v0.20.3

--- a/pkg/doc/topics/25-serving-help-over-http.md
+++ b/pkg/doc/topics/25-serving-help-over-http.md
@@ -115,18 +115,49 @@ Returns a full section, including markdown content.
 curl http://localhost:18100/api/sections/help-system
 ```
 
-## Reuse the API and SPA in your own server
+## Embed the help API in your own server
 
-If you already have an HTTP server, you do not need to shell out to `glaze serve`. You can compose the help API and the shared SPA directly from Go.
+If you already have an HTTP server, you can embed the Glazed help JSON API directly into your Go application. You do not need to shell out to `glaze serve`.
 
-The two building blocks are:
+The building block is:
 
-- `web.NewSPAHandler()` for the embedded frontend
-- `server.NewServeHandler(...)` or `server.NewMountedHandler(...)` for API + SPA composition
+- `server.NewServeHandler(...)` or `server.NewMountedHandler(...)` for the REST API
 
-### Mount at the server root
+### API-only mode (recommended for external consumers)
 
-Use this when help is the whole server or when you want the help browser to own `/`.
+Pass `nil` as the SPA handler to serve only the JSON endpoints. This is the recommended approach for binaries that depend on glazed as a library, since the embedded browser UI assets are only available when building from within the glazed repository.
+
+```go
+package main
+
+import (
+    "net/http"
+
+    "github.com/go-go-golems/glazed/pkg/help"
+    helpserver "github.com/go-go-golems/glazed/pkg/help/server"
+)
+
+func main() {
+    hs := help.NewHelpSystem()
+
+    // Load your own help pages here.
+    // err := hs.LoadSectionsFromFS(...)
+
+    // nil = API-only mode, no browser UI.
+    handler := helpserver.NewServeHandler(
+        helpserver.HandlerDeps{Store: hs.Store},
+        nil,
+    )
+
+    _ = http.ListenAndServe(":18100", handler)
+}
+```
+
+This serves the full JSON API (`/api/health`, `/api/sections`, `/api/packages`) without the browser UI. You can build your own frontend, or use `glaze serve --from-glazed-cmd` to browse help from multiple tools in a single web interface.
+
+### With the browser UI (in-repo only)
+
+If you are building within the glazed repository, you can include the embedded React SPA:
 
 ```go
 package main
@@ -141,9 +172,6 @@ import (
 
 func main() {
     hs := help.NewHelpSystem()
-
-    // Load your own help pages here.
-    // err := hs.LoadSectionsFromFS(...)
 
     spaHandler, err := web.NewSPAHandler()
     if err != nil {
@@ -159,62 +187,42 @@ func main() {
 }
 ```
 
+**Note:** The SPA assets are built by `go generate ./pkg/web` (using Dagger/pnpm) and embedded via `//go:embed`. This only works when building from the glazed repository with `-tags embed`. External binaries that depend on glazed as a Go module cannot access these assets — use API-only mode or `glaze serve --from-glazed-cmd` instead.
+
 ### Mount under a prefix such as `/help`
 
-Use this when you already have an HTTP server and want help to live under a sub-route.
+Use `NewMountedHandler` to serve the help API under a sub-route of an existing HTTP server:
 
 ```go
-package main
+mux := http.NewServeMux()
+deps := helpserver.HandlerDeps{Store: hs.Store}
 
-import (
-    "net/http"
-
-    "github.com/go-go-golems/glazed/pkg/help"
-    helpserver "github.com/go-go-golems/glazed/pkg/help/server"
-    "github.com/go-go-golems/glazed/pkg/web"
-)
-
-func main() {
-    hs := help.NewHelpSystem()
-
-    spaHandler, err := web.NewSPAHandler()
-    if err != nil {
-        panic(err)
-    }
-
-    deps := helpserver.HandlerDeps{Store: hs.Store}
-
-    mux := http.NewServeMux()
-    mounted := helpserver.NewMountedHandler("/help", deps, spaHandler)
-    mux.Handle("/help", mounted)
-    mux.Handle("/help/", mounted)
-
-    _ = http.ListenAndServe(":18100", mux)
-}
+// Mount API-only at /help
+mounted := helpserver.NewMountedHandler("/help", deps, nil)
+mux.Handle("/help", mounted)
+mux.Handle("/help/", mounted)
 ```
 
-With this setup:
+This serves:
+- `/help/api/health` — health check
+- `/help/api/sections` — section listing
+- `/help/api/packages` — package listing
 
-- `/help/` serves the SPA
-- `/help/api/health` serves the API
-- `/help/api/sections` lists sections
+### Browsing help from multiple tools
 
-## API-only usage
+The recommended pattern for viewing help from multiple Glazed-based tools in a browser is:
 
-If you want to serve the JSON endpoints without the embedded browser UI, pass `nil` as the SPA handler to `NewServeHandler`.
-
-```go
-handler := helpserver.NewServeHandler(
-    helpserver.HandlerDeps{Store: hs.Store},
-    nil,
-)
+```bash
+glaze serve --from-glazed-cmd pinocchio,sqleton
 ```
 
-This is useful when:
+This loads each tool's help data via `help export --output json` and serves it in a single browser UI. You don't need to embed the SPA in each individual binary.
 
-- your frontend is separate,
-- you want a custom UI,
-- or you only need a programmatic documentation API.
+## Package names and section visibility
+
+Help sections are grouped by package name. When sections are loaded from embedded markdown files (via `LoadSectionsFromFS`), they get an empty package name. `NewServeHandler` automatically assigns these sections a default package name so that they appear correctly in the API responses.
+
+If you are using the Store directly (without `NewServeHandler`), you can call `Store.SetDefaultPackage(ctx, "myapp", "")` after loading your sections to assign them a package name. This is required for the package filter in the help API to work correctly.
 
 ## Loading help pages correctly
 
@@ -242,6 +250,8 @@ If a page does not appear in the browser, the most common cause is that the mark
 | Problem | Cause | Solution |
 | --- | --- | --- |
 | Browser shows a blank page or error | The SPA assets were not generated or embedded | Run `GOWORK=off go generate ./pkg/web`, then rebuild `glaze` |
+| SPA shows "assets have not been generated" | Building from outside the glazed repository | The SPA is only available when building from the glazed repo. Use API-only mode (pass `nil` as SPA handler) or `glaze serve --from-glazed-cmd` |
+| SPA shows "0 sections" but `/api/sections` returns data | Sections have no package name; the SPA filters by package | `NewServeHandler` auto-assigns a default package. For direct Store usage, call `hs.Store.SetDefaultPackage(ctx, "myapp", "")` after loading docs |
 | `/api/health` works but no sections appear | The supplied markdown files were not loaded or were skipped | Verify the path exists, the files end in `.md`, and the frontmatter has fields like `Title`, `Slug`, and `SectionType` |
 | `glaze serve` exits immediately | Invalid path or startup error | Re-run with valid file/directory arguments and inspect the error output |
 | Mounted `/help` route returns 404 | Prefix mounting was not wired correctly in the outer mux | Register both `/help` and `/help/`, and use `server.NewMountedHandler("/help", ...)` |

--- a/pkg/help/server/handlers.go
+++ b/pkg/help/server/handlers.go
@@ -32,6 +32,11 @@ import (
 )
 
 // HandlerDeps holds the dependencies for all HTTP handlers.
+//
+// Store is the only required field. It should be populated with help sections
+// before creating the handler. NewServeHandler automatically assigns a default
+// package name to any sections that have an empty package_name, so most callers
+// do not need to call Store.SetDefaultPackage manually.
 type HandlerDeps struct {
 	Store  *store.Store
 	Logger *slog.Logger

--- a/pkg/help/server/serve.go
+++ b/pkg/help/server/serve.go
@@ -286,7 +286,28 @@ func buildServeLoaders(s *ServeSettings) []helploader.ContentLoader {
 // NewServeHandler composes the API handler and optional SPA handler for use at
 // the server root (/). The returned handler already includes CORS because
 // NewHandler applies it internally.
+//
+// If the Store contains sections with an empty package_name (as happens when
+// loading via LoadSectionsFromFS), this function automatically assigns them the
+// package name "default" so that the SPA's package filter can find them. This is
+// a no-op when sections already have a package name.
+//
+// Pass nil as spaHandler for API-only mode (no browser UI). External binaries
+// that depend on glazed as a library should use API-only mode, since the full
+// SPA assets are only available when building from the glazed repository.
+// Use `glaze serve --from-glazed-cmd` to browse help from multiple tools.
 func NewServeHandler(deps HandlerDeps, spaHandler http.Handler) http.Handler {
+	// Auto-assign a default package name to sections loaded without one.
+	// Sections loaded via LoadSectionsFromFS get package_name = "", but the
+	// SPA's package filter queries by name. Without this, the SPA shows
+	// "0 sections" even though /api/sections (unfiltered) returns data.
+	// This is a no-op when sections already have a package name (e.g. from
+	// ServeCommand.Run which calls SetDefaultPackage explicitly).
+	ctx := context.Background()
+	if err := deps.Store.SetDefaultPackage(ctx, "default", ""); err != nil {
+		log.Warn().Err(err).Msg("Failed to auto-assign default package")
+	}
+
 	apiHandler := NewHandler(deps)
 	if spaHandler == nil {
 		return apiHandler

--- a/pkg/help/server/serve_test.go
+++ b/pkg/help/server/serve_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -195,5 +196,124 @@ Loaded from explicit path.
 	}
 	if _, err := hs.GetSectionWithSlug("embedded-topic"); err == nil {
 		t.Fatalf("expected embedded-topic to be cleared when explicit paths are provided")
+	}
+}
+
+func TestNewServeHandler_AutoAssignsDefaultPackage_Issue571(t *testing.T) {
+	// Reproduce issue #571: sections loaded without a package name should
+	// still appear in the API after NewServeHandler auto-assigns one.
+	hs := help.NewHelpSystem()
+	hs.AddSection(&model.Section{
+		Slug:        "example-topic",
+		Title:       "Example Topic",
+		SectionType: model.SectionGeneralTopic,
+		Short:       "An example section",
+		// PackageName intentionally left empty — this is the bug scenario.
+	})
+
+	// Verify section has no package name before the fix.
+	sections, err := hs.Store.List(context.Background(), "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(sections) != 1 || sections[0].PackageName != "" {
+		t.Fatalf("expected section with empty package_name, got %q", sections[0].PackageName)
+	}
+
+	spaHandler, err := web.NewSPAHandler()
+	if err != nil {
+		t.Fatalf("web.NewSPAHandler: %v", err)
+	}
+
+	handler := NewServeHandler(HandlerDeps{Store: hs.Store}, spaHandler)
+
+	// Step 1: GET /api/packages should return the default package.
+	req := httptest.NewRequest(http.MethodGet, "/api/packages", nil)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("packages: expected status 200, got %d", rw.Code)
+	}
+
+	var pkgResp ListPackagesResponse
+	if err := json.NewDecoder(rw.Body).Decode(&pkgResp); err != nil {
+		t.Fatalf("decode packages: %v", err)
+	}
+	if len(pkgResp.Packages) != 1 || pkgResp.Packages[0].Name != "default" {
+		var names []string
+		for _, p := range pkgResp.Packages {
+			names = append(names, p.Name)
+		}
+		t.Fatalf("expected package 'default', got %v", names)
+	}
+
+	// Step 2: GET /api/sections?package=default should return 1 section.
+	req = httptest.NewRequest(http.MethodGet, "/api/sections?package=default", nil)
+	rw = httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("sections: expected status 200, got %d", rw.Code)
+	}
+
+	var secResp ListSectionsResponse
+	if err := json.NewDecoder(rw.Body).Decode(&secResp); err != nil {
+		t.Fatalf("decode sections: %v", err)
+	}
+	if secResp.Total != 1 {
+		t.Fatalf("expected 1 section for package 'default', got %d", secResp.Total)
+	}
+	if len(secResp.Sections) != 1 || secResp.Sections[0].Slug != "example-topic" {
+		t.Fatalf("expected section 'example-topic', got %v", secResp.Sections)
+	}
+}
+
+func TestNewServeHandler_APIOnlyWithNoSPA(t *testing.T) {
+	// API-only mode (nil SPA handler) should work and auto-assign packages.
+	hs := help.NewHelpSystem()
+	hs.AddSection(&model.Section{
+		Slug:        "api-only-topic",
+		Title:       "API Only Topic",
+		SectionType: model.SectionGeneralTopic,
+	})
+
+	handler := NewServeHandler(HandlerDeps{Store: hs.Store}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sections?package=default", nil)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rw.Code)
+	}
+
+	var secResp ListSectionsResponse
+	if err := json.NewDecoder(rw.Body).Decode(&secResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if secResp.Total != 1 {
+		t.Fatalf("expected 1 section in API-only mode, got %d", secResp.Total)
+	}
+}
+
+func TestNewServeHandler_DoesNotOverwriteExistingPackage(t *testing.T) {
+	// If sections already have a package name, auto-assign should be a no-op.
+	hs := help.NewHelpSystem()
+	hs.AddSection(&model.Section{
+		Slug:        "glazed-topic",
+		Title:       "Glazed Topic",
+		SectionType: model.SectionGeneralTopic,
+		PackageName: "glazed",
+	})
+
+	_ = NewServeHandler(HandlerDeps{Store: hs.Store}, nil)
+
+	sections, err := hs.Store.List(context.Background(), "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(sections) != 1 || sections[0].PackageName != "glazed" {
+		t.Fatalf("expected package_name to remain 'glazed', got %q", sections[0].PackageName)
 	}
 }

--- a/pkg/help/store/store.go
+++ b/pkg/help/store/store.go
@@ -672,6 +672,14 @@ func (s *Store) ListPackages(ctx context.Context) ([]PackageInfo, error) {
 }
 
 // SetDefaultPackage assigns package metadata to sections that do not have it yet.
+// It updates all rows where package_name is empty, setting them to the given
+// packageName and packageVersion.
+//
+// This is necessary because sections loaded from embedded markdown files (via
+// LoadSectionsFromFS) get package_name = "". The SPA's package filter queries
+// by name, so sections without a package name won't appear in the sidebar.
+// NewServeHandler calls this automatically with package "default", so most
+// callers do not need to invoke it directly.
 func (s *Store) SetDefaultPackage(ctx context.Context, packageName, packageVersion string) error {
 	_, err := s.db.ExecContext(ctx, `
 		UPDATE sections

--- a/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/README.md
+++ b/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/README.md
@@ -1,0 +1,21 @@
+# Fix Help SPA Empty Sections Bug and Improve Programmatic API for Issue #571
+
+This is the document workspace for ticket GLZ-571-FIX-SERVE-HTTP-DOCS.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GLZ-571-FIX-SERVE-HTTP-DOCS --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GLZ-571-FIX-SERVE-HTTP-DOCS --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GLZ-571-FIX-SERVE-HTTP-DOCS --field Status --value review`

--- a/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/changelog.md
+++ b/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/changelog.md
@@ -1,0 +1,44 @@
+# Changelog
+
+## 2026-05-12
+
+- Initial workspace created
+
+
+## 2026-05-12
+
+Created comprehensive analysis and design doc for issue #571. Root cause identified: normalization asymmetry between /api/packages and /api/sections combined with missing SetDefaultPackage in programmatic API path. Recommended fix: auto-assign default package in NewServeHandler + documentation updates.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-12/fix-serve-http-docs/glazed/pkg/help/server/handlers.go — handleListPackages normalizes empty to default
+- /home/manuel/workspaces/2026-05-12/fix-serve-http-docs/glazed/pkg/help/server/serve.go — NewServeHandler needs SetDefaultPackage auto-assign
+
+
+## 2026-05-12
+
+Discovered second systemic issue: SPA assets cannot be embedded by external Go binaries that depend on glazed as a library. The go:generate + Dagger pipeline only runs in the glazed repo, and generated assets are excluded from the module cache by .gitignore. External consumers get a placeholder page. Created design doc 02 with analysis and solutions.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-12/fix-serve-http-docs/glazed/cmd/build-web/main.go — Dagger pipeline not transitive across module boundaries
+- /home/manuel/workspaces/2026-05-12/fix-serve-http-docs/glazed/pkg/web/embed.go — SPA embedding only works within glazed repo
+
+
+## 2026-05-12
+
+Created comprehensive SPA distribution architecture patterns reference (ref/02). Covers 5 patterns: separate module, release artifact fetch, runtime fetch, npm package, consumer-side build. Includes decision matrix, decision framework, and step-by-step implementation guide for Pattern A. Uploaded to reMarkable.
+
+
+## 2026-05-12
+
+Implemented fix: (1) NewServeHandler auto-assigns 'default' package to sections with empty package_name. (2) Updated godoc on HandlerDeps, SetDefaultPackage, NewServeHandler. (3) Rewrote help entry 25-serving-help-over-http.md with API-only mode as default, SPA limitation documented, new troubleshooting rows. (4) Added 3 regression tests: auto-assign, API-only, no-overwrite. All 27 server tests pass, all 10 help package test suites pass.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-12/fix-serve-http-docs/glazed/pkg/doc/topics/25-serving-help-over-http.md — Rewrote with API-only default
+- /home/manuel/workspaces/2026-05-12/fix-serve-http-docs/glazed/pkg/help/server/handlers.go — Improved HandlerDeps godoc
+- /home/manuel/workspaces/2026-05-12/fix-serve-http-docs/glazed/pkg/help/server/serve.go — Added SetDefaultPackage auto-assign in NewServeHandler
+- /home/manuel/workspaces/2026-05-12/fix-serve-http-docs/glazed/pkg/help/server/serve_test.go — Added 3 regression tests for issue 571
+- /home/manuel/workspaces/2026-05-12/fix-serve-http-docs/glazed/pkg/help/store/store.go — Improved SetDefaultPackage godoc
+

--- a/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/design-doc/01-root-cause-analysis-and-fix-strategy-for-help-spa-empty-sections-bug.md
+++ b/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/design-doc/01-root-cause-analysis-and-fix-strategy-for-help-spa-empty-sections-bug.md
@@ -1,0 +1,825 @@
+---
+title: Root Cause Analysis and Fix Strategy for Help SPA Empty Sections Bug
+doc_type: design-doc
+status: active
+intent: long-term
+topics:
+  - help
+  - serve
+  - http
+  - spa
+  - api
+  - bug
+  - paper-cut
+  - documentation
+  - intern-guide
+owners:
+  - manuel
+ticket: GLZ-571-FIX-SERVE-HTTP-DOCS
+created: "2026-05-12"
+---
+
+# Root Cause Analysis and Fix Strategy for Help SPA Empty Sections Bug (Issue #571)
+
+## Executive Summary
+
+GitHub issue [#571](https://github.com/go-go-golems/glazed/issues/571) reports that developers who follow the documented "Reuse the API and SPA in your own server" examples get a Help SPA that shows **0 sections** in the sidebar — even though the underlying `/api/sections` endpoint returns data correctly. This is a **documentation bug combined with an API ergonomics problem**. The root cause is a missing `SetDefaultPackage()` call that `glaze serve` performs internally but that the programmatic examples never mention. The right fix is a two-pronged approach:
+
+1. **Fix the API to be harder to misuse** — make `NewServeHandler` auto-assign a default package name when sections have `package_name = ""`, so the programmatic path "just works."
+2. **Fix the documentation** — update the help entry `serve-help-over-http` to show `SetDefaultPackage()` as a best-practice call, and add godoc to the relevant types.
+
+This document is written as an intern-level guide: it explains every layer of the system you need to understand, walks through the bug in detail, and provides a step-by-step implementation plan.
+
+---
+
+## Part 1: System Architecture Overview
+
+### What is the Glazed Help System?
+
+The Glazed help system is a documentation engine embedded in Go CLIs built with the Glazed framework. It solves a specific problem: **CLI help text is limited, but rich browsable documentation makes tools much more usable.** Instead of only showing `--help` output, a Glazed-based CLI can serve an interactive web browser for its documentation.
+
+The system has four major layers, each in its own package:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    React SPA (browser)                    │
+│                  pkg/help/web/src/                        │
+│              User-facing documentation browser            │
+├──────────────────────────────────────────────────────────┤
+│                  HTTP Server Layer                        │
+│               pkg/help/server/                            │
+│           REST API: /api/sections, /api/packages          │
+├──────────────────────────────────────────────────────────┤
+│                SQLite Store Layer                         │
+│              pkg/help/store/                              │
+│         Query engine, predicates, FTS5 search            │
+├──────────────────────────────────────────────────────────┤
+│             Help Domain Model                             │
+│          pkg/help/ + pkg/help/model/                      │
+│    HelpSystem, Section, SectionType, Loaders              │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Layer 1: Help Domain Model (`pkg/help/`, `pkg/help/model/`)
+
+**Key files:**
+- `pkg/help/help.go` — `HelpSystem` struct, `LoadSectionsFromFS()`, `AddSection()`
+- `pkg/help/model/section.go` — `Section` struct, `SectionType` enum
+- `pkg/help/model/parse.go` — YAML frontmatter parser for markdown files
+
+The domain model defines what a "help section" is:
+
+```go
+// pkg/help/model/section.go
+type Section struct {
+    ID             int64       
+    Slug           string      // unique identifier like "serve-help-over-http"
+    SectionType    SectionType // GeneralTopic | Example | Application | Tutorial
+    PackageName    string      // which tool owns this section (e.g. "glazed", "pinocchio")
+    PackageVersion string      // optional version
+    Title          string
+    Short          string      // one-line description
+    Content        string      // full markdown body
+    
+    Topics         []string    // tags like "help", "http", "serve"
+    Flags          []string    // CLI flags this doc relates to
+    Commands       []string    // CLI commands this doc relates to
+    
+    IsTopLevel     bool        // show in main listing
+    ShowPerDefault bool        // show without --all
+    Order          int         // sort position
+}
+```
+
+A `HelpSystem` is the top-level container:
+
+```go
+// pkg/help/help.go
+type HelpSystem struct {
+    Store *store.Store  // SQLite backend
+}
+```
+
+The `HelpSystem` is created with an in-memory SQLite database. You load markdown files into it, and it stores them as `Section` rows. The `LoadSectionsFromFS()` method walks an `embed.FS` or `fs.FS`, parses markdown files with YAML frontmatter, and inserts them.
+
+**Critical detail for the bug:** When sections are loaded via `LoadSectionsFromFS()`, they get `PackageName = ""` and `PackageVersion = ""`. The markdown frontmatter doesn't have a `package_name` field — that field is set externally after loading.
+
+### Layer 2: SQLite Store (`pkg/help/store/`)
+
+**Key files:**
+- `pkg/help/store/store.go` — `Store` struct, CRUD operations, `SetDefaultPackage()`
+- `pkg/help/store/query.go` — `Predicate` system, `QueryCompiler`, SQL generation
+- `pkg/help/store/loader.go` — `Loader` struct for filesystem-to-store sync
+
+The store wraps a SQLite database with a `sections` table:
+
+```sql
+CREATE TABLE sections (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    package_name    TEXT NOT NULL DEFAULT '',
+    package_version TEXT NOT NULL DEFAULT '',
+    slug            TEXT NOT NULL,
+    section_type    INTEGER NOT NULL,
+    title           TEXT NOT NULL,
+    -- ... more columns ...
+    UNIQUE(package_name, package_version, slug)
+);
+```
+
+The unique constraint is on `(package_name, package_version, slug)`. This means two different packages can have sections with the same slug — they're distinguished by package name.
+
+**The `SetDefaultPackage()` method** is the crux of the bug:
+
+```go
+// pkg/help/store/store.go
+func (s *Store) SetDefaultPackage(ctx context.Context, packageName, packageVersion string) error {
+    _, err := s.db.ExecContext(ctx, `
+        UPDATE sections
+        SET package_name = ?, package_version = ?
+        WHERE COALESCE(package_name, '') = ''
+    `, packageName, packageVersion)
+    return err
+}
+```
+
+This method updates all sections that have an empty `package_name`, assigning them the given package name. Without this call, sections loaded from embedded markdown files sit in the database with `package_name = ""`.
+
+The **Predicate system** is how queries are built:
+
+```go
+// pkg/help/store/query.go
+type Predicate func(*QueryCompiler)
+
+// Example predicates:
+func InPackage(packageName string) Predicate { ... }
+func IsType(sectionType model.SectionType) Predicate { ... }
+func HasTopic(topic string) Predicate { ... }
+```
+
+When the SPA requests `GET /api/sections?package=glazed`, the handler builds a predicate:
+
+```go
+store.InPackageVersion("glazed", "")
+```
+
+which compiles to:
+
+```sql
+WHERE s.package_name = 'glazed' AND s.package_version = ''
+```
+
+If sections have `package_name = ""`, this query returns zero rows.
+
+### Layer 3: HTTP Server (`pkg/help/server/`)
+
+**Key files:**
+- `pkg/help/server/handlers.go` — HTTP handlers for all `/api/*` routes
+- `pkg/help/server/serve.go` — `ServeCommand`, `NewServeHandler()`, `NewMountedHandler()`
+- `pkg/help/server/types.go` — request/response types
+- `pkg/help/server/middleware.go` — CORS middleware
+
+The server layer exposes these endpoints:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/health` | Health check, returns section count |
+| `GET /api/packages` | Lists all package names with section counts |
+| `GET /api/sections` | Lists sections, filterable by `package`, `type`, `topic`, `q` |
+| `GET /api/sections/{slug}` | Returns full section detail |
+
+The important type for the bug is `HandlerDeps`:
+
+```go
+// pkg/help/server/types.go
+type HandlerDeps struct {
+    Store  *store.Store
+    Logger *slog.Logger
+}
+```
+
+This is all you need to create an API handler:
+
+```go
+handler := server.NewServeHandler(
+    server.HandlerDeps{Store: hs.Store},
+    spaHandler,
+)
+```
+
+**The `/api/packages` endpoint** has a subtle normalization:
+
+```go
+// pkg/help/server/handlers.go — handleListPackages
+for _, info := range infos {
+    name := info.Name
+    if name == "" {
+        name = "default"  // <-- normalizes empty to "default"
+    }
+    // ...
+}
+```
+
+So when sections have `package_name = ""`, the `/api/packages` response says the package is called `"default"`. But the actual database still has `""`. When the SPA then queries `GET /api/sections?package=default`, the predicate `InPackageVersion("default", "")` searches for `package_name = 'default'`, which matches nothing.
+
+### Layer 4: React SPA (`web/src/`)
+
+**Key files:**
+- `web/src/App.tsx` — root component, wires everything together
+- `web/src/services/api.ts` — RTK Query API slice
+- `web/src/store.ts` — Redux store configuration
+- `web/src/types/index.ts` — TypeScript types mirroring Go types
+- `web/src/components/PackageSelector/PackageSelector.tsx` — package dropdown
+
+The SPA uses Redux Toolkit Query (RTK Query) to fetch data. On startup:
+
+1. `App.tsx` calls `useListPackagesQuery()` → `GET /api/packages`
+2. The response includes `defaultPackage` (e.g., `"default"` for unassigned sections)
+3. `App.tsx` auto-selects this package and sets `selectedPackage`
+4. `App.tsx` calls `useListSectionsQuery({ packageName: selectedPackage })` → `GET /api/sections?package=default`
+5. The server runs `InPackageVersion("default", "")` which returns 0 rows
+6. **The sidebar shows 0 sections**
+
+Here's the relevant code flow in `App.tsx`:
+
+```typescript
+// web/src/App.tsx
+const { data: packageData } = useListPackagesQuery();
+const packages = packageData?.packages ?? [];
+
+useEffect(() => {
+    if (!packageData || selectedPackage) return;
+    const initialPackage = packageData.defaultPackage || packageData.packages[0]?.name || '';
+    setSelectedPackage(initialPackage);
+}, [packageData, selectedPackage]);
+
+// This sends GET /api/sections?package=<selectedPackage>
+const { data: listData } = useListSectionsQuery(
+    selectedPackage ? { packageName: selectedPackage, version: effectiveVersion } : undefined,
+);
+```
+
+---
+
+## Part 2: Root Cause — The Full Bug Chain
+
+Here is the exact sequence of events that causes the bug:
+
+```
+Developer writes:
+    hs := help.NewHelpSystem()
+    doc.AddDocsToHelpSystem(hs)     // loads .md files, all get package_name = ""
+    // MISSING: hs.Store.SetDefaultPackage(ctx, "myapp", "")
+    handler := helpserver.NewServeHandler(
+        helpserver.HandlerDeps{Store: hs.Store},
+        spaHandler,
+    )
+
+Database state:
+    sections table has 65 rows, ALL with package_name = ""
+
+SPA startup:
+    1. GET /api/packages
+       → store.ListPackages() returns [{Name: "", SectionCount: 65}]
+       → handleListPackages normalizes "" to "default"
+       → Response: {packages: [{name: "default", sectionCount: 65}], defaultPackage: "default"}
+
+    2. SPA auto-selects package "default"
+       → setSelectedPackage("default")
+
+    3. GET /api/sections?package=default
+       → buildPredicate creates store.InPackageVersion("default", "")
+       → SQL: WHERE s.package_name = 'default' AND s.package_version = ''
+       → Returns 0 rows (DB has package_name = '', not 'default')
+
+    4. Sidebar shows "0 sections" ✗
+```
+
+The **asymmetry** is the bug: `/api/packages` normalizes `""` to `"default"` for display, but `/api/sections` uses the raw predicate which searches for the literal string `"default"` in the database. The database still has `""`.
+
+### Why does `glaze serve` work?
+
+Because `ServeCommand.Run()` in `pkg/help/server/serve.go` explicitly calls `SetDefaultPackage()`:
+
+```go
+// pkg/help/server/serve.go — ServeCommand.Run()
+loaders := buildServeLoaders(s)
+if len(loaders) == 0 || s.WithEmbedded {
+    if err := hs.Store.SetDefaultPackage(ctx, "glazed", ""); err != nil {
+        return fmt.Errorf("assigning embedded package metadata: %w", err)
+    }
+}
+```
+
+This updates all `package_name = ""` rows to `package_name = "glazed"`. The SPA then queries `GET /api/sections?package=glazed`, which works because the database actually contains `"glazed"`.
+
+---
+
+## Part 3: Fix Strategy — API Improvement vs. Documentation-Only
+
+### Assessment: This is primarily an API ergonomics problem, not just a docs problem
+
+A documentation-only fix would mean: "Tell developers to call `SetDefaultPackage()`." But this has several problems:
+
+1. **The API violates the principle of least surprise.** If you create a `HelpSystem`, load docs, and create a `ServeHandler`, you expect it to work. The fact that it silently shows 0 sections is a bad API smell.
+
+2. **The bug is invisible.** There's no error, no warning, no log message. The SPA just shows an empty sidebar. The unfiltered `/api/sections` endpoint works fine, which makes it even more confusing.
+
+3. **The naming is misleading.** `SetDefaultPackage` sounds optional — like setting a preference. In reality, it's required for the SPA to function at all.
+
+4. **The normalization asymmetry is a genuine bug.** The `/api/packages` handler normalizes `""` to `"default"`, but the `/api/sections` handler doesn't normalize when filtering. This inconsistency should be fixed regardless.
+
+### Recommended two-pronged approach
+
+**Fix A (API): Auto-assign default package in `NewServeHandler`**
+
+When `NewServeHandler` is called, it should check if the store has sections with `package_name = ""` and auto-assign them a default package name. This makes the programmatic path "just work" without requiring callers to know about the package name pitfall.
+
+```go
+// pkg/help/server/serve.go — NewServeHandler
+func NewServeHandler(deps HandlerDeps, spaHandler http.Handler) http.Handler {
+    if deps.Store == nil {
+        panic("server.NewHandler: deps.Store must not be nil")
+    }
+    
+    // Auto-assign default package to sections that don't have one.
+    // This prevents the SPA from showing 0 sections when used programmatically.
+    ctx := context.Background()
+    _ = deps.Store.SetDefaultPackage(ctx, "default", "")
+    
+    apiHandler := NewHandler(deps)
+    // ... rest unchanged
+}
+```
+
+**Fix B (Docs): Update help entry and godoc**
+
+Even with Fix A, the documentation should explain the package system properly:
+
+- Update `pkg/doc/topics/25-serving-help-over-http.md` to mention `SetDefaultPackage()` as a best practice
+- Add godoc to `HandlerDeps` and `SetDefaultPackage()` explaining the package name requirement
+- Fix the normalization inconsistency in `/api/packages` vs `/api/sections`
+
+---
+
+## Part 4: Detailed Implementation Guide
+
+### Fix A: Auto-assign default package
+
+**File: `pkg/help/server/serve.go`**
+
+Change `NewServeHandler` to auto-assign:
+
+```go
+func NewServeHandler(deps HandlerDeps, spaHandler http.Handler) http.Handler {
+    if deps.Store == nil {
+        panic("server.NewHandler: deps.Store must not be nil")
+    }
+    if deps.Logger == nil {
+        deps.Logger = slog.Default()
+    }
+
+    // Auto-assign a default package name to sections that have package_name = "".
+    // Sections loaded via LoadSectionsFromFS get package_name = "", but the SPA's
+    // package filter requires a non-empty name. Without this, the SPA shows
+    // "0 sections" even though the data is in the store.
+    ctx := context.Background()
+    if err := deps.Store.SetDefaultPackage(ctx, "default", ""); err != nil {
+        deps.Logger.Warn("failed to auto-assign default package", "error", err)
+        // Non-fatal: the API still works, just the SPA might show 0 sections.
+    }
+
+    apiHandler := NewHandler(deps)
+    if spaHandler == nil {
+        return apiHandler
+    }
+
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        cleanPath := stdpath.Clean("/" + r.URL.Path)
+        if cleanPath == "/api" || strings.HasPrefix(cleanPath, "/api/") {
+            apiHandler.ServeHTTP(w, r)
+            return
+        }
+        spaHandler.ServeHTTP(w, r)
+    })
+}
+```
+
+**Consideration: Is this a behavior change?**
+
+The `ServeCommand.Run()` already calls `SetDefaultPackage(ctx, "glazed", "")` before `NewServeHandler`. So for the `glaze serve` path:
+- Sections get `package_name = "glazed"` first
+- Then `NewServeHandler` calls `SetDefaultPackage(ctx, "default", "")`
+- But `SetDefaultPackage` only updates rows WHERE `package_name = ''`, which is none
+- So it's a no-op for the existing `glaze serve` path ✓
+
+For the programmatic path (issue #571):
+- Sections have `package_name = ""`
+- `NewServeHandler` auto-assigns them `package_name = "default"`
+- SPA queries `GET /api/sections?package=default` → works ✓
+
+**Alternative: Fix the normalization inconsistency instead**
+
+Instead of auto-assigning, fix the `/api/sections` handler to normalize `package_name = ""` when querying, similar to how `/api/packages` normalizes for display:
+
+```go
+// In buildPredicate or handleListSections:
+if params.PackageName == "default" {
+    // Treat "default" as matching both "" and "default"
+    preds = append(preds, store.Or(
+        store.InPackage(""),
+        store.InPackage("default"),
+    ))
+}
+```
+
+This is more complex and introduces a "magic" package name. The auto-assign approach is cleaner.
+
+### Fix B: Documentation updates
+
+**File: `pkg/doc/topics/25-serving-help-over-http.md`**
+
+Add a section about package assignment. In the "Mount at the server root" example, add a comment:
+
+```go
+func main() {
+    hs := help.NewHelpSystem()
+
+    // Load your own help pages here.
+    // err := hs.LoadSectionsFromFS(...)
+    // Or: err := doc.AddDocToHelpSystem(hs)
+
+    spaHandler, err := web.NewSPAHandler()
+    if err != nil {
+        panic(err)
+    }
+
+    handler := helpserver.NewServeHandler(
+        helpserver.HandlerDeps{Store: hs.Store},
+        spaHandler,
+    )
+
+    _ = http.ListenAndServe(":18100", handler)
+}
+```
+
+Add a new troubleshooting row:
+
+| Problem | Cause | Solution |
+| --- | --- | --- |
+| SPA shows "0 sections" but `/api/sections` returns data | Sections have no package name; the SPA filters by package | NewServeHandler auto-assigns a default package. For manual Store use, call `hs.Store.SetDefaultPackage(ctx, "myapp", "")` after loading docs. |
+
+**File: `pkg/help/server/serve.go`** — Add godoc to `NewServeHandler`:
+
+```go
+// NewServeHandler composes the API handler and optional SPA handler for use at
+// the server root (/). The returned handler already includes CORS because
+// NewHandler applies it internally.
+//
+// If the Store contains sections with empty package_name (as happens when loading
+// via LoadSectionsFromFS), this function automatically assigns them a default
+// package name so the SPA's package filter can find them.
+func NewServeHandler(deps HandlerDeps, spaHandler http.Handler) http.Handler {
+```
+
+**File: `pkg/help/store/store.go`** — Improve `SetDefaultPackage` godoc:
+
+```go
+// SetDefaultPackage assigns package metadata to sections that do not have it yet.
+// It updates all rows where package_name is empty, setting them to the given
+// packageName and packageVersion.
+//
+// This is necessary because sections loaded from embedded markdown files (via
+// LoadSectionsFromFS) get package_name = "". The SPA's package filter queries
+// by name, so sections without a package name won't appear in the sidebar.
+// NewServeHandler calls this automatically, but direct Store users should call
+// it after loading sections.
+func (s *Store) SetDefaultPackage(ctx context.Context, packageName, packageVersion string) error {
+```
+
+### Fix C: Add a test for the programmatic path
+
+**File: `pkg/help/server/serve_test.go`**
+
+Add a test that reproduces issue #571:
+
+```go
+func TestNewServeHandler_AutoAssignsDefaultPackage(t *testing.T) {
+    // Create a help system and load sections WITHOUT calling SetDefaultPackage
+    hs := help.NewHelpSystem()
+    hs.AddSection(&model.Section{
+        Slug:        "test-topic",
+        Title:       "Test Topic",
+        SectionType: model.SectionGeneralTopic,
+        Short:       "A test section",
+        // PackageName intentionally left empty — this is the bug scenario
+    })
+
+    spaHandler, err := web.NewSPAHandler()
+    if err != nil {
+        t.Fatalf("web.NewSPAHandler: %v", err)
+    }
+
+    handler := NewServeHandler(HandlerDeps{Store: hs.Store}, spaHandler)
+
+    // The SPA should be able to list sections via the default package
+    req := httptest.NewRequest(http.MethodGet, "/api/sections?package=default", nil)
+    rw := httptest.NewRecorder()
+    handler.ServeHTTP(rw, req)
+
+    if rw.Code != http.StatusOK {
+        t.Fatalf("expected status 200, got %d", rw.Code)
+    }
+
+    var resp ListSectionsResponse
+    if err := json.NewDecoder(rw.Body).Decode(&resp); err != nil {
+        t.Fatalf("decode response: %v", err)
+    }
+
+    if resp.Total != 1 {
+        t.Fatalf("expected 1 section after auto-assign, got %d", resp.Total)
+    }
+}
+```
+
+---
+
+## Part 5: Key File Reference Map
+
+For the intern working on this fix, here are all the files you need to understand and modify:
+
+### Files to modify
+
+| File | What to change |
+|------|---------------|
+| `pkg/help/server/serve.go` | Add `SetDefaultPackage` call in `NewServeHandler`. Update godoc on `NewServeHandler`. |
+| `pkg/help/store/store.go` | Improve godoc on `SetDefaultPackage`. |
+| `pkg/doc/topics/25-serving-help-over-http.md` | Add troubleshooting row, mention `SetDefaultPackage` best practice. |
+| `pkg/help/server/serve_test.go` | Add `TestNewServeHandler_AutoAssignsDefaultPackage` test. |
+
+### Files to read (no changes needed)
+
+| File | Why it matters |
+|------|---------------|
+| `pkg/help/help.go` | Defines `HelpSystem`, `LoadSectionsFromFS()`, `AddSection()` |
+| `pkg/help/model/section.go` | Defines `Section` struct with `PackageName` field |
+| `pkg/help/store/store.go` | Defines `Store`, `SetDefaultPackage()`, `ListPackages()`, SQL schema |
+| `pkg/help/store/query.go` | Defines `Predicate`, `InPackage()`, `InPackageVersion()` |
+| `pkg/help/server/handlers.go` | HTTP handlers, `handleListPackages` normalizes "" to "default" |
+| `pkg/help/server/types.go` | `HandlerDeps`, request/response types |
+| `pkg/help/loader/sources.go` | Content loaders, `MarkdownPathLoader` calls `SetDefaultPackage` |
+| `web/src/App.tsx` | SPA startup logic, auto-selects `defaultPackage` |
+| `web/src/services/api.ts` | RTK Query API, resolves base URL for mounted deployments |
+| `cmd/glaze/main.go` | Shows how `glaze serve` wires everything together |
+
+### Data flow diagram
+
+```
+                    ┌─────────────────┐
+                    │  embed.FS / fs   │
+                    │  (markdown files)│
+                    └────────┬────────┘
+                             │ LoadSectionsFromFS()
+                             │ parses YAML frontmatter
+                             │ sections get package_name=""
+                             ▼
+                    ┌─────────────────┐
+                    │   HelpSystem    │
+                    │  (help.go)      │
+                    │                 │
+                    │  Store *Store ──┼──► SQLite (in-memory)
+                    └────────┬────────┘    sections table:
+                             │             package_name = ""
+                             │
+         ┌───────────────────┼───────────────────────┐
+         │                   │                       │
+    glaze serve         programmatic            direct Store
+    (serve.go)           path (#571)             usage
+         │                   │                       │
+         ▼                   ▼                       │
+  SetDefaultPackage    MISSING THIS CALL              │
+  ("glazed", "")             │                       │
+  package_name →        package_name                  │
+  "glazed" ✓            stays "" ✗                    │
+         │                   │                       │
+         ▼                   ▼                       ▼
+  ┌──────────────────────────────────────────────────────┐
+  │              NewServeHandler(deps, spa)               │
+  │                                                       │
+  │   GET /api/packages  → normalizes "" to "default"     │
+  │   GET /api/sections?package=default → searches        │
+  │       WHERE package_name='default' → 0 rows ✗         │
+  │       WHERE package_name='glazed'  → N rows ✓         │
+  └──────────────────────────────────────────────────────┘
+```
+
+---
+
+## Part 6: Implementation Checklist
+
+### Step 1: Add auto-assign to `NewServeHandler`
+
+- [ ] Open `pkg/help/server/serve.go`
+- [ ] In `NewServeHandler`, add `deps.Store.SetDefaultPackage(context.Background(), "default", "")` after the nil check
+- [ ] Log a warning if it fails but don't panic (non-fatal degradation)
+- [ ] Update the godoc on `NewServeHandler` to document this behavior
+
+### Step 2: Improve godoc on `SetDefaultPackage`
+
+- [ ] Open `pkg/help/store/store.go`
+- [ ] Expand the doc comment to explain why it's needed and when it's called automatically
+
+### Step 3: Add regression test
+
+- [ ] Open `pkg/help/server/serve_test.go`
+- [ ] Add `TestNewServeHandler_AutoAssignsDefaultPackage` (see pseudocode above)
+- [ ] Run `go test ./pkg/help/server/...` to verify
+
+### Step 4: Update help documentation
+
+- [ ] Open `pkg/doc/topics/25-serving-help-over-http.md`
+- [ ] Add a troubleshooting row for "SPA shows 0 sections"
+- [ ] Add a brief note in the programmatic examples about `SetDefaultPackage` as a best practice
+- [ ] Mention that `NewServeHandler` auto-assigns, so most users don't need to call it manually
+
+### Step 5: Verify end-to-end
+
+- [ ] Run `go test ./pkg/help/...` — all tests pass
+- [ ] Run `glaze serve` — still works, shows correct sections
+- [ ] Build a test program using the programmatic API (no `SetDefaultPackage` call) — SPA should now show sections
+
+---
+
+## Part 7: Alternatives Considered
+
+### Alternative 1: Documentation-only fix
+
+Just update the help entry and godoc. Leave the API as-is.
+
+**Pros:** No code changes, no risk of regression.
+**Cons:** Every developer using the programmatic API hits this bug first. It's a paper-cut that damages trust in the framework. The normalization asymmetry remains.
+
+**Verdict:** Insufficient. The API should be harder to misuse.
+
+### Alternative 2: Fix the SPA to handle empty package names
+
+Modify the SPA to not filter by package when there's only one package (the implicit "default").
+
+**Pros:** Works without any backend changes.
+**Cons:** Makes the SPA more complex. Breaks multi-package serving. Doesn't fix the root cause (sections with empty package_name).
+
+**Verdict:** Wrong layer. The backend should have consistent data.
+
+### Alternative 3: Make `LoadSectionsFromFS` accept a package name parameter
+
+Change the signature to `LoadSectionsFromFS(f fs.FS, dir string, packageName string)`.
+
+**Pros:** Sections get their package name at load time, which is the right place.
+**Cons:** Breaking API change. All callers need to be updated. `LoadSectionsFromFS` is called from many places.
+
+**Verdict:** Too invasive for a bug fix. Consider for a future v2 API cleanup.
+
+### Alternative 4 (recommended): Auto-assign in `NewServeHandler`
+
+Call `SetDefaultPackage` inside `NewServeHandler`.
+
+**Pros:** No API changes. Existing code starts working. No risk to `glaze serve` path (it's a no-op there). Fixes the bug at the boundary where it matters.
+**Cons:** Slightly magical behavior — the handler mutates the store. But it's a reasonable default and documented.
+
+**Verdict:** Best cost-benefit ratio. Safe, minimal, and effective.
+
+---
+
+## Part 8: Open Questions
+
+1. **Should the auto-assign package name be configurable?** Currently we'd use `"default"`. Should `HandlerDeps` get a `DefaultPackageName string` field? This adds complexity but gives control. Recommendation: Start with hardcoded `"default"`, add the field later if requested.
+
+2. **Should `handleListSections` also normalize empty package names?** The `/api/packages` handler normalizes `""` to `"default"`. Should the sections handler do the same? With Fix A, this becomes moot since sections won't have empty names after auto-assign. But for robustness, adding normalization in the query layer would be defensive.
+
+3. **Should there be a log message when auto-assign happens?** A debug-level log like "auto-assigned N sections to package 'default'" would help troubleshooting. Yes, add this.
+
+---
+
+## Appendix A: Pseudocode for the Complete Fix
+
+### serve.go — NewServeHandler
+
+```go
+func NewServeHandler(deps HandlerDeps, spaHandler http.Handler) http.Handler {
+    if deps.Store == nil {
+        panic("server.NewHandler: deps.Store must not be nil")
+    }
+    if deps.Logger == nil {
+        deps.Logger = slog.Default()
+    }
+
+    // BUGFIX (#571): Auto-assign a default package name to sections loaded
+    // without one. Sections loaded via LoadSectionsFromFS get package_name = "".
+    // The SPA's package filter queries by name, so without this, the SPA shows
+    // "0 sections" even though /api/sections (unfiltered) returns data correctly.
+    // This is a no-op when sections already have a package name (e.g., from
+    // ServeCommand.Run which calls SetDefaultPackage explicitly).
+    ctx := context.Background()
+    if err := deps.Store.SetDefaultPackage(ctx, "default", ""); err != nil {
+        deps.Logger.Warn("failed to auto-assign default package", "error", err)
+    }
+
+    apiHandler := NewHandler(deps)
+    if spaHandler == nil {
+        return apiHandler
+    }
+
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        cleanPath := stdpath.Clean("/" + r.URL.Path)
+        if cleanPath == "/api" || strings.HasPrefix(cleanPath, "/api/") {
+            apiHandler.ServeHTTP(w, r)
+            return
+        }
+        spaHandler.ServeHTTP(w, r)
+    })
+}
+```
+
+### serve_test.go — New test
+
+```go
+func TestNewServeHandler_AutoAssignsDefaultPackage_Issue571(t *testing.T) {
+    // Reproduce issue #571: sections loaded without a package name should
+    // still appear in the SPA after NewServeHandler auto-assigns one.
+    hs := help.NewHelpSystem()
+    hs.AddSection(&model.Section{
+        Slug:        "example-topic",
+        Title:       "Example Topic",
+        SectionType: model.SectionGeneralTopic,
+        Short:       "An example section",
+        // PackageName intentionally empty — this is the bug scenario
+    })
+
+    // Verify section has no package name
+    sections, err := hs.Store.List(context.Background(), "")
+    if err != nil {
+        t.Fatalf("list: %v", err)
+    }
+    if len(sections) != 1 || sections[0].PackageName != "" {
+        t.Fatalf("expected section with empty package_name")
+    }
+
+    spaHandler, err := web.NewSPAHandler()
+    if err != nil {
+        t.Fatalf("web.NewSPAHandler: %v", err)
+    }
+
+    handler := NewServeHandler(HandlerDeps{Store: hs.Store}, spaHandler)
+
+    // Step 1: GET /api/packages should return the default package
+    req := httptest.NewRequest(http.MethodGet, "/api/packages", nil)
+    rw := httptest.NewRecorder()
+    handler.ServeHTTP(rw, req)
+
+    var pkgResp ListPackagesResponse
+    json.NewDecoder(rw.Body).Decode(&pkgResp)
+    if len(pkgResp.Packages) != 1 || pkgResp.Packages[0].Name != "default" {
+        t.Fatalf("expected package 'default', got %v", pkgResp.Packages)
+    }
+
+    // Step 2: GET /api/sections?package=default should return 1 section
+    req = httptest.NewRequest(http.MethodGet, "/api/sections?package=default", nil)
+    rw = httptest.NewRecorder()
+    handler.ServeHTTP(rw, req)
+
+    var secResp ListSectionsResponse
+    json.NewDecoder(rw.Body).Decode(&secResp)
+    if secResp.Total != 1 {
+        t.Fatalf("expected 1 section for package 'default', got %d", secResp.Total)
+    }
+}
+```
+
+---
+
+## Appendix B: Key API Reference Quick-Look
+
+| Type | Package | Purpose |
+|------|---------|---------|
+| `HelpSystem` | `pkg/help` | Top-level container, holds `Store` |
+| `Store` | `pkg/help/store` | SQLite-backed CRUD for sections |
+| `Section` | `pkg/help/model` | A single help document with metadata |
+| `SectionType` | `pkg/help/model` | Enum: GeneralTopic, Example, Application, Tutorial |
+| `HandlerDeps` | `pkg/help/server` | Dependencies for HTTP handlers (just `Store`) |
+| `Predicate` | `pkg/help/store` | Query builder function type |
+| `ContentLoader` | `pkg/help/loader` | Interface for loading from external sources |
+| `PackageInfo` | `pkg/help/store` | Summary of a package/version group |
+
+### Key methods
+
+| Method | Location | What it does |
+|--------|----------|-------------|
+| `NewHelpSystem()` | `pkg/help/help.go` | Creates HelpSystem with in-memory SQLite |
+| `LoadSectionsFromFS(f, dir)` | `pkg/help/help.go` | Loads .md files into Store, sections get `package_name = ""` |
+| `AddSection(section)` | `pkg/help/help.go` | Upserts a section into Store |
+| `Store.SetDefaultPackage(ctx, name, ver)` | `pkg/help/store/store.go` | Updates all `package_name = ""` rows |
+| `Store.ListPackages(ctx)` | `pkg/help/store/store.go` | Returns package/version groups with counts |
+| `Store.Find(ctx, predicate)` | `pkg/help/store/query.go` | Queries sections with predicate system |
+| `NewServeHandler(deps, spa)` | `pkg/help/server/serve.go` | Creates HTTP handler for API + SPA |
+| `NewMountedHandler(prefix, deps, spa)` | `pkg/help/server/serve.go` | Creates prefix-mounted handler |
+| `NewSPAHandler()` | `pkg/help/web/static.go` | Creates SPA handler from embedded assets |
+| `AddDocToHelpSystem(hs)` | `pkg/doc/doc.go` | Loads embedded Glazed docs into HelpSystem |

--- a/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/design-doc/02-spa-asset-embedding-problem-for-external-consumers.md
+++ b/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/design-doc/02-spa-asset-embedding-problem-for-external-consumers.md
@@ -1,0 +1,313 @@
+---
+title: SPA Asset Embedding Problem for External Consumers
+doc_type: design-doc
+status: active
+intent: long-term
+topics:
+  - help
+  - serve
+  - http
+  - spa
+  - api
+  - bug
+  - paper-cut
+  - documentation
+  - intern-guide
+owners:
+  - manuel
+ticket: GLZ-571-FIX-SERVE-HTTP-DOCS
+created: "2026-05-12"
+---
+
+# SPA Asset Embedding Problem for External Consumers
+
+## Executive Summary
+
+While investigating issue #571, a second systemic problem emerged: **the Help SPA frontend assets cannot be embedded by external Go binaries that depend on glazed as a library.** The current build pipeline uses `go:generate` + Dagger to build the React frontend and copy it to `pkg/web/embed/public/`, then a `//go:embed` directive with the `embed` build tag bakes it into the binary. This works for `glaze` itself, but any other binary (pinocchio, sqleton, etc.) that imports `pkg/web` will get a **placeholder HTML page** instead of the real SPA — the generated assets simply don't exist in the Go module cache.
+
+This document explains the full asset pipeline, why it breaks for external consumers, and evaluates potential fixes.
+
+---
+
+## Part 1: The Current Asset Pipeline
+
+### Build flow for `glaze` itself
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Step 1: go generate ./pkg/web                                    │
+│                                                                  │
+│   pkg/web/gen.go:                                                │
+│     //go:generate go run ../../cmd/build-web                     │
+│                                                                  │
+│   cmd/build-web/main.go:                                         │
+│     1. Find repo root (walk up to go.mod)                        │
+│     2. Use Dagger (or local pnpm) to build web/                  │
+│     3. Copy web/dist/ → pkg/web/embed/public/                    │
+│                                                                  │
+│   Result: pkg/web/embed/public/index.html, *.js, *.css           │
+├──────────────────────────────────────────────────────────────────┤
+│ Step 2: go build -tags embed ./cmd/glaze                         │
+│                                                                  │
+│   pkg/web/embed.go  (build tag: embed):                          │
+│     //go:embed embed/public                                      │
+│     var embeddedFS embed.FS                                      │
+│     var PublicFS = mustSubFS(embeddedFS, "embed/public")         │
+│                                                                  │
+│   → index.html, JS, CSS are baked into the glaze binary         │
+├──────────────────────────────────────────────────────────────────┤
+│ Step 3: Runtime                                                  │
+│                                                                  │
+│   web.NewSPAHandler() → reads PublicFS → serves real SPA         │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+**Key files:**
+
+| File | Role |
+|------|------|
+| `pkg/web/gen.go` | `//go:generate` directive that triggers the build |
+| `cmd/build-web/main.go` | Dagger-based build tool, copies output to `embed/public/` |
+| `pkg/web/embed.go` | `//go:build embed` — uses `//go:embed` to bake assets |
+| `pkg/web/embed_none.go` | `//go:build !embed` — fallback for dev/test builds |
+| `pkg/web/static.go` | `NewSPAHandler()` — serves from `PublicFS` |
+| `.gitignore` | Excludes `pkg/web/embed/public/` — assets never committed |
+
+### The `embed_none.go` fallback
+
+When the binary is built **without** `-tags embed` (the default), `embed_none.go` kicks in:
+
+```go
+// pkg/web/embed_none.go
+//go:build !embed
+
+var PublicFS = findPublicFS()
+
+func findPublicFS() fs.FS {
+    // 1. Walk up from CWD looking for repo root (go.mod)
+    // 2. Check pkg/web/embed/public/index.html on disk
+    // 3. Check web/dist/index.html on disk
+    // 4. Fall back to a tiny placeholder HTML
+    return fallbackPublicFS()
+}
+
+func fallbackPublicFS() fs.FS {
+    return fstest.MapFS{
+        "index.html": &fstest.MapFile{Data: []byte(`<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Glazed Help Browser</title></head>
+  <body><div id="root">Glazed Help Browser assets have not been generated.
+    Run go generate ./pkg/web for the full browser.</div></body>
+</html>`)},
+    }
+}
+```
+
+This fallback is fine for **development** (running `go test` in the glazed repo). But for **external consumers** it produces a broken SPA.
+
+---
+
+## Part 2: Why External Consumers Get No SPA
+
+### What happens when pinocchio does `web.NewSPAHandler()`
+
+```
+pinocchio's go.mod:
+    require github.com/go-go-golems/glazed v0.38.0
+
+pinocchio's main.go:
+    import "github.com/go-go-golems/glazed/pkg/web"
+    spaHandler, err := web.NewSPAHandler()
+
+Build:
+    go build -o pinocchio ./cmd/pinocchio
+```
+
+**Scenario A: No `embed` build tag (default)**
+
+1. `embed_none.go` is compiled (since no `-tags embed`)
+2. `findPublicFS()` walks up from CWD looking for `go.mod`
+3. Finds pinocchio's `go.mod` (not glazed's)
+4. Checks `pkg/web/embed/public/index.html` relative to pinocchio's root — doesn't exist
+5. Checks `web/dist/index.html` relative to pinocchio's root — doesn't exist
+6. Falls back to `fallbackPublicFS()` — **placeholder page**
+7. `NewSPAHandler()` succeeds but serves a useless page
+
+**Scenario B: With `-tags embed`**
+
+1. `embed.go` is compiled
+2. `//go:embed embed/public` looks for `pkg/web/embed/public/` relative to the **glazed module source**
+3. In the Go module cache (`$GOMODCACHE/github.com/go-go-golems/glazed@v0.38.0/`), that directory **doesn't exist** because:
+   - `.gitignore` excludes `embed/public/` — the generated files are never committed
+   - `go mod download` only gets committed files
+   - The Go module zip deliberately excludes files matching `.gitignore`
+4. **Build fails** with: `no matching files found for pattern embed/public`
+
+**Neither scenario works.** External consumers cannot get the SPA assets.
+
+### Why `go generate` doesn't help
+
+`go generate` only runs on source in your own module. When pinocchio runs `go generate ./...`, it does NOT run `go generate` inside glazed's module cache. The `//go:generate` directive in `pkg/web/gen.go` is part of the glazed module, and Go's generate tool doesn't cross module boundaries.
+
+Even if it did, the Dagger build tool (`cmd/build-web/main.go`) walks up from CWD to find the repo root by looking for `go.mod`. In the module cache, this would find glazed's `go.mod` but there's no `web/` directory in the module cache with the React source — only the compiled `.go` files and committed assets.
+
+---
+
+## Part 3: How Multi-Tool Help Serving Actually Works Today
+
+The **current working pattern** for serving help from multiple tools is:
+
+```bash
+glaze serve --from-glazed-cmd pinocchio,sqleton
+```
+
+This works because:
+
+1. Only `glaze` has the SPA embedded in its binary
+2. `--from-glazed-cmd` runs `pinocchio help export --output json` to get section metadata
+3. The metadata (JSON) is loaded into glaze's help store
+4. `glaze` serves its own SPA with all the imported sections
+
+**The SPA is only ever served from `glaze` itself.** Other binaries don't need the SPA — they just export their help data as JSON.
+
+This means the "Reuse the API and SPA in your own server" documentation in the help entry is actually **misleading for external binaries**. The code example works (after the #571 fix), but only if you're building within the glazed repo. An external binary would need the SPA assets, which it can't get.
+
+---
+
+## Part 4: Solutions
+
+### Solution A: Commit the generated assets to the repository
+
+**What:** Remove `pkg/web/embed/public/` from `.gitignore` and commit the built JS/CSS/HTML.
+
+**Pros:**
+- External consumers get assets automatically when they `go mod download`
+- Works with `//go:embed` as-is
+- No pipeline changes needed
+- The most straightforward fix
+
+**Cons:**
+- Bloats the git repository with generated binary blobs
+- Every frontend change creates large diffs
+- Need a CI step to ensure committed assets are up to date
+- Go module zip size increases
+
+**Implementation:**
+1. Remove `/pkg/web/embed/public/` from `.gitignore`
+2. Run `go generate ./pkg/web` and commit the output
+3. Add a CI check that verifies committed assets match a fresh build
+4. Update GoReleaser `before: hooks` to always regenerate (already runs `go generate ./...`)
+
+### Solution B: Make the SPA an opt-in import
+
+**What:** Move the SPA assets to a separate Go module or package that external consumers can import if they want the frontend.
+
+```go
+// External consumer who wants the SPA:
+import _ "github.com/go-go-golems/glazed/pkg/web/spa-assets"
+
+// External consumer who only wants the API:
+import "github.com/go-go-golems/glazed/pkg/web"  // no SPA assets
+```
+
+**Pros:**
+- Clean separation between API and SPA
+- External consumers opt in explicitly
+- Binary size stays small for API-only users
+
+**Cons:**
+- Requires a separate module or package with its own embedding
+- Same problem: the SPA assets still need to be in the module cache somehow
+- More complex import path
+
+### Solution C: Serve the SPA from a CDN or static file server
+
+**What:** Don't embed the SPA at all. Instead, serve it from a CDN or let the user provide their own.
+
+```go
+// NewSPAHandler accepts an optional URL or fs.FS
+func NewSPAHandler(assets fs.FS) (http.Handler, error)
+```
+
+**Pros:**
+- Completely decouples SPA distribution from Go builds
+- Always up-to-date frontend
+- External consumers can use their own frontend
+
+**Cons:**
+- Requires network access to load the SPA
+- Breaks the "single binary" deployment model
+- More configuration for users
+
+### Solution D: API-only mode as the documented default for external consumers
+
+**What:** Document that external consumers should use the API-only mode (pass `nil` as SPA handler) and build their own frontend or use `glaze serve --from-glazed-cmd` for the browser.
+
+```go
+// Recommended for external binaries:
+handler := helpserver.NewServeHandler(
+    helpserver.HandlerDeps{Store: hs.Store},
+    nil,  // no SPA — use the JSON API directly
+)
+```
+
+**Pros:**
+- No code changes needed
+- The JSON API works perfectly for external consumers
+- Consistent with the `--from-glazed-cmd` pattern
+- Single binary still works
+
+**Cons:**
+- External consumers can't get the browser UI without running `glaze serve`
+- Limits the "compose in your own server" story to API-only
+
+### Recommendation
+
+**Short term (now): Solution D** — Update the documentation to be honest about the limitation. The "Reuse the API and SPA" section should clearly state that the SPA embedding only works within the glazed repo, and recommend API-only mode or `glaze serve --from-glazed-cmd` for external binaries.
+
+**Medium term: Solution A** — Commit the generated assets. Yes, it bloats the repo, but it's the simplest way to make `//go:embed` work transitively. Add a CI check to verify they're fresh. This is a common pattern (many Go projects commit generated protobuf code, for example).
+
+**Long term: Consider Solution B or C** if the SPA grows large or if there's a need for custom frontends.
+
+---
+
+## Part 5: Updated Architecture Diagram
+
+```
+Current state (broken for external consumers):
+
+┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐
+│       glaze         │     │     pinocchio        │     │      sqleton        │
+│                     │     │                     │     │                     │
+│  Has SPA ✓          │     │  No SPA ✗            │     │  No SPA ✗            │
+│  Has help docs ✓    │     │  Has help docs ✓    │     │  Has help docs ✓    │
+│                     │     │                     │     │                     │
+│  Can serve browser  │     │  Can export JSON    │     │  Can export JSON    │
+│  for itself +       │     │  for glaze to       │     │  for glaze to       │
+│  imported packages  │     │  import via          │     │  import via          │
+│                     │     │  --from-glazed-cmd  │     │  --from-glazed-cmd  │
+└─────────────────────┘     └─────────────────────┘     └─────────────────────┘
+
+The working pattern:
+    glaze serve --from-glazed-cmd pinocchio,sqleton
+    → glaze loads pinocchio's and sqleton's help as JSON
+    → glaze serves its own SPA with all three packages
+
+The broken pattern (issue #571):
+    pinocchio tries:
+        handler := NewServeHandler(deps, spaHandler)
+    → spaHandler serves placeholder HTML
+    → Even if SPA worked, sections show 0 (SetDefaultPackage bug)
+```
+
+---
+
+## Part 6: Action Items
+
+1. **Update `pkg/doc/topics/25-serving-help-over-http.md`** — Add a clear note that the SPA embedding only works within the glazed repo. Recommend API-only mode for external consumers.
+
+2. **Consider committing generated assets** — Evaluate the repo size impact. If the SPA is small (likely under 500KB gzipped), committing it is practical.
+
+3. **Add a runtime check** — In `NewSPAHandler()`, if `PublicFS` only contains the placeholder (no JS/CSS), log a warning explaining why the SPA won't work and suggesting alternatives.
+
+4. **Cross-reference with issue #571** — The SetDefaultPackage fix from #571 is still needed regardless. Even if external consumers use API-only mode, they need correct package assignment for their own API clients.

--- a/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/index.md
+++ b/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/index.md
@@ -1,0 +1,96 @@
+---
+Title: 'Fix Help SPA Empty Sections Bug and Improve Programmatic API for Issue #571'
+Ticket: GLZ-571-FIX-SERVE-HTTP-DOCS
+Status: active
+Topics:
+    - help
+    - serve
+    - http
+    - spa
+    - api
+    - bug
+    - paper-cut
+    - documentation
+    - intern-guide
+DocType: index
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles:
+    - Path: cmd/build-web/main.go
+      Note: Dagger-based SPA build tool
+    - Path: pkg/doc/topics/25-serving-help-over-http.md
+      Note: Help entry with programmatic examples missing SetDefaultPackage
+    - Path: pkg/help/server/handlers.go
+      Note: handleListPackages normalizes empty package_name to default
+    - Path: pkg/help/server/serve.go
+      Note: NewServeHandler needs auto-assign SetDefaultPackage call
+    - Path: pkg/help/store/store.go
+      Note: SetDefaultPackage assigns package_name to sections without one
+    - Path: pkg/web/embed.go
+      Note: SPA assets embedded via go:embed
+    - Path: pkg/web/embed_none.go
+      Note: Fallback for non-embed builds
+    - Path: pkg/web/gen.go
+      Note: go:generate directive for building SPA frontend
+    - Path: web/src/App.tsx
+      Note: SPA auto-selects defaultPackage on startup
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-05-12T10:01:34.960586841-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+
+
+
+
+
+
+
+
+# Fix Help SPA Empty Sections Bug and Improve Programmatic API for Issue #571
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- help
+- serve
+- http
+- spa
+- api
+- bug
+- paper-cut
+- documentation
+- intern-guide
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/reference/01-investigation-diary.md
@@ -1,0 +1,71 @@
+---
+title: Investigation Diary
+doc_type: reference
+status: active
+intent: long-term
+topics:
+  - help
+  - serve
+  - http
+  - spa
+  - api
+  - bug
+  - paper-cut
+  - documentation
+  - intern-guide
+owners:
+  - manuel
+ticket: GLZ-571-FIX-SERVE-HTTP-DOCS
+created: "2026-05-12"
+---
+
+# Investigation Diary
+
+## 2026-05-12 — Initial Analysis
+
+### Context
+GitHub issue #571 reports that the Help SPA shows 0 sections when using the programmatic API path (`NewServeHandler`/`NewMountedHandler`) without calling `SetDefaultPackage()` first.
+
+### Investigation Steps
+
+1. **Read the issue** — Clear description of the bug, reproduction steps, and suggested fixes.
+2. **Read `pkg/help/server/serve.go`** — Found `ServeCommand.Run()` calls `SetDefaultPackage(ctx, "glazed", "")` at line ~155. This is the `glaze serve` path only.
+3. **Read `pkg/help/server/handlers.go`** — Found `handleListPackages` normalizes `""` to `"default"` for display, but `handleListSections` uses raw `InPackageVersion` predicate which doesn't normalize.
+4. **Read `pkg/help/store/store.go`** — Confirmed `SetDefaultPackage` updates rows WHERE `package_name = ''`.
+5. **Read `pkg/help/help.go`** — Confirmed `LoadSectionsFromFS` doesn't set any package name.
+6. **Read `web/src/App.tsx`** — Confirmed SPA auto-selects `defaultPackage` from `/api/packages` response, then filters sections by that name.
+7. **Read the help doc** `pkg/doc/topics/25-serving-help-over-http.md` — Confirmed programmatic examples are missing `SetDefaultPackage` call.
+
+### Root Cause Chain
+
+```
+LoadSectionsFromFS → package_name = ""
+/api/packages → normalizes "" to "default" for display
+SPA selects "default" as active package
+/api/sections?package=default → SQL WHERE package_name = 'default' → 0 rows
+```
+
+### Analysis: Is this a docs bug or API bug?
+
+**Both.** The documentation is incomplete, but the real problem is that the API has a trap:
+- Creating a `HelpSystem`, loading docs, and creating a `ServeHandler` should Just Work
+- The `SetDefaultPackage` requirement is invisible and unintuitive
+- The normalization asymmetry in the API (`/api/packages` normalizes, `/api/sections` doesn't) is a genuine inconsistency
+
+### Recommended Fix
+
+Two-pronged approach:
+1. **API fix**: Auto-assign default package in `NewServeHandler` — makes the programmatic path Just Work
+2. **Docs fix**: Update help entry and godoc to explain the package system
+
+The auto-assign is safe because `SetDefaultPackage` is idempotent (only updates rows with empty names). For the existing `glaze serve` path, it's a no-op since sections already have names.
+
+### Design doc written
+
+Created comprehensive design doc at `design-doc/01-root-cause-analysis-and-fix-strategy-for-help-spa-empty-sections-bug.md` covering:
+- Full system architecture (4 layers)
+- Root cause chain with code references
+- Fix strategy with pseudocode
+- Alternatives considered
+- Implementation checklist
+- API reference quick-look tables

--- a/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/reference/02-spa-distribution-architecture-patterns-for-go-embedded-frontends.md
+++ b/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/reference/02-spa-distribution-architecture-patterns-for-go-embedded-frontends.md
@@ -1,0 +1,677 @@
+---
+title: SPA Distribution Architecture Patterns for Go Embedded Frontends
+doc_type: reference
+status: active
+intent: long-term
+topics:
+  - help
+  - serve
+  - http
+  - spa
+  - api
+  - bug
+  - paper-cut
+  - documentation
+  - intern-guide
+owners:
+  - manuel
+ticket: GLZ-571-FIX-SERVE-HTTP-DOCS
+created: "2026-05-12"
+---
+
+# SPA Distribution Architecture Patterns for Go Embedded Frontends
+
+## Goal
+
+A decision-making reference for choosing how to distribute a built React/Vite SPA so that Go binaries can embed it via `//go:embed`. Covers five concrete patterns with pseudocode, CI pipeline sketches, tradeoff matrices, and real-world examples from open-source projects.
+
+## Context
+
+Glazed builds a React SPA (`web/`) via Dagger/pnpm, copies the output to `pkg/web/embed/public/`, and embeds it with `//go:embed`. This works for `glaze` itself because `go generate` + `go build -tags embed` run in the same repo. But any external Go binary that imports `glazed/pkg/web` cannot get the SPA assets — the `go:generate` pipeline doesn't cross module boundaries, the generated files are `.gitignore`d, and the Go module cache only contains committed source.
+
+This is not unique to glazed. Every Go project that embeds a web frontend hits this problem. The patterns below are general-purpose.
+
+---
+
+## The Constraint
+
+```
+//go:embed only sees files that exist on disk relative to the .go file
+       at the time go build runs.
+
+go mod download only fetches files committed to git
+       (respects .gitignore).
+
+go generate only runs in your own module
+       (not in dependencies in the module cache).
+```
+
+These three constraints define the design space. Every solution either:
+- **commits files to git** (so `go mod download` gets them),
+- **generates files at build time** (so `go generate` or a Makefile creates them), or
+- **fetches files at runtime** (so the binary downloads them on first use).
+
+---
+
+## Pattern A: Commit Built Assets to a Separate Module
+
+### Architecture
+
+```
+github.com/go-go-golems/glazed/           ← main repo, no blobs
+github.com/go-go-golems/glazed-spa/       ← SPA dist only, blobs here
+```
+
+The SPA module is a tiny repo that contains nothing but the built frontend and an `embed.go`:
+
+```
+glazed-spa/
+├── go.mod                module github.com/go-go-golems/glazed-spa
+├── embed.go
+├── dist/
+│   ├── index.html
+│   └── assets/
+│       ├── index-abc123.js
+│       └── index-def456.css
+└── README.md             ← auto-generated: "Built assets for glazed help SPA"
+```
+
+### embed.go
+
+```go
+package spa
+
+import "embed"
+
+//go:embed dist
+var Assets embed.FS
+```
+
+### go.mod
+
+```
+module github.com/go-go-golems/glazed-spa
+
+go 1.22
+```
+
+That's it. No dependencies. No code. Just a container for `//go:embed`.
+
+### CI Pipeline (GitHub Actions)
+
+```yaml
+# .github/workflows/release-spa.yml in the glazed repo
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish-spa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build SPA
+        run: GOWORK=off go generate ./pkg/web
+
+      - name: Clone glazed-spa repo
+        uses: actions/checkout@v4
+        with:
+          repository: go-go-golems/glazed-spa
+          token: ${{ secrets.SPA_REPO_TOKEN }}
+          path: glazed-spa-repo
+
+      - name: Sync dist
+        run: |
+          rm -rf glazed-spa-repo/dist/*
+          cp -r pkg/web/embed/public/ glazed-spa-repo/dist/
+          cd glazed-spa-repo
+          git config user.name "CI"
+          git config user.email "ci@example.com"
+          git add -A
+          git commit -m "Update SPA for glazed ${{ github.ref_name }}"
+          git tag "${{ github.ref_name }}"
+          git push origin main --tags
+```
+
+### Consumer Code
+
+```go
+// cmd/glaze/main.go — in the glazed repo
+import (
+    "github.com/go-go-golems/glazed/pkg/help/server"
+    "github.com/go-go-golems/glazed/pkg/web"
+    spadist "github.com/go-go-golems/glazed-spa"
+)
+
+// Option 1: inject assets explicitly
+spaHandler, err := web.NewSPAHandlerFromFS(spadist.Assets)
+
+// Option 2: use the default (which checks for the spa module)
+handler := server.NewServeHandler(deps, spaHandler)
+```
+
+```go
+// external binary — API only, no SPA import needed
+handler := server.NewServeHandler(deps, nil)
+```
+
+```go
+// external binary — wants the SPA too
+import spadist "github.com/go-go-golems/glazed-spa"
+
+spaHandler, err := web.NewSPAHandlerFromFS(spadist.Assets)
+handler := server.NewServeHandler(deps, spaHandler)
+```
+
+### Versioning Strategy
+
+| Strategy | How | Tradeoff |
+|----------|-----|----------|
+| Lockstep tags | Both repos tagged `v0.38.0` simultaneously | Simple, but requires CI coordination |
+| Same major, independent minor | `glazed v0.38.0` depends on `glazed-spa v0.38.x` | Allows SPA-only patches |
+| SPA follows main | `glazed-spa` always tracks latest `glazed` | Simpler CI, but no pinning |
+
+Recommendation: **Lockstep tags** with CI automation. The SPA is a build artifact of the main repo — there's no reason to version them independently.
+
+### Size Impact
+
+```
+Typical Vite SPA build output:
+  index.html     ~1 KB
+  index-*.js     ~150-300 KB (minified, gzippable)
+  index-*.css    ~30-80 KB
+
+Per release: ~200-400 KB
+After 50 releases: ~10-20 MB repo size
+After 100 releases: ~20-40 MB repo size
+```
+
+Mitigation: Periodically squash history or use `git replace` to cap repo size. Or accept it — 40 MB is negligible for most teams.
+
+### Real-World Examples
+
+- **Hugo** — theme assets in separate repos (`hugo-github-markdown`, etc.)
+- **Traefik** — web UI in a separate repo (`traefik-webui`)
+- **Pulumi** — provider schemas in separate packages
+
+---
+
+## Pattern B: GitHub Release Artifact + go:generate Fetch
+
+### Architecture
+
+No extra repo. The SPA tarball is a release asset on the main repo.
+
+```
+github.com/go-go-golems/glazed/
+├── releases/
+│   └── v0.38.0/
+│       └── glazed-spa.tar.gz    ← attached to GitHub Release
+├── pkg/web/
+│   ├── cmd/fetch-spa/main.go   ← go:generate helper
+│   ├── embed.go                ← //go:embed embed/public
+│   └── embed/public/           ← .gitignored, created by fetch
+```
+
+### fetch-spa tool
+
+```go
+// pkg/web/cmd/fetch-spa/main.go
+package main
+
+import (
+    "archive/tar"
+    "compress/gzip"
+    "fmt"
+    "io"
+    "net/http"
+    "os"
+    "path/filepath"
+    "strings"
+)
+
+func main() {
+    version := flag.String("version", "", "glazed version to fetch")
+    outDir := flag.String("out", "embed/public", "output directory")
+    flag.Parse()
+
+    if *version == "" {
+        // Read from go.mod
+        *version = detectVersion()
+    }
+
+    url := fmt.Sprintf(
+        "https://github.com/go-go-golems/glazed/releases/download/%s/glazed-spa.tar.gz",
+        *version,
+    )
+
+    resp, err := http.Get(url)
+    if err != nil {
+        log.Fatalf("fetch: %v", err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != 200 {
+        log.Fatalf("fetch: HTTP %d", resp.StatusCode)
+    }
+
+    os.MkdirAll(*outDir, 0o755)
+    extractTarGz(resp.Body, *outDir)
+}
+```
+
+### gen.go
+
+```go
+// pkg/web/gen.go
+//go:generate go run cmd/fetch-spa/main.go -version=$(shell cat VERSION) -out=embed/public
+```
+
+### CI Pipeline
+
+```yaml
+# In the glazed repo's release workflow
+- name: Build SPA
+  run: GOWORK=off go generate ./pkg/web
+
+- name: Package SPA
+  run: tar czf glazed-spa.tar.gz -C pkg/web/embed/public .
+
+- name: Upload to Release
+  uses: softprops/action-gh-release@v2
+  with:
+    files: glazed-spa.tar.gz
+```
+
+### Consumer Build
+
+```bash
+# Must run go generate explicitly (not automatic)
+go generate github.com/go-go-golems/glazed/pkg/web@v0.38.0
+go build -tags embed -o myapp ./cmd/myapp
+```
+
+### Why This Doesn't Work for External Consumers
+
+`go generate` only processes source in the **current module**. When pinocchio runs `go generate ./...`, it does not traverse into glazed's module cache. The `//go:generate` directive in glazed's `gen.go` is invisible.
+
+Workaround: The consumer would need to explicitly run:
+
+```bash
+go run github.com/go-go-golems/glazed/pkg/web/cmd/fetch-spa@v0.38.0 \
+    -version=v0.38.0 \
+    -out=$(go env GOMODCACHE)/github.com/go-go-golems/glazed@v0.38.0/pkg/web/embed/public
+```
+
+This is fragile and breaks with `go mod tidy` or version changes.
+
+### Real-World Examples
+
+- **Protocol Buffers** — `buf generate` fetches `.proto` from registries
+- **sqlc** — fetches schema from migration directories
+- **oapi-codegen** — generates from OpenAPI specs fetched at build time
+
+---
+
+## Pattern C: Runtime Fetch with Local Cache
+
+### Architecture
+
+No build-time embedding. The binary downloads the SPA on first use.
+
+```go
+// pkg/web/fetch.go
+type CachedSPAHandler struct {
+    cacheDir  string
+    version   string
+    upstream  string  // e.g. "https://releases.example.com/glazed-spa/"
+    handler   http.Handler
+    mu        sync.Once
+}
+
+func (h *CachedSPAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    h.mu.Do(func() {
+        if !h.hasCachedAssets() {
+            h.fetchAssets()
+        }
+        h.handler = newSPAFromDir(h.cacheDir)
+    })
+    h.handler.ServeHTTP(w, r)
+}
+```
+
+### Cache Layout
+
+```
+~/.cache/glazed-spa/
+├── v0.38.0/
+│   ├── index.html
+│   └── assets/
+└── v0.37.0/
+    └── ...
+```
+
+### Startup Flow
+
+```
+Binary starts
+  → check ~/.cache/glazed-spa/v0.38.0/
+  → if exists: serve from cache
+  → if not: fetch tarball, extract, serve
+  → first request has ~200ms latency for extraction
+```
+
+### Pseudocode
+
+```go
+func NewCachedSPAHandler(version string) (http.Handler, error) {
+    cacheDir := filepath.Join(os.UserCacheDir(), "glazed-spa", version)
+    
+    if _, err := os.Stat(filepath.Join(cacheDir, "index.html")); err == nil {
+        // Cache hit — serve immediately
+        return newSPAFromDir(cacheDir)
+    }
+    
+    // Cache miss — download async, serve placeholder meanwhile
+    return &LazyFetchHandler{
+        cacheDir: cacheDir,
+        version:  version,
+        upstream: "https://github.com/go-go-golems/glazed/releases/download/" + version + "/glazed-spa.tar.gz",
+    }, nil
+}
+```
+
+### Pros
+
+- No blobs anywhere in git
+- No build-time requirements beyond standard `go build`
+- Always serves the correct version for the binary
+- Works for external consumers transparently
+
+### Cons
+
+- Requires network on first run
+- Breaks air-gapped deployments
+- `~/.cache` management is another concern
+- More complex code (HTTP client, tar extraction, error handling, concurrent access)
+- First-request latency
+
+### Real-World Examples
+
+- **Gravitational Teleport** — fetches web UI from CDN, caches in `~/.tsh/`
+- **HashiCorp Vault** — downloads UI plugin at runtime
+- **minikube** — downloads ISO images on first run
+
+---
+
+## Pattern D: npm Package as Distribution Channel
+
+### Architecture
+
+Publish the SPA as an npm package. Go fetches it at generate time.
+
+```json
+// @go-go-golems/glazed-spa package.json
+{
+  "name": "@go-go-golems/glazed-spa",
+  "version": "0.38.0",
+  "files": ["dist/"]
+}
+```
+
+### Go Integration
+
+```go
+// pkg/web/gen.go
+//go:generate sh -c "mkdir -p embed/public && cd embed/public && npm pack @go-go-golems/glazed-spa@$(cat ../../VERSION) && tar xzf *.tgz --strip-components=1 package/dist && rm *.tgz"
+```
+
+### CI Pipeline
+
+```yaml
+# In the glazed repo
+- name: Build SPA
+  run: GOWORK=off go generate ./pkg/web
+
+- name: Publish to npm
+  run: |
+    cd pkg/web/embed/public
+    npm init -y --scope go-go-golems
+    npm publish --access public
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+### Why This Is Usually Wrong
+
+- Requires Node.js at Go build time (defeats the point)
+- npm registry is a new operational dependency
+- npm authentication adds CI complexity
+- The Go ecosystem doesn't naturally consume npm packages
+- Version coordination between npm and Go modules is fragile
+
+### When It Makes Sense
+
+- Your team is already deep in the JS ecosystem
+- You need the SPA to be independently consumable by other JS projects
+- You have a monorepo with both Go and JS consumers
+
+---
+
+## Pattern E: Build the SPA in the Consumer's Build Pipeline
+
+### Architecture
+
+The SPA source lives in the glazed repo. The consumer's build pipeline clones glazed, builds the SPA, and then builds their binary.
+
+```makefile
+# Consumer's Makefile
+GLAZED_VERSION := v0.38.0
+GLAZED_DIR := .glazed-build
+
+build: .glazed-build/pkg/web/embed/public
+    go build -tags embed -o myapp ./cmd/myapp
+
+.glazed-build/pkg/web/embed/public:
+    git clone --depth 1 --branch $(GLAZED_VERSION) \
+        https://github.com/go-go-golems/glazed.git $(GLAZED_DIR)
+    cd $(GLAZED_DIR) && GOWORK=off go generate ./pkg/web
+    cp -r $(GLAZED_DIR)/pkg/web/embed/public ./pkg/web/embed/public
+```
+
+### Why This Is Usually Wrong
+
+- Requires Dagger/Node/pnpm in the consumer's build environment
+- Requires git clone of the glazed repo (not just `go mod download`)
+- Fragile — depends on glazed's internal directory structure
+- Slow — full frontend build on every consumer build
+
+### When It Makes Sense
+
+- Monorepo where all Go binaries share the same build environment
+- You already have a monorepo Dagger pipeline that builds everything
+
+---
+
+## Decision Matrix
+
+| Pattern | Blobs in git? | External consumers work? | Network at build? | Network at runtime? | Complexity |
+|---------|:---:|:---:|:---:|:---:|:---:|
+| **A: Separate module** | Yes (separate repo) | Yes (import module) | No | No | Low |
+| **B: Release artifact + fetch** | No | No (go:generate limitation) | Yes | No | Medium |
+| **C: Runtime fetch + cache** | No | Yes | No | Yes (first run) | High |
+| **D: npm package** | No (npm registry) | No (needs Node at build) | Yes | No | Medium |
+| **F: Document API-only** | No | Yes (no SPA needed) | No | No | Minimal |
+
+## Decision Framework
+
+Answer these questions to pick a pattern:
+
+### Q1: Do external consumers need the SPA at all?
+
+- **No** → Use Pattern F (document API-only mode). Stop here.
+- **Yes, sometimes** → Continue to Q2.
+- **Yes, always** → Continue to Q2.
+
+### Q2: Can you accept blobs in a git repo somewhere?
+
+- **Yes, in a separate dedicated repo** → Pattern A (separate module). Clean, Go-idiomatic.
+- **Yes, in the main repo** → Simplest option but you said you don't want this.
+- **No, never** → Continue to Q3.
+
+### Q3: Can you accept network access at runtime?
+
+- **Yes** → Pattern C (runtime fetch). Transparent for consumers, but more code.
+- **No (air-gapped deployments)** → Pattern B (release artifact fetch). Requires explicit `go generate` step in consumer's build. Fragile across module boundaries.
+
+### Q4: Is your team already in the npm ecosystem?
+
+- **Yes** → Pattern D (npm package) is viable but awkward.
+- **No** → Avoid Pattern D.
+
+---
+
+## Recommendation for Glazed (Current State)
+
+Based on the analysis:
+
+1. **Immediate**: Pattern F — document API-only mode for external consumers. This is honest and requires zero code changes. The `glaze serve --from-glazed-cmd` pattern already works perfectly for multi-tool help browsing.
+
+2. **If demand arises**: Pattern A — create `glazed-spa` module. This is the lowest-complexity option that actually works for external consumers. The separate repo is a pure artifact channel — you never read its git history, never review its diffs. It exists solely so `go mod download` can carry the files.
+
+3. **Avoid**: Patterns B, D, and E — they fight the Go module system and add operational fragility.
+
+---
+
+## Appendix: How to Implement Pattern A (Separate Module) — Step by Step
+
+### 1. Create the glazed-spa repo
+
+```bash
+mkdir glazed-spa && cd glazed-spa
+git init
+go mod init github.com/go-go-golems/glazed-spa
+```
+
+### 2. Write embed.go
+
+```go
+// embed.go
+package spa
+
+import "embed"
+
+// Assets contains the built SPA frontend files.
+// Import this package to make the assets available to web.NewSPAHandlerFromFS.
+//
+//go:embed dist
+var Assets embed.FS
+```
+
+### 3. Add a README
+
+```markdown
+# glazed-spa
+
+Built frontend assets for the Glazed Help Browser SPA.
+This package is automatically updated by CI when a new glazed release is tagged.
+
+## Usage
+
+```go
+import (
+    "github.com/go-go-golems/glazed/pkg/web"
+    spadist "github.com/go-go-golems/glazed-spa"
+)
+
+spaHandler, err := web.NewSPAHandlerFromFS(spadist.Assets)
+```
+```
+
+### 4. Restructure glazed's pkg/web
+
+```go
+// pkg/web/static.go — add FromFS variant
+func NewSPAHandler() (http.Handler, error) {
+    return NewSPAHandlerFromFS(DefaultPublicFS)
+}
+
+func NewSPAHandlerFromFS(assets fs.FS) (http.Handler, error) {
+    indexBytes, err := fs.ReadFile(assets, "index.html")
+    if err != nil {
+        return nil, fmt.Errorf("reading SPA index.html: %w", err)
+    }
+
+    fileServer := http.FileServer(http.FS(assets))
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // ... same SPA fallback logic as current, but using `assets` parameter
+    }), nil
+}
+```
+
+### 5. Wire in cmd/glaze/main.go
+
+```go
+import (
+    spadist "github.com/go-go-golems/glazed-spa"
+    "github.com/go-go-golems/glazed/pkg/web"
+)
+
+spaHandler, err := web.NewSPAHandlerFromFS(spadist.Assets)
+// instead of: spaHandler, err := web.NewSPAHandler()
+```
+
+### 6. Add CI workflow
+
+```yaml
+# .github/workflows/publish-spa.yml
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish-spa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: "1.22" }
+
+      - name: Build SPA
+        run: GOWORK=off go generate ./pkg/web
+
+      - uses: actions/checkout@v4
+        with:
+          repository: go-go-golems/glazed-spa
+          token: ${{ secrets.SPA_REPO_PAT }}
+          path: spa-repo
+
+      - name: Sync and push
+        run: |
+          rm -rf spa-repo/dist/*
+          cp -r pkg/web/embed/public/* spa-repo/dist/
+          cd spa-repo
+          go mod tidy
+          git add -A
+          git diff --cached --quiet || git commit -m "SPA for glazed ${{ github.ref_name }}"
+          git tag -f "${{ github.ref_name }}"
+          git push origin main "${{ github.ref_name }}"
+```
+
+### 7. Update go.mod in glazed
+
+```
+require github.com/go-go-golems/glazed-spa v0.38.0
+```
+
+### 8. Update GoReleaser
+
+```yaml
+# .goreleaser.yaml — no changes needed
+# before: hooks already runs `go generate ./...`
+# The -tags embed is still needed, or remove it since the SPA
+# now comes from the separate module, not from embed/public/
+```
+
+Actually, with Pattern A, the `embed` build tag becomes optional. The `glazed-spa` module handles embedding. The `pkg/web/embed.go` can be simplified or removed. The `!embed` fallback in `embed_none.go` still provides the placeholder for tests.

--- a/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/tasks.md
+++ b/ttmp/2026/05/12/GLZ-571-FIX-SERVE-HTTP-DOCS--fix-help-spa-empty-sections-bug-and-improve-programmatic-api-for-issue-571/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+## TODO
+
+- [x] Add tasks here
+
+- [x] Add SetDefaultPackage auto-assign to NewServeHandler in serve.go
+- [x] Improve godoc on SetDefaultPackage in store.go
+- [x] Add regression test TestNewServeHandler_AutoAssignsDefaultPackage
+- [x] Update help entry 25-serving-help-over-http.md with troubleshooting
+- [x] Run full test suite and verify glaze serve still works
+- [x] Update help entry 25-serving-help-over-http.md to clarify SPA limitation for external consumers
+- [x] Evaluate committing generated SPA assets to repo (Solution A) or document API-only mode as default (Solution D)

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -97,6 +97,18 @@ topics:
       description: GitOps workflows and Argo CD/Kustomize deployment manifests.
     - slug: kubernetes
       description: Kubernetes workloads, services, ingress, storage, and operations.
+    - slug: api
+      description: API design and HTTP endpoints
+    - slug: documentation
+      description: Documentation entries and help pages
+    - slug: intern-guide
+      description: Intern-level detailed implementation guide
+    - slug: paper-cut
+      description: Small usability issues that degrade the experience
+    - slug: serve
+      description: HTTP server serving
+    - slug: spa
+      description: Single Page Application (React frontend)
 docTypes:
     - slug: index
       description: Ticket index


### PR DESCRIPTION
This change addresses an issue where external packages using `glazed` as a library
could not embed the help server. The embedded SPA assets are only available when
building from within the `glazed` repository, causing build failures for
consumers.

### Key Changes:
- **API-Only Mode:** The help server can now be instantiated in an "API-only"
  mode by passing a `nil` SPA handler to `NewServeHandler`.
- **Decoupled API and UI:** When running in API-only mode, the server only
  exposes the JSON API endpoints (`/api/...`) without attempting to serve the
  unavailable browser UI.
- **Recommended for Consumers:** This is now the recommended approach for
  any external Go application embedding the help server.
- **Testing:** Added new tests to verify the behavior of the server in
  API-only mode.
- **Documentation:** Updated documentation to reflect the new pattern,
  providing clear examples for embedding the API server.