### PR TITLE
Add glazedclilint comment suppressions

### DIFF
--- a/pkg/analysis/glazedclilint/analyzer.go
+++ b/pkg/analysis/glazedclilint/analyzer.go
@@ -381,9 +381,11 @@ func parseSuppressions(pass *analysis.Pass, file *ast.File) suppressionSet {
 				end := pass.Fset.Position(comment.End())
 				set.ignoredLines[start.Line] = true
 				set.ignoredLines[end.Line] = true
-				if nextStart, nextEnd := nextNodeRange(pass, file, comment.End()); nextStart > 0 {
-					for line := nextStart; line <= nextEnd; line++ {
-						set.ignoredLines[line] = true
+				if !hasNodeStartingOnLineBefore(pass, file, start.Line, comment.Slash) {
+					if nextStart, nextEnd := nextNodeRange(pass, file, comment.End()); nextStart > 0 {
+						for line := nextStart; line <= nextEnd; line++ {
+							set.ignoredLines[line] = true
+						}
 					}
 				}
 			}
@@ -408,6 +410,27 @@ func normalizedCommentText(s string) string {
 
 func suppressionReason(text, prefix string) string {
 	return strings.TrimSpace(strings.TrimPrefix(text, prefix))
+}
+
+func hasNodeStartingOnLineBefore(pass *analysis.Pass, file *ast.File, line int, before token.Pos) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil || found {
+			return !found
+		}
+		pos := n.Pos()
+		if pos == token.NoPos || pos >= before {
+			return true
+		}
+		if pass.Fset.Position(pos).Line == line {
+			switch n.(type) {
+			case ast.Expr, ast.Stmt, ast.Spec, ast.Decl:
+				found = true
+			}
+		}
+		return true
+	})
+	return found
 }
 
 func nextNodeRange(pass *analysis.Pass, file *ast.File, after token.Pos) (int, int) {

--- a/pkg/analysis/glazedclilint/analyzer.go
+++ b/pkg/analysis/glazedclilint/analyzer.go
@@ -365,15 +365,16 @@ func parseSuppressions(pass *analysis.Pass, file *ast.File) suppressionSet {
 	for _, group := range file.Comments {
 		for _, comment := range group.List {
 			text := normalizedCommentText(comment.Text)
-			switch {
-			case strings.HasPrefix(text, suppressionFileIgnorePrefix):
-				if suppressionReason(text, suppressionFileIgnorePrefix) == "" {
+			if reason, ok := suppressionDirectiveReason(text, suppressionFileIgnorePrefix); ok {
+				if reason == "" {
 					set.invalidComments = append(set.invalidComments, comment.Slash)
 					continue
 				}
 				set.fileIgnore = true
-			case strings.HasPrefix(text, suppressionIgnorePrefix):
-				if suppressionReason(text, suppressionIgnorePrefix) == "" {
+				continue
+			}
+			if reason, ok := suppressionDirectiveReason(text, suppressionIgnorePrefix); ok {
+				if reason == "" {
 					set.invalidComments = append(set.invalidComments, comment.Slash)
 					continue
 				}
@@ -408,8 +409,21 @@ func normalizedCommentText(s string) string {
 	return s
 }
 
-func suppressionReason(text, prefix string) string {
-	return strings.TrimSpace(strings.TrimPrefix(text, prefix))
+func suppressionDirectiveReason(text, prefix string) (string, bool) {
+	if text == prefix {
+		return "", true
+	}
+	if !strings.HasPrefix(text, prefix) {
+		return "", false
+	}
+	remaining := strings.TrimPrefix(text, prefix)
+	if remaining == "" {
+		return "", true
+	}
+	if remaining[0] != ' ' && remaining[0] != '\t' {
+		return "", false
+	}
+	return strings.TrimSpace(remaining), true
 }
 
 func hasNodeStartingOnLineBefore(pass *analysis.Pass, file *ast.File, line int, before token.Pos) bool {

--- a/pkg/analysis/glazedclilint/analyzer.go
+++ b/pkg/analysis/glazedclilint/analyzer.go
@@ -56,8 +56,8 @@ func run(pass *analysis.Pass) (any, error) {
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
 	fileInfo := buildFileInfo(pass)
-	reportInvalidSuppressions(pass, fileInfo)
 	allowedPaths := splitCSV(allowPathsFlag)
+	reportInvalidSuppressions(pass, fileInfo, allowedPaths)
 
 	// Function-local analysis is needed for the Glazed-section rule because it has
 	// to connect a local variable initialized from settings.NewGlazedSection to a
@@ -459,9 +459,12 @@ func nextNodeRange(pass *analysis.Pass, file *ast.File, after token.Pos) (int, i
 	return start, end
 }
 
-func reportInvalidSuppressions(pass *analysis.Pass, fileInfo map[*ast.File]fileMeta) {
+func reportInvalidSuppressions(pass *analysis.Pass, fileInfo map[*ast.File]fileMeta, allowedPaths []string) {
 	for _, meta := range fileInfo {
 		for _, pos := range meta.suppressions.invalidComments {
+			if shouldSkip(pass, fileInfo, allowedPaths, pos) {
+				continue
+			}
 			pass.Reportf(pos, diagnosticInvalidSuppression)
 		}
 	}

--- a/pkg/analysis/glazedclilint/analyzer.go
+++ b/pkg/analysis/glazedclilint/analyzer.go
@@ -381,8 +381,10 @@ func parseSuppressions(pass *analysis.Pass, file *ast.File) suppressionSet {
 				end := pass.Fset.Position(comment.End())
 				set.ignoredLines[start.Line] = true
 				set.ignoredLines[end.Line] = true
-				if nextLine := nextNodeLine(pass, file, comment.End()); nextLine > 0 {
-					set.ignoredLines[nextLine] = true
+				if nextStart, nextEnd := nextNodeRange(pass, file, comment.End()); nextStart > 0 {
+					for line := nextStart; line <= nextEnd; line++ {
+						set.ignoredLines[line] = true
+					}
 				}
 			}
 		}
@@ -408,8 +410,8 @@ func suppressionReason(text, prefix string) string {
 	return strings.TrimSpace(strings.TrimPrefix(text, prefix))
 }
 
-func nextNodeLine(pass *analysis.Pass, file *ast.File, after token.Pos) int {
-	best := token.NoPos
+func nextNodeRange(pass *analysis.Pass, file *ast.File, after token.Pos) (int, int) {
+	var best ast.Node
 	ast.Inspect(file, func(n ast.Node) bool {
 		if n == nil {
 			return true
@@ -418,15 +420,20 @@ func nextNodeLine(pass *analysis.Pass, file *ast.File, after token.Pos) int {
 		if pos <= after {
 			return true
 		}
-		if best == token.NoPos || pos < best {
-			best = pos
+		if best == nil || pos < best.Pos() {
+			best = n
 		}
 		return true
 	})
-	if best == token.NoPos {
-		return 0
+	if best == nil {
+		return 0, 0
 	}
-	return pass.Fset.Position(best).Line
+	start := pass.Fset.Position(best.Pos()).Line
+	end := pass.Fset.Position(best.End()).Line
+	if end < start {
+		end = start
+	}
+	return start, end
 }
 
 func reportInvalidSuppressions(pass *analysis.Pass, fileInfo map[*ast.File]fileMeta) {

--- a/pkg/analysis/glazedclilint/analyzer.go
+++ b/pkg/analysis/glazedclilint/analyzer.go
@@ -13,12 +13,15 @@ import (
 )
 
 const (
-	diagnosticRawEnv            = "use Glazed config/env middleware or an explicit command field instead of os.Getenv in CLI code"
-	diagnosticRawFlags          = "define CLI flags with cmds.WithFlags(fields.New(...)) instead of raw Cobra/pflag/flag APIs"
-	diagnosticGlazedWithoutRows = "this command exposes Glazed output flags but does not implement RunIntoGlazeProcessor"
-	glazedSettingsPkg           = "github.com/go-go-golems/glazed/pkg/settings"
-	glazedCmdsPkg               = "github.com/go-go-golems/glazed/pkg/cmds"
-	pflagPkg                    = "github.com/spf13/pflag"
+	diagnosticRawEnv             = "use Glazed config/env middleware or an explicit command field instead of os.Getenv in CLI code"
+	diagnosticRawFlags           = "define CLI flags with cmds.WithFlags(fields.New(...)) instead of raw Cobra/pflag/flag APIs"
+	diagnosticGlazedWithoutRows  = "this command exposes Glazed output flags but does not implement RunIntoGlazeProcessor"
+	diagnosticInvalidSuppression = "glazedclilint suppression requires a reason"
+	glazedSettingsPkg            = "github.com/go-go-golems/glazed/pkg/settings"
+	glazedCmdsPkg                = "github.com/go-go-golems/glazed/pkg/cmds"
+	pflagPkg                     = "github.com/spf13/pflag"
+	suppressionIgnorePrefix      = "glazedclilint:ignore"
+	suppressionFileIgnorePrefix  = "glazedclilint:file-ignore"
 )
 
 var (
@@ -53,6 +56,7 @@ func run(pass *analysis.Pass) (any, error) {
 	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
 	fileInfo := buildFileInfo(pass)
+	reportInvalidSuppressions(pass, fileInfo)
 	allowedPaths := splitCSV(allowPathsFlag)
 
 	// Function-local analysis is needed for the Glazed-section rule because it has
@@ -76,8 +80,8 @@ func run(pass *analysis.Pass) (any, error) {
 		if shouldSkip(pass, fileInfo, allowedPaths, call.Pos()) {
 			return
 		}
-		checkRawEnv(pass, call)
-		checkRawFlags(pass, call)
+		checkRawEnv(pass, fileInfo, call)
+		checkRawFlags(pass, fileInfo, call)
 	})
 
 	return nil, nil
@@ -127,7 +131,7 @@ func analyzeFunction(
 			}
 			for _, arg := range node.Args {
 				if isTrackedGlazedSectionArg(pass, glazedVars, arg) {
-					pass.Reportf(arg.Pos(), diagnosticGlazedWithoutRows)
+					reportDiagnostic(pass, fileInfo, arg.Pos(), diagnosticGlazedWithoutRows)
 					break
 				}
 			}
@@ -136,17 +140,17 @@ func analyzeFunction(
 	})
 }
 
-func checkRawEnv(pass *analysis.Pass, call *ast.CallExpr) {
+func checkRawEnv(pass *analysis.Pass, fileInfo map[*ast.File]fileMeta, call *ast.CallExpr) {
 	fn := calledFunction(pass, call)
 	if fn == nil || fn.Pkg() == nil {
 		return
 	}
 	if fn.Pkg().Path() == "os" && fn.Name() == "Getenv" {
-		pass.Reportf(call.Pos(), diagnosticRawEnv)
+		reportDiagnostic(pass, fileInfo, call.Pos(), diagnosticRawEnv)
 	}
 }
 
-func checkRawFlags(pass *analysis.Pass, call *ast.CallExpr) {
+func checkRawFlags(pass *analysis.Pass, fileInfo map[*ast.File]fileMeta, call *ast.CallExpr) {
 	fn := calledFunction(pass, call)
 	if fn == nil {
 		return
@@ -156,7 +160,7 @@ func checkRawFlags(pass *analysis.Pass, call *ast.CallExpr) {
 		switch fn.Pkg().Path() {
 		case "flag", pflagPkg:
 			if isFlagDefinitionName(fn.Name()) {
-				pass.Reportf(call.Pos(), diagnosticRawFlags)
+				reportDiagnostic(pass, fileInfo, call.Pos(), diagnosticRawFlags)
 				return
 			}
 		}
@@ -166,7 +170,7 @@ func checkRawFlags(pass *analysis.Pass, call *ast.CallExpr) {
 		return
 	}
 	if receiverIsPFlagSet(pass, call) {
-		pass.Reportf(call.Pos(), diagnosticRawFlags)
+		reportDiagnostic(pass, fileInfo, call.Pos(), diagnosticRawFlags)
 	}
 }
 
@@ -332,8 +336,15 @@ func unwrapParens(expr ast.Expr) ast.Expr {
 }
 
 type fileMeta struct {
-	filename  string
-	generated bool
+	filename     string
+	generated    bool
+	suppressions suppressionSet
+}
+
+type suppressionSet struct {
+	fileIgnore      bool
+	ignoredLines    map[int]bool
+	invalidComments []token.Pos
 }
 
 func buildFileInfo(pass *analysis.Pass) map[*ast.File]fileMeta {
@@ -341,11 +352,114 @@ func buildFileInfo(pass *analysis.Pass) map[*ast.File]fileMeta {
 	for _, file := range pass.Files {
 		pos := pass.Fset.Position(file.Pos())
 		ret[file] = fileMeta{
-			filename:  filepath.ToSlash(pos.Filename),
-			generated: isGeneratedFile(file),
+			filename:     filepath.ToSlash(pos.Filename),
+			generated:    isGeneratedFile(file),
+			suppressions: parseSuppressions(pass, file),
 		}
 	}
 	return ret
+}
+
+func parseSuppressions(pass *analysis.Pass, file *ast.File) suppressionSet {
+	set := suppressionSet{ignoredLines: map[int]bool{}}
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			text := normalizedCommentText(comment.Text)
+			switch {
+			case strings.HasPrefix(text, suppressionFileIgnorePrefix):
+				if suppressionReason(text, suppressionFileIgnorePrefix) == "" {
+					set.invalidComments = append(set.invalidComments, comment.Slash)
+					continue
+				}
+				set.fileIgnore = true
+			case strings.HasPrefix(text, suppressionIgnorePrefix):
+				if suppressionReason(text, suppressionIgnorePrefix) == "" {
+					set.invalidComments = append(set.invalidComments, comment.Slash)
+					continue
+				}
+				start := pass.Fset.Position(comment.Slash)
+				end := pass.Fset.Position(comment.End())
+				set.ignoredLines[start.Line] = true
+				set.ignoredLines[end.Line] = true
+				if nextLine := nextNodeLine(pass, file, comment.End()); nextLine > 0 {
+					set.ignoredLines[nextLine] = true
+				}
+			}
+		}
+	}
+	return set
+}
+
+func normalizedCommentText(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "//")
+	s = strings.TrimPrefix(s, "/*")
+	s = strings.TrimSuffix(s, "*/")
+	s = strings.TrimSpace(s)
+	// analysistest expectations live in comments as "// want ...". They are
+	// not part of the suppression syntax under test.
+	if i := strings.Index(s, " // want "); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	return s
+}
+
+func suppressionReason(text, prefix string) string {
+	return strings.TrimSpace(strings.TrimPrefix(text, prefix))
+}
+
+func nextNodeLine(pass *analysis.Pass, file *ast.File, after token.Pos) int {
+	best := token.NoPos
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			return true
+		}
+		pos := n.Pos()
+		if pos <= after {
+			return true
+		}
+		if best == token.NoPos || pos < best {
+			best = pos
+		}
+		return true
+	})
+	if best == token.NoPos {
+		return 0
+	}
+	return pass.Fset.Position(best).Line
+}
+
+func reportInvalidSuppressions(pass *analysis.Pass, fileInfo map[*ast.File]fileMeta) {
+	for _, meta := range fileInfo {
+		for _, pos := range meta.suppressions.invalidComments {
+			pass.Reportf(pos, diagnosticInvalidSuppression)
+		}
+	}
+}
+
+func reportDiagnostic(pass *analysis.Pass, fileInfo map[*ast.File]fileMeta, pos token.Pos, message string) {
+	if isSuppressed(pass, fileInfo, pos) {
+		return
+	}
+	pass.Report(analysis.Diagnostic{Pos: pos, Message: message})
+}
+
+func isSuppressed(pass *analysis.Pass, fileInfo map[*ast.File]fileMeta, pos token.Pos) bool {
+	if fileInfo == nil {
+		return false
+	}
+	filename := filepath.ToSlash(pass.Fset.Position(pos).Filename)
+	line := pass.Fset.Position(pos).Line
+	for _, meta := range fileInfo {
+		if meta.filename != filename {
+			continue
+		}
+		if meta.suppressions.fileIgnore {
+			return true
+		}
+		return meta.suppressions.ignoredLines[line]
+	}
+	return false
 }
 
 func shouldSkip(pass *analysis.Pass, fileInfo map[*ast.File]fileMeta, allowedPaths []string, pos token.Pos) bool {

--- a/pkg/analysis/glazedclilint/testdata/src/a/file_suppressed.go
+++ b/pkg/analysis/glazedclilint/testdata/src/a/file_suppressed.go
@@ -1,0 +1,16 @@
+//glazedclilint:file-ignore legacy file scoped suppression in test fixture
+
+package a
+
+import (
+	"flag"
+	"os"
+)
+
+func fileSuppressedEnv() string {
+	return os.Getenv("FILE")
+}
+
+func fileSuppressedFlag() {
+	_ = flag.String("file", "", "file")
+}

--- a/pkg/analysis/glazedclilint/testdata/src/a/file_suppression_invalid.go
+++ b/pkg/analysis/glazedclilint/testdata/src/a/file_suppression_invalid.go
@@ -1,0 +1,9 @@
+//glazedclilint:file-ignore // want `glazedclilint suppression requires a reason`
+
+package a
+
+import "os"
+
+func invalidFileSuppressionStillReports() string {
+	return os.Getenv("FILE_INVALID") // want `use Glazed config/env middleware`
+}

--- a/pkg/analysis/glazedclilint/testdata/src/a/file_suppression_malformed.go
+++ b/pkg/analysis/glazedclilint/testdata/src/a/file_suppression_malformed.go
@@ -1,0 +1,9 @@
+package a
+
+import "os"
+
+//glazedclilint:file-ignore-old legacy typo in test fixture
+
+func malformedFileSuppressionDoesNotSuppress() string {
+	return os.Getenv("MALFORMED_FILE") // want `use Glazed config/env middleware`
+}

--- a/pkg/analysis/glazedclilint/testdata/src/a/generated.go
+++ b/pkg/analysis/glazedclilint/testdata/src/a/generated.go
@@ -4,6 +4,8 @@ package a
 
 import "os"
 
+//glazedclilint:ignore
+
 func generatedEnvIsSkipped() string {
 	return os.Getenv("GENERATED")
 }

--- a/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go
+++ b/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go
@@ -22,6 +22,11 @@ func trailingSuppressionDoesNotSuppressNextStatement() string {
 	return first + second
 }
 
+func malformedDirectiveDoesNotSuppress() string {
+	//glazedclilint:ignore-old legacy typo in test fixture
+	return os.Getenv("MALFORMED") // want `use Glazed config/env middleware`
+}
+
 func sameLineRawFlagSuppressed() {
 	_ = flag.String("legacy", "", "legacy") //glazedclilint:ignore legacy standard flag adapter in test fixture
 }

--- a/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go
+++ b/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go
@@ -1,0 +1,34 @@
+package a
+
+import (
+	"flag"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func sameLineEnvSuppressed() string {
+	return os.Getenv("SAME_LINE") //glazedclilint:ignore legacy bootstrap env read in test fixture
+}
+
+func previousLineEnvSuppressed() string {
+	//glazedclilint:ignore legacy bootstrap env read in test fixture
+	return os.Getenv("PREVIOUS_LINE")
+}
+
+func sameLineRawFlagSuppressed() {
+	_ = flag.String("legacy", "", "legacy") //glazedclilint:ignore legacy standard flag adapter in test fixture
+}
+
+func previousLineCobraFlagSuppressed() *cobra.Command {
+	var address string
+	cmd := &cobra.Command{}
+	//glazedclilint:ignore legacy Cobra bridge in test fixture
+	cmd.Flags().StringVar(&address, "address", ":8080", "listen address")
+	return cmd
+}
+
+func invalidSuppressionStillReports() string {
+	//glazedclilint:ignore // want `glazedclilint suppression requires a reason`
+	return os.Getenv("INVALID") // want `use Glazed config/env middleware`
+}

--- a/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go
+++ b/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go
@@ -16,6 +16,12 @@ func previousLineEnvSuppressed() string {
 	return os.Getenv("PREVIOUS_LINE")
 }
 
+func trailingSuppressionDoesNotSuppressNextStatement() string {
+	first := os.Getenv("TRAILING")   //glazedclilint:ignore legacy bootstrap env read in test fixture
+	second := os.Getenv("NEXT_LINE") // want `use Glazed config/env middleware`
+	return first + second
+}
+
 func sameLineRawFlagSuppressed() {
 	_ = flag.String("legacy", "", "legacy") //glazedclilint:ignore legacy standard flag adapter in test fixture
 }

--- a/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go
+++ b/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go
@@ -28,6 +28,19 @@ func previousLineCobraFlagSuppressed() *cobra.Command {
 	return cmd
 }
 
+func previousLineMultiLineCobraFlagSuppressed() *cobra.Command {
+	var address string
+	cmd := &cobra.Command{}
+	//glazedclilint:ignore legacy multi-line Cobra bridge in test fixture
+	cmd.Flags().StringVar(
+		&address,
+		"address",
+		":8080",
+		"listen address",
+	)
+	return cmd
+}
+
 func invalidSuppressionStillReports() string {
 	//glazedclilint:ignore // want `glazedclilint suppression requires a reason`
 	return os.Getenv("INVALID") // want `use Glazed config/env middleware`

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/README.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/README.md
@@ -1,0 +1,21 @@
+# Add inline and file scoped suppressions to glazedclilint
+
+This is the document workspace for ticket GLAZED-LINT-001.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GLAZED-LINT-001 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GLAZED-LINT-001 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GLAZED-LINT-001 --field Status --value review`

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/changelog.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/changelog.md
@@ -13,3 +13,13 @@ Created suppression ticket, implementation guide, task list, and diary for inlin
 
 - /home/manuel/workspaces/2026-05-24/add-js-providers/glazed/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/design-doc/01-inline-and-file-scoped-suppression-implementation-guide.md — Suppression implementation design
 
+
+## 2026-05-27
+
+Implemented reasoned inline and file scoped glazedclilint suppressions with analysistest coverage and full repository validation.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-24/add-js-providers/glazed/pkg/analysis/glazedclilint/analyzer.go — Suppression implementation
+- /home/manuel/workspaces/2026-05-24/add-js-providers/glazed/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go — Suppression fixtures
+

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/changelog.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/changelog.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 2026-05-27
+
+- Initial workspace created
+
+
+## 2026-05-27
+
+Created suppression ticket, implementation guide, task list, and diary for inline/file scoped glazedclilint suppressions.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-24/add-js-providers/glazed/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/design-doc/01-inline-and-file-scoped-suppression-implementation-guide.md — Suppression implementation design
+

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/changelog.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/changelog.md
@@ -23,3 +23,12 @@ Implemented reasoned inline and file scoped glazedclilint suppressions with anal
 - /home/manuel/workspaces/2026-05-24/add-js-providers/glazed/pkg/analysis/glazedclilint/analyzer.go — Suppression implementation
 - /home/manuel/workspaces/2026-05-24/add-js-providers/glazed/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go — Suppression fixtures
 
+
+## 2026-05-27
+
+Opened PR 583 for glazedclilint suppressions and triggered Codex review before downstream rollout.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-24/add-js-providers/glazed/pkg/analysis/glazedclilint/analyzer.go — Suppression implementation under PR review
+

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/changelog.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/changelog.md
@@ -32,3 +32,13 @@ Opened PR 583 for glazedclilint suppressions and triggered Codex review before d
 
 - /home/manuel/workspaces/2026-05-24/add-js-providers/glazed/pkg/analysis/glazedclilint/analyzer.go — Suppression implementation under PR review
 
+
+## 2026-05-27
+
+Fixed PR 583 Codex feedback by expanding previous-line suppressions across the next AST node range and adding a multi-line fixture.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-24/add-js-providers/glazed/pkg/analysis/glazedclilint/analyzer.go — next-node range suppression fix
+- /home/manuel/workspaces/2026-05-24/add-js-providers/glazed/pkg/analysis/glazedclilint/testdata/src/a/suppressions.go — multi-line suppression fixture
+

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/design-doc/01-inline-and-file-scoped-suppression-implementation-guide.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/design-doc/01-inline-and-file-scoped-suppression-implementation-guide.md
@@ -1,0 +1,191 @@
+---
+Title: Inline and file scoped suppression implementation guide
+Ticket: GLAZED-LINT-001
+Status: active
+Topics:
+    - cli
+    - automation
+    - linting
+DocType: design-doc
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles:
+    - Path: pkg/analysis/glazedclilint/analyzer.go
+      Note: |-
+        Analyzer implementation that will parse and honor suppressions
+        Analyzer implementation to extend with suppression parsing
+    - Path: pkg/analysis/glazedclilint/analyzer_test.go
+      Note: |-
+        analysistest entry point for suppression behavior
+        Existing analysistest entry point
+    - Path: pkg/analysis/glazedclilint/testdata/src/a/a.go
+      Note: |-
+        Fixture file where inline and file scoped suppressions are exercised
+        Fixture file for suppression cases
+ExternalSources: []
+Summary: Design and implementation guide for adding reasoned inline and file scoped suppressions to glazedclilint.
+LastUpdated: 2026-05-27T15:10:00-04:00
+WhatFor: Use this to implement and review comment-based suppression support before reducing Makefile allow-path scopes across downstream packages.
+WhenToUse: Before changing glazedclilint suppression semantics or reducing broad allow-path usage in downstream repositories.
+---
+
+
+# Inline and file scoped suppression implementation guide
+
+## Executive summary
+
+`glazedclilint` currently supports broad suppression through the `-glazedclilint.allow-paths` flag. That works for rollout bootstrap, but it is too coarse for long-term policy enforcement. A directory allow path can hide future violations in production command packages. The analyzer needs comment-based suppression so maintainers can exempt a specific legacy line, declaration, or file while keeping the rest of the package under policy.
+
+The implementation should add two comment forms:
+
+```go
+//glazedclilint:ignore <reason>
+```
+
+and:
+
+```go
+//glazedclilint:file-ignore <reason>
+```
+
+The reason must be non-empty. A bare suppression is not honored and should produce an analyzer diagnostic. Inline `ignore` applies to the next syntax node or the same line. File `file-ignore` applies to the entire file. This gives downstream repositories a way to replace broad Makefile allow paths with file-level or line-level documented exceptions.
+
+## Problem statement
+
+The INFRA-002 rollout found a real issue in `discord-bot`: an allow path for `cmd/discord-bot/` skipped every current and future file in the primary command package. That path made the rollout pass, but it also weakened future enforcement. If a new file under `cmd/discord-bot/` introduced raw pflag or raw environment access, CI would not catch it.
+
+Exact file paths are better than broad directories, but sometimes even a whole file is too much. A mostly compliant file may contain one legacy raw flag definition or one bootstrap-time environment read. Today the only available choices are:
+
+1. migrate the code immediately;
+2. allow-list the containing file or directory;
+3. accept the diagnostic and fail CI.
+
+The missing option is a local, reviewed suppression with a reason.
+
+## Proposed syntax
+
+### Same-line or next-node suppression
+
+```go
+value := os.Getenv("DISCORD_TOKEN") //glazedclilint:ignore legacy bootstrap before command settings exist
+```
+
+```go
+//glazedclilint:ignore legacy pflag adapter; migrate after INFRA-002
+cmd.Flags().StringVar(&path, "config", "", "config path")
+```
+
+The suppression applies to the diagnostic whose position is on the same line as the comment or inside the next AST node after the comment.
+
+### File scoped suppression
+
+```go
+//glazedclilint:file-ignore generated legacy Cobra bridge; tracked by INFRA follow-up
+```
+
+This suppresses all diagnostics in the file. It should be used sparingly. It is still better than a Makefile directory allow path because the exception is attached to the file and contains a reason.
+
+### Invalid suppression
+
+```go
+//glazedclilint:ignore
+```
+
+This should not suppress anything. The analyzer should report:
+
+```text
+glazedclilint suppression requires a reason
+```
+
+## Design decisions
+
+### Suppressions require a reason
+
+Suppressions without reasons turn the comment mechanism into an invisible allow path. The reason is part of the review contract. It explains why the code is still exempt and gives future maintainers a starting point for migration.
+
+### Suppression matching is position-based
+
+The analyzer already reports diagnostics by AST position. The suppression logic should answer one question: should a diagnostic at this position be skipped? It does not need to change the existing rule logic.
+
+### File-level suppressions are explicit
+
+A file-level suppression should use `file-ignore`, not an `ignore` comment at the top of the file. This prevents accidental whole-file exemptions from comments that were intended for one declaration.
+
+### Path allow lists remain supported
+
+The existing `allow-paths` flag should remain. It is still useful for framework internals, generated compatibility areas, and initial rollouts. Comment suppressions are an additional narrower mechanism, not a replacement in this ticket.
+
+## Implementation plan
+
+1. Extend `fileMeta` to include suppression metadata.
+2. Parse comments in `buildFileInfo`.
+3. Add `suppressionSet` with:
+   - file-wide boolean and reason;
+   - ignored lines;
+   - next-node suppression positions;
+   - invalid suppression comment positions.
+4. Add `suppressed(pass, fileInfo, pos)` helper.
+5. Change diagnostic emission from `pass.Reportf` to a helper that checks suppressions first.
+6. Report invalid bare suppression comments once per file.
+7. Add analysistest fixtures for:
+   - same-line ignore;
+   - previous-line ignore;
+   - file-ignore;
+   - invalid ignore with expected diagnostic;
+   - invalid file-ignore with expected diagnostic.
+8. Run focused and full tests:
+
+```bash
+go test ./pkg/analysis/glazedclilint -count=1
+go test ./... 
+```
+
+## Pseudocode
+
+```go
+func report(pass, fileInfo, pos, message) {
+    if shouldSuppress(pass, fileInfo, pos) {
+        return
+    }
+    pass.Reportf(pos, message)
+}
+
+func shouldSuppress(pass, fileInfo, pos) bool {
+    filename := pass.Fset.Position(pos).Filename
+    line := pass.Fset.Position(pos).Line
+    meta := fileInfoByFilename[filename]
+    if meta.suppressions.fileIgnore {
+        return true
+    }
+    if meta.suppressions.ignoredLines[line] {
+        return true
+    }
+    if meta.suppressions.ignoredLines[line-1] && pos belongs to next node {
+        return true
+    }
+    return false
+}
+```
+
+The actual implementation can avoid complex ownership logic by mapping an ignore comment to the line of the next AST node using `ast.Inspect`.
+
+## Tasks
+
+- [ ] Create ticket and docs.
+- [ ] Design suppression syntax.
+- [ ] Implement suppression parsing.
+- [ ] Add report helper and wire existing diagnostics through it.
+- [ ] Add invalid suppression diagnostics.
+- [ ] Add analysistest fixtures.
+- [ ] Run focused tests.
+- [ ] Run full tests.
+- [ ] Commit implementation.
+- [ ] Update diary and changelog.
+- [ ] Run docmgr doctor.
+
+## Review instructions
+
+Start with `pkg/analysis/glazedclilint/analyzer.go`. Review suppression parsing before reviewing rule changes. The main correctness question is whether suppression matching is narrow enough: same-line, next-node, or explicit file-wide only.
+
+Then review `pkg/analysis/glazedclilint/testdata/src/a/a.go`. The fixtures should make the intended semantics obvious without relying on prose.

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/index.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/index.md
@@ -1,0 +1,57 @@
+---
+Title: Add inline and file scoped suppressions to glazedclilint
+Ticket: GLAZED-LINT-001
+Status: active
+Topics:
+    - cli
+    - automation
+    - linting
+DocType: index
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-05-27T14:35:09.804405072-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Add inline and file scoped suppressions to glazedclilint
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- cli
+- automation
+- linting
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/reference/01-implementation-diary.md
@@ -1,0 +1,80 @@
+---
+Title: Implementation diary
+Ticket: GLAZED-LINT-001
+Status: active
+Topics:
+  - cli
+  - automation
+  - linting
+DocType: reference
+Intent: long-term
+Owners:
+  - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: Chronological diary for adding inline and file scoped suppressions to glazedclilint.
+LastUpdated: 2026-05-27T15:10:00-04:00
+WhatFor: Preserve implementation context, failures, validation, and follow-up work.
+WhenToUse: Read before continuing or reviewing GLAZED-LINT-001.
+---
+
+# Diary
+
+## Goal
+
+Capture the implementation of reasoned inline and file scoped suppressions in `glazedclilint`, so downstream repositories can reduce broad `allow-paths` scopes after this feature lands.
+
+## Step 1: Create ticket and design the suppression contract
+
+This step created the `GLAZED-LINT-001` ticket in the `glazed` repository's own `ttmp` workspace and wrote the implementation guide. The design is intentionally narrow: keep existing path allow-lists, but add comment suppressions for cases where a line, declaration, or file needs an explicit legacy exception.
+
+The central rule is that suppressions must have reasons. A suppression without a reason should not hide diagnostics.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Add a new ticket to add inline suppression in ./glazed/ and file scopes, use docmgr --root ./glazed/ttmp to put the ticket in the right directory. Then add an implementation guide and tasks, and then work them off, committing at appropriate intervals. Once this is all finished and set up, let me know, before we do a pass over all our packages again to reduce the scope of things we allow.
+
+commit at appropriat eintervals, and keep a diary as you worok"
+
+**Assistant interpretation:** Create a docmgr ticket under the `glazed` repo, document the suppression design and tasks, implement the analyzer feature with tests, maintain a diary, and commit in reviewable increments.
+
+**Inferred user intent:** The user wants the analyzer to support local suppressions before another rollout pass reduces broad Makefile allow paths across downstream packages.
+
+**Commit (code):** pending.
+
+### What I did
+- Created ticket `GLAZED-LINT-001` with `docmgr --root ./ttmp` inside `glazed`.
+- Added design doc `design-doc/01-inline-and-file-scoped-suppression-implementation-guide.md`.
+- Rewrote `tasks.md` with concrete implementation tasks.
+- Initialized this diary.
+
+### Why
+- The Discord rollout feedback showed that broad directory allow paths can hide future policy violations.
+- Inline and file-scoped suppressions give maintainers narrower, reasoned exceptions.
+
+### What worked
+- The existing analyzer is small and position-based, so suppression can be added without changing the rule logic.
+
+### What didn't work
+- N/A.
+
+### What I learned
+- The current analyzer already centralizes path/test/generated skipping in `shouldSkip`, so comment suppression should be implemented near that layer and report emission should go through a helper.
+
+### What was tricky to build
+- The design needs to make file-level suppression explicit. A top-of-file `ignore` comment should not accidentally suppress an entire file; that is what `file-ignore` is for.
+
+### What warrants a second pair of eyes
+- Whether the suppression syntax names are final: `glazedclilint:ignore` and `glazedclilint:file-ignore`.
+- Whether mandatory reasons should have a minimum length beyond non-empty.
+
+### What should be done in the future
+- Implement and test suppression parsing.
+- After this lands, use it to reduce broad allow paths in downstream rollout PRs.
+
+### Code review instructions
+- Start with the design doc, then review analyzer changes.
+- Validate with `go test ./pkg/analysis/glazedclilint -count=1`.
+
+### Technical details
+- Ticket root: `/home/manuel/workspaces/2026-05-24/add-js-providers/glazed/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint`.

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/reference/01-implementation-diary.md
@@ -3,20 +3,29 @@ Title: Implementation diary
 Ticket: GLAZED-LINT-001
 Status: active
 Topics:
-  - cli
-  - automation
-  - linting
+    - cli
+    - automation
+    - linting
 DocType: reference
 Intent: long-term
 Owners:
-  - manuel
-RelatedFiles: []
+    - manuel
+RelatedFiles:
+    - Path: pkg/analysis/glazedclilint/analyzer.go
+      Note: Implemented suppression parsing and suppression-aware reporting
+    - Path: pkg/analysis/glazedclilint/testdata/src/a/file_suppressed.go
+      Note: File scoped suppression fixture
+    - Path: pkg/analysis/glazedclilint/testdata/src/a/file_suppression_invalid.go
+      Note: Invalid file scoped suppression fixture
+    - Path: pkg/analysis/glazedclilint/testdata/src/a/suppressions.go
+      Note: Inline suppression and invalid suppression fixtures
 ExternalSources: []
 Summary: Chronological diary for adding inline and file scoped suppressions to glazedclilint.
 LastUpdated: 2026-05-27T15:10:00-04:00
 WhatFor: Preserve implementation context, failures, validation, and follow-up work.
 WhenToUse: Read before continuing or reviewing GLAZED-LINT-001.
 ---
+
 
 # Diary
 
@@ -78,3 +87,92 @@ commit at appropriat eintervals, and keep a diary as you worok"
 
 ### Technical details
 - Ticket root: `/home/manuel/workspaces/2026-05-24/add-js-providers/glazed/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint`.
+
+## Step 2: Implement suppression parsing and tests
+
+This step implemented the suppression mechanism in `glazedclilint`. The analyzer now recognizes reasoned inline suppressions and reasoned file scoped suppressions. Existing path allow-lists remain intact, but downstream repositories can now use narrower source-level exceptions where a Makefile allow path would exempt too much code.
+
+The implementation keeps rule detection unchanged. Existing checks still identify raw environment reads, raw flag definitions, and Glazed-output sections on non-row commands. The only new behavior is that diagnostic emission goes through a suppression-aware helper before reporting.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Implement the documented suppression feature, add tests, validate it, and commit the code separately from the ticket setup.
+
+**Inferred user intent:** The user wants the analyzer ready before reducing downstream `allow-paths` scopes.
+
+**Commit (code):** 7bb545e — "Add glazedclilint comment suppressions"
+
+### What I did
+- Extended `fileMeta` with parsed suppression metadata.
+- Added support for:
+  - `//glazedclilint:ignore <reason>` on the same line as a diagnostic.
+  - `//glazedclilint:ignore <reason>` on the line before the next AST node.
+  - `//glazedclilint:file-ignore <reason>` for explicit file scoped suppression.
+- Added `diagnosticInvalidSuppression` for bare suppressions without reasons.
+- Added `reportDiagnostic` so raw env, raw flag, and Glazed-without-rows diagnostics all honor suppressions consistently.
+- Added `reportInvalidSuppressions` so invalid suppression comments are reported once per comment.
+- Added analysistest fixtures:
+  - `suppressions.go`
+  - `file_suppressed.go`
+  - `file_suppression_invalid.go`
+- Ran focused and full validation.
+
+### Why
+- Broad `allow-paths` are useful for rollout bootstrap, but they can hide future violations.
+- Comment suppressions let us exempt a specific legacy line or file with an explicit reason while keeping the rest of the package under analyzer policy.
+
+### What worked
+- Same-line suppressions work.
+- Previous-line suppressions work by mapping an ignore comment to the next AST node line.
+- File scoped suppressions work through explicit `file-ignore` syntax.
+- Bare suppressions do not hide diagnostics and emit `glazedclilint suppression requires a reason`.
+- Existing generated/test/path skip behavior remains intact.
+
+### What didn't work
+- The first implementation used `pass.Reportf(pos, message)` with a non-constant format string. The package failed to build with:
+
+```text
+pkg/analysis/glazedclilint/analyzer.go:438:20: non-constant format string in call to (*golang.org/x/tools/go/analysis.Pass).Reportf
+```
+
+- Fix: changed suppression-aware reporting to use `pass.Report(analysis.Diagnostic{Pos: pos, Message: message})`.
+- The first invalid suppression tests did not fire because analysistest `// want ...` comments were parsed as suppression reasons.
+- Fix: `normalizedCommentText` strips ` // want ` suffixes before suppression parsing.
+
+### What I learned
+- Analyzer test expectations are themselves comments. Suppression parsers need to avoid interpreting `// want` test metadata as part of the suppression syntax under test.
+- It is safer to keep invalid suppression reporting independent from normal diagnostic suppression. Invalid comments should remain visible even in a file that otherwise has suppression state.
+
+### What was tricky to build
+- Previous-line suppressions need to be narrow. The implementation maps an ignore comment to both its own line and the line of the next AST node after the comment. This handles the normal pattern immediately above a call without turning a top-of-file `ignore` into an accidental file-level suppression.
+
+### What warrants a second pair of eyes
+- Whether next-node line mapping is sufficient for multi-line statements. It is intentionally simple and should be reviewed before relying on it for complex suppressions.
+- Whether block comments should remain supported through the generic normalization or be disallowed in a future tightening pass.
+
+### What should be done in the future
+- Add downstream examples when reducing `allow-paths` scopes.
+- Consider adding rule IDs later, for example `glazedclilint:ignore raw-env <reason>`.
+- Consider a minimum reason length if empty-only validation proves too weak.
+
+### Code review instructions
+- Start with `reportDiagnostic`, `parseSuppressions`, and `isSuppressed` in `pkg/analysis/glazedclilint/analyzer.go`.
+- Then review the new fixtures in `pkg/analysis/glazedclilint/testdata/src/a/`.
+- Validate with:
+  - `go test ./pkg/analysis/glazedclilint -count=1`
+  - `go test ./...`
+
+### Technical details
+- Focused validation passed:
+
+```bash
+go test ./pkg/analysis/glazedclilint -count=1
+```
+
+- Full validation passed:
+
+```bash
+go test ./...
+```

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/reference/01-implementation-diary.md
@@ -176,3 +176,73 @@ go test ./pkg/analysis/glazedclilint -count=1
 ```bash
 go test ./...
 ```
+
+## Step 3: Open the suppression PR and trigger Codex
+
+This step published the suppression branch for review. The branch is intentionally separate from the earlier INFRA-002 rollout branch so the analyzer capability can be reviewed, merged, and released before downstream repositories start replacing broad Makefile allow paths with source-local suppressions.
+
+The PR is now the gate for the downstream cleanup pass. I triggered Codex immediately so any analyzer design feedback can be addressed before we depend on the new syntax in downstream repositories.
+
+### Prompt Context
+
+**User prompt (verbatim):** "open PR, then after merge and release, bump-glazed downstream and using the new capabilities. Also tighten up the allowances and ask me about which os.Getenv / cobra should be allowed and which not, and if we should adjust the glazed lint in the first place."
+
+**Assistant interpretation:** Publish the Glazed suppression feature for review first, then only after merge/release update downstream packages to a released Glazed version and use narrower suppressions/allowances. Before deciding suppressions, gather user policy decisions about which raw env/Cobra usages should remain allowed and whether the analyzer rules themselves need adjustment.
+
+**Inferred user intent:** The user wants a controlled two-stage rollout: first land the analyzer capability in Glazed, then use it downstream with policy review rather than blindly suppressing every current finding.
+
+**Commit (code):** N/A — PR creation and Codex trigger only.
+
+### What I did
+- Opened PR 583: https://github.com/go-go-golems/glazed/pull/583
+- Triggered Codex on the PR with `ggg pr codex-trigger`.
+- Checked initial readiness with `ggg pr ready`.
+
+### Why
+- Downstream repositories should not use unreleased suppression syntax.
+- Codex feedback should be handled before broad downstream lint cleanup depends on this implementation.
+
+### What worked
+- GitHub PR creation succeeded.
+- Codex trigger succeeded and posted a review request comment.
+- Initial readiness classified the PR as waiting for Codex rather than failed.
+
+### What didn't work
+- The PR is not ready yet because Codex has not produced its latest signal.
+
+```text
+state: waiting_codex
+terminal: false
+```
+
+### What I learned
+- The correct next gate is PR 583 readiness, not downstream mutation.
+- Downstream cleanup needs a policy pass with the user before converting every broad allow path into inline suppressions.
+
+### What was tricky to build
+- The sequencing matters: downstream suppression comments would be invalid until a tagged Glazed release contains the analyzer change. The downstream pass must wait for the PR to merge and for the release to become visible to `go list -m -versions`.
+
+### What warrants a second pair of eyes
+- Whether the suppression syntax and invalid-suppression diagnostic are acceptable before they become part of downstream policy.
+- Whether the analyzer should distinguish rule IDs before downstream packages start accumulating suppressions.
+
+### What should be done in the future
+- After PR 583 is merged and released, bump downstream Glazed versions.
+- For each downstream finding, ask whether to:
+  - migrate to Glazed settings/parameters;
+  - allow exact legacy files;
+  - add inline/file scoped suppression with a reason;
+  - or adjust the analyzer rule.
+
+### Code review instructions
+- Review PR 583 in GitHub.
+- Validate readiness with:
+  - `ggg pr ready https://github.com/go-go-golems/glazed/pull/583 --output json`
+
+### Technical details
+- PR URL: https://github.com/go-go-golems/glazed/pull/583
+- Initial readiness command:
+
+```bash
+ggg pr ready https://github.com/go-go-golems/glazed/pull/583 --output json
+```

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/reference/01-implementation-diary.md
@@ -246,3 +246,69 @@ terminal: false
 ```bash
 ggg pr ready https://github.com/go-go-golems/glazed/pull/583 --output json
 ```
+
+## Step 4: Address Codex feedback for multi-line suppressions
+
+Codex reviewed PR 583 and found that previous-line suppressions only marked the first line of the next AST node. That was too narrow for multi-line statements because a diagnostic can be reported on a later line inside the same suppressed statement.
+
+The fix keeps the previous-line suppression narrow, but expands it across the full source range of the next AST node. This preserves the intended behavior for a comment immediately above a statement while allowing multi-line Cobra or Glazed calls to be suppressed with one reasoned comment.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 3)
+
+**Assistant interpretation:** Keep the PR moving through review and fix analyzer feedback before merge/release/downstream use.
+
+**Inferred user intent:** The suppression implementation should be reliable enough to use in downstream repositories without creating broad Makefile allow paths.
+
+**Commit (code):** 8714219 — "Fix multiline glazedclilint suppressions"
+
+### What I did
+- Replaced `nextNodeLine` with `nextNodeRange`.
+- When a previous-line `glazedclilint:ignore` is valid, the analyzer now marks every line from the next node start through its end as ignored.
+- Added a multi-line Cobra flag fixture to prove the suppression applies to a diagnostic reported inside a multi-line call.
+- Ran focused and full tests.
+- Pushed the fix and retriggered Codex on PR 583.
+
+### Why
+- A single reasoned suppression comment above a legacy statement should cover the complete statement, not just the first token line.
+- Without this, downstream repositories would either need awkward same-line suppressions on arguments or broader file/path suppressions.
+
+### What worked
+- Focused analyzer tests passed.
+- Full repository tests passed.
+- Pre-push hooks passed again.
+- Codex was retriggered on the fixed head.
+
+### What didn't work
+- The initial implementation was too narrow for multi-line statements. Codex reported:
+
+```text
+Track next-node ranges for suppressions
+
+For a //glazedclilint:ignore placed before a multi-line statement, this only records the first line ...
+```
+
+### What I learned
+- Suppression mapping should follow the analyzer's diagnostic positions, not just the visual position of the statement start.
+- AST node ranges give a simple and reviewable boundary for previous-line suppressions.
+
+### What was tricky to build
+- The fix needed to avoid turning `ignore` into a broad block suppression. It still selects only the next AST node after the comment, then marks that node's source range. It does not suppress subsequent statements.
+
+### What warrants a second pair of eyes
+- Whether choosing the smallest AST node after the comment is the correct long-term behavior for every formatting pattern. It works for the tested statement/call cases, but statement-oriented selection could be considered later if edge cases appear.
+
+### What should be done in the future
+- Consider adding tests for multi-line Glazed `cmds.WithSections(...)` diagnostics during a later analyzer-hardening pass.
+
+### Code review instructions
+- Review `nextNodeRange` and the loop that marks ignored lines in `parseSuppressions`.
+- Review `previousLineMultiLineCobraFlagSuppressed` in `suppressions.go`.
+- Validate with:
+  - `go test ./pkg/analysis/glazedclilint -count=1`
+  - `go test ./...`
+
+### Technical details
+- PR URL: https://github.com/go-go-golems/glazed/pull/583
+- Latest pushed head after this fix: `8714219`.

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/tasks.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/tasks.md
@@ -18,13 +18,13 @@ LastUpdated: 2026-05-27T15:10:00-04:00
 
 # Tasks
 
-- [ ] Design suppression syntax and semantics.
-- [ ] Implement comment parsing for `glazedclilint:ignore` and `glazedclilint:file-ignore`.
-- [ ] Require non-empty reasons for suppressions.
-- [ ] Wire raw env, raw flag, and Glazed-without-rows diagnostics through suppression-aware reporting.
-- [ ] Add analysistest fixtures for inline, previous-line, file-scoped, and invalid suppressions.
-- [ ] Run `go test ./pkg/analysis/glazedclilint -count=1`.
-- [ ] Run `go test ./...` or the repo-appropriate full validation.
-- [ ] Update diary and changelog.
-- [ ] Commit implementation and docs.
-- [ ] Report readiness for downstream allow-scope reduction pass.
+- [x] Design suppression syntax and semantics.
+- [x] Implement comment parsing for `glazedclilint:ignore` and `glazedclilint:file-ignore`.
+- [x] Require non-empty reasons for suppressions.
+- [x] Wire raw env, raw flag, and Glazed-without-rows diagnostics through suppression-aware reporting.
+- [x] Add analysistest fixtures for inline, previous-line, file-scoped, and invalid suppressions.
+- [x] Run `go test ./pkg/analysis/glazedclilint -count=1`.
+- [x] Run `go test ./...` or the repo-appropriate full validation.
+- [x] Update diary and changelog.
+- [x] Commit implementation and docs.
+- [x] Report readiness for downstream allow-scope reduction pass.

--- a/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/tasks.md
+++ b/ttmp/2026/05/27/GLAZED-LINT-001--add-inline-and-file-scoped-suppressions-to-glazedclilint/tasks.md
@@ -1,0 +1,30 @@
+---
+Title: Tasks
+Ticket: GLAZED-LINT-001
+Status: active
+Topics:
+  - cli
+  - automation
+  - linting
+DocType: tasks
+Intent: short-term
+Owners:
+  - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: Task checklist for adding inline and file scoped glazedclilint suppressions.
+LastUpdated: 2026-05-27T15:10:00-04:00
+---
+
+# Tasks
+
+- [ ] Design suppression syntax and semantics.
+- [ ] Implement comment parsing for `glazedclilint:ignore` and `glazedclilint:file-ignore`.
+- [ ] Require non-empty reasons for suppressions.
+- [ ] Wire raw env, raw flag, and Glazed-without-rows diagnostics through suppression-aware reporting.
+- [ ] Add analysistest fixtures for inline, previous-line, file-scoped, and invalid suppressions.
+- [ ] Run `go test ./pkg/analysis/glazedclilint -count=1`.
+- [ ] Run `go test ./...` or the repo-appropriate full validation.
+- [ ] Update diary and changelog.
+- [ ] Commit implementation and docs.
+- [ ] Report readiness for downstream allow-scope reduction pass.

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -145,6 +145,8 @@ topics:
       description: Server-side rendering of frontend routes and HTML
     - slug: backend
       description: Backend services, APIs, persistence, and operational server-side implementation details
+    - slug: automation
+      description: Automation scripts, tooling, and workflow orchestration
 docTypes:
     - slug: index
       description: Ticket index


### PR DESCRIPTION
## Summary
- add reason-required inline suppressions with //glazedclilint:ignore <reason>
- add reason-required file scoped suppressions with //glazedclilint:file-ignore <reason>
- report bare suppression comments as invalid instead of silently suppressing diagnostics
- document the suppression design and implementation diary in GLAZED-LINT-001

## Validation
- go test ./pkg/analysis/glazedclilint -count=1
- go test ./...
- docmgr --root ./ttmp doctor --ticket GLAZED-LINT-001 --stale-after 30
- push pre-hook passed test, lint/gosec/govulncheck, and snapshot release