### PR TITLE
Open docs-yolo GitOps PR after image publish

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,13 +9,28 @@ on:
 permissions:
   contents: read
   packages: write
+  pull-requests: write
+  id-token: write
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.compute.outputs.image_ref }}
+      image_tag: ${{ steps.compute.outputs.image_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Compute image coordinates
+        id: compute
+        shell: bash
+        run: |
+          set -euo pipefail
+          image_tag="sha-${GITHUB_SHA::7}"
+          image_ref="ghcr.io/go-go-golems/glazed:${image_tag}"
+          echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
+          echo "image_ref=${image_ref}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -70,3 +85,43 @@ jobs:
           labels: ${{ steps.meta_ssr.outputs.labels }}
           cache-from: type=gha,scope=glazed-ssr
           cache-to: type=gha,mode=max,scope=glazed-ssr
+
+
+  gitops-pr:
+    name: Open docs-yolo GitOps PR
+    needs: build-and-push
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Check out infra-tooling repository
+        uses: actions/checkout@v6
+        with:
+          repository: go-go-golems/infra-tooling
+          ref: main
+          path: .infra-tooling
+
+      - name: Read GitOps PR token from Vault
+        uses: hashicorp/vault-action@v3
+        with:
+          url: https://vault.yolo.scapegoat.dev
+          method: jwt
+          path: github-actions
+          role: glazed-gitops-pr
+          jwtGithubAudience: https://vault.yolo.scapegoat.dev
+          exportToken: true
+          secrets: |
+            kv/data/ci/github/glazed/gitops-pr-token token | GITOPS_PR_TOKEN
+
+      - name: Open GitOps pull request for docs-yolo image bump
+        uses: ./.infra-tooling/actions/open-gitops-pr
+        with:
+          config: deploy/gitops-targets.json
+          image: ${{ needs.build-and-push.outputs.image_ref }}
+          all_targets: true
+          push: true
+          open_pr: true
+          git_author_name: github-actions[bot]
+          git_author_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/deploy/gitops-targets.json
+++ b/deploy/gitops-targets.json
@@ -1,0 +1,24 @@
+{
+  "targets": [
+    {
+      "name": "docs-yolo-prod",
+      "gitops_repo": "wesen/2026-03-27--hetzner-k3s",
+      "gitops_branch": "main",
+      "manifest_path": "gitops/kustomize/docs-yolo/deployment.yaml",
+      "images": [
+        {
+          "container_name": "docs-browser",
+          "image_name": "ghcr.io/go-go-golems/glazed"
+        },
+        {
+          "container_name": "docs-registry",
+          "image_name": "ghcr.io/go-go-golems/glazed"
+        },
+        {
+          "container_name": "docs-ssr",
+          "image_name": "ghcr.io/go-go-golems/glazed-ssr"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add docs-yolo GitOps target metadata using infra-tooling multi-image support
- extend the container image workflow to read the GitOps PR token from Vault via the glazed-gitops-pr role
- open a docs-yolo GitOps PR after publishing the Glazed runtime and SSR images on main

## Validation
- parsed .github/workflows/container.yml
- parsed deploy/gitops-targets.json
- validated deploy/gitops-targets.json with infra-tooling validator
- dry-ran the multi-image patch against the local k3s docs-yolo manifest

Note: infra-tooling multi-image support has already been merged to main. Terraform/Vault role was applied and pushed separately.