### PR TITLE
Fix semantic version ordering in docs API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/yuin/goldmark v1.8.2
 	github.com/yuin/gopher-lua v1.1.1
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
+	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.56.0
 	golang.org/x/tools v0.47.0
 	gopkg.in/errgo.v2 v2.1.0
@@ -129,7 +130,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
-	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/pkg/help/server/handlers.go
+++ b/pkg/help/server/handlers.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/mod/semver"
+
 	"github.com/go-go-golems/glazed/pkg/help/model"
 	"github.com/go-go-golems/glazed/pkg/help/store"
 )
@@ -144,10 +146,10 @@ func (h *Handler) handleListPackages(w http.ResponseWriter, r *http.Request) {
 
 	packages := make([]PackageSummary, 0, len(byName))
 	for _, pkg := range byName {
-		sort.Sort(sort.Reverse(sort.StringSlice(pkg.Versions)))
-		// After reverse-sorting, versions[0] is the lexicographically highest version.
-		// For standard semver (vX.Y.Z), this is the latest version. The LatestVersion
-		// field makes this contract explicit so the frontend doesn't rely on array order.
+		sortPackageVersions(pkg.Versions)
+		// Semantic versions sort newest-first, making versions[0] the latest release.
+		// LatestVersion keeps that contract explicit for clients that do not rely on
+		// array order.
 		if len(pkg.Versions) > 0 {
 			pkg.LatestVersion = pkg.Versions[0]
 		}
@@ -163,6 +165,30 @@ func (h *Handler) handleListPackages(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func sortPackageVersions(versions []string) {
+	sort.SliceStable(versions, func(i, j int) bool {
+		left, right := versions[i], versions[j]
+		leftValid, rightValid := semver.IsValid(left), semver.IsValid(right)
+		switch {
+		case leftValid && rightValid:
+			if comparison := semver.Compare(left, right); comparison != 0 {
+				return comparison > 0
+			}
+			// Build metadata does not affect semantic precedence. Use the original
+			// strings as a deterministic tie-breaker.
+			return left > right
+		case leftValid:
+			return true
+		case rightValid:
+			return false
+		default:
+			// Preserve deterministic behavior for legacy non-semver labels while
+			// keeping real releases ahead of them.
+			return left > right
+		}
+	})
 }
 
 func displayPackageName(name string) string {

--- a/pkg/help/server/server_test.go
+++ b/pkg/help/server/server_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/go-go-golems/glazed/pkg/help/model"
@@ -355,6 +357,50 @@ func TestContentTypeJSON(t *testing.T) {
 
 	if got := rw.Header().Get("Content-Type"); got != "application/json" {
 		t.Errorf("expected Content-Type=application/json, got %s", got)
+	}
+}
+
+func TestHandlePackagesSortsVersionsBySemanticPrecedence(t *testing.T) {
+	st, err := store.NewInMemory()
+	if err != nil {
+		t.Fatalf("store.NewInMemory: %v", err)
+	}
+	ctx := context.Background()
+	versions := []string{"v0.8.9", "v0.10.4", "v0.10.4-rc.1", "nightly"}
+	for i, version := range versions {
+		section := &model.Section{
+			PackageName:    "go-go-goja",
+			PackageVersion: version,
+			Slug:           fmt.Sprintf("section-%d", i),
+			Title:          version,
+			SectionType:    model.SectionGeneralTopic,
+		}
+		if err := st.Upsert(ctx, section); err != nil {
+			t.Fatalf("Upsert(%q): %v", version, err)
+		}
+	}
+	handler := NewHandler(HandlerDeps{Store: st})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/packages", nil)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+	if rw.Code != http.StatusOK {
+		t.Fatalf("packages status = %d: %s", rw.Code, rw.Body.String())
+	}
+
+	var response ListPackagesResponse
+	if err := json.Unmarshal(rw.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if len(response.Packages) != 1 {
+		t.Fatalf("expected one package, got %#v", response.Packages)
+	}
+	want := []string{"v0.10.4", "v0.10.4-rc.1", "v0.8.9", "nightly"}
+	if !slices.Equal(response.Packages[0].Versions, want) {
+		t.Fatalf("versions = %v, want %v", response.Packages[0].Versions, want)
+	}
+	if response.Packages[0].LatestVersion != "v0.10.4" {
+		t.Fatalf("latestVersion = %q, want v0.10.4", response.Packages[0].LatestVersion)
 	}
 }
 


### PR DESCRIPTION
## Summary
- sort documentation package versions by semantic precedence instead of reverse lexical order
- keep semantic versions ahead of legacy non-semver labels with deterministic fallback ordering
- add regression coverage for `v0.10.4` versus `v0.8.9`, prereleases, and non-semver labels

## Why
Goja documentation v0.10.4 published successfully, but `/api/packages` continued reporting v0.8.9 as `latestVersion` because lexical ordering treats `v0.8.9` as greater than `v0.10.4`.

## Validation
- `go test ./...`
- repository pre-commit/pre-push test, lint, gosec, and govulncheck hooks
- `git diff --check`