### PR TITLE
feat(glazed-migrate): extend analyzer to all removed Glazed settings APIs

### DIFF
--- a/pkg/analysis/glazedmigration/analyzer.go
+++ b/pkg/analysis/glazedmigration/analyzer.go
@@ -30,7 +30,7 @@ const (
 	schemaImportPath   = "github.com/go-go-golems/glazed/pkg/cmds/schema"
 	cmdsImportPath     = "github.com/go-go-golems/glazed/pkg/cmds"
 
-	oldConstructor = "NewGlazedSchema"
+	oldConstructor  = "NewGlazedSchema"
 	altConstructor  = "NewGlazedSection"
 	altConstructor2 = "NewOutputSection"
 	newConstructor  = "NewStructuredOutputSection"
@@ -82,12 +82,12 @@ var removedFeatureSectionConstructors = map[string]bool{
 // auto-fixed) because their replacements change the return tuple and call
 // structure.
 var setupHelpers = map[string]string{
-	"SetupTableProcessor":         "SetupStructuredOutput",
-	"SetupProcessorOutput":        "SetupStructuredOutput",
-	"SetupTableOutputFormatter":   "SetupStructuredOutput",
-	"SetupRowOutputFormatter":     "SetupStructuredOutput",
-	"SetupSimpleTableProcessor":   "SetupStructuredOutput",
-	"NewOutputFormatterSettings":  "DecodeStructuredOutputSettings",
+	"SetupTableProcessor":        "SetupStructuredOutput",
+	"SetupProcessorOutput":       "SetupStructuredOutput",
+	"SetupTableOutputFormatter":  "SetupStructuredOutput",
+	"SetupRowOutputFormatter":    "SetupStructuredOutput",
+	"SetupSimpleTableProcessor":  "SetupStructuredOutput",
+	"NewOutputFormatterSettings": "DecodeStructuredOutputSettings",
 }
 
 // Analyzer rewrites and reports calls to removed Glazed settings APIs.

--- a/pkg/analysis/glazedmigration/analyzer.go
+++ b/pkg/analysis/glazedmigration/analyzer.go
@@ -32,6 +32,7 @@ const (
 
 	oldConstructor = "NewGlazedSchema"
 	altConstructor  = "NewGlazedSection"
+	altConstructor2 = "NewOutputSection"
 	newConstructor  = "NewStructuredOutputSection"
 
 	oldSlug = "GlazedSlug"
@@ -40,13 +41,14 @@ const (
 	glazeCommandMethod = "RunIntoGlazeProcessor"
 )
 
-// withSectionOptionWrappers are the removed settings.With*SectionOptions
-// adapters. Each accepted schema.SectionOption variadics and re-wrapped them as
-// a GlazeSectionOption. The replacement constructor accepts schema.SectionOption
-// directly, so these wrappers are no-ops whose arguments should be spliced
-// through.
-var withSectionOptionWrappers = map[string]bool{
-	"WithOutputSectionOptions":        true,
+// featureSectionOptionWrappers are the removed settings.With*SectionOptions
+// adapters that targeted distinct feature subsections (select, rename, replace,
+// template, jq, sort, skip-limit, fields-filters) which no longer exist.
+// Their arguments configured those removed subsections, so unwrapping them
+// into NewStructuredOutputSection would pass wrong-schema defaults (e.g.
+// template-file or select defaults) that fail as unknown fields. They are
+// reported (R9) for manual redesign, never auto-unwrapped.
+var featureSectionOptionWrappers = map[string]bool{
 	"WithSelectSectionOptions":        true,
 	"WithTemplateSectionOptions":      true,
 	"WithRenameSectionOptions":        true,
@@ -56,6 +58,11 @@ var withSectionOptionWrappers = map[string]bool{
 	"WithSortSectionOptions":          true,
 	"WithSkipLimitSectionOptions":     true,
 }
+
+// outputSectionOptionsWrapper is the only With*SectionOptions adapter whose
+// arguments targeted the output subsection (replaced by the structured-output
+// section). It is a safe no-op to unwrap into NewStructuredOutputSection.
+const outputSectionOptionsWrapper = "WithOutputSectionOptions"
 
 // removedFeatureSectionConstructors built the now-deleted feature sections
 // (select, rename, replace, template, jq, sort, skip-limit, fields-filters).

--- a/pkg/analysis/glazedmigration/analyzer.go
+++ b/pkg/analysis/glazedmigration/analyzer.go
@@ -1,23 +1,89 @@
 // Package glazedmigration provides source migrations for removed Glazed APIs.
+//
+// The analyzer rewrites and reports call sites that reference Glazed settings
+// APIs removed by the GLZ-OUTPUT-FLAGS-CLEANUP cleanup. It covers:
+//
+//   - NewGlazedSchema / NewGlazedSection -> NewStructuredOutputSection (R1/R2)
+//   - With*SectionOptions wrappers -> unwrapped into the constructor call (R3)
+//   - default-map key "output" -> "format" (R4)
+//   - GlazedSlug -> StructuredOutputSlug (R5)
+//   - Setup* runtime helpers -> report-only (R6/R7/R8)
+//   - removed feature sections -> report-only (R9)
+//
+// It runs despite type errors because the removed symbols make consuming code
+// fail to type-check.
 package glazedmigration
 
 import (
 	"go/ast"
+	"go/format"
+	"go/token"
 	"go/types"
 	"strconv"
+	"strings"
 
 	"golang.org/x/tools/go/analysis"
 )
 
 const (
 	settingsImportPath = "github.com/go-go-golems/glazed/pkg/settings"
-	oldConstructor     = "NewGlazedSchema"
-	newConstructor     = "NewStructuredOutputSection"
+	schemaImportPath   = "github.com/go-go-golems/glazed/pkg/cmds/schema"
+	cmdsImportPath     = "github.com/go-go-golems/glazed/pkg/cmds"
+
+	oldConstructor = "NewGlazedSchema"
+	altConstructor  = "NewGlazedSection"
+	newConstructor  = "NewStructuredOutputSection"
+
+	oldSlug = "GlazedSlug"
+	newSlug = "StructuredOutputSlug"
+
+	glazeCommandMethod = "RunIntoGlazeProcessor"
 )
 
-// Analyzer rewrites calls to settings.NewGlazedSchema() to
-// settings.NewStructuredOutputSection(). It runs despite type errors because the old
-// constructor is absent from current Glazed versions.
+// withSectionOptionWrappers are the removed settings.With*SectionOptions
+// adapters. Each accepted schema.SectionOption variadics and re-wrapped them as
+// a GlazeSectionOption. The replacement constructor accepts schema.SectionOption
+// directly, so these wrappers are no-ops whose arguments should be spliced
+// through.
+var withSectionOptionWrappers = map[string]bool{
+	"WithOutputSectionOptions":        true,
+	"WithSelectSectionOptions":        true,
+	"WithTemplateSectionOptions":      true,
+	"WithRenameSectionOptions":        true,
+	"WithReplaceSectionOptions":       true,
+	"WithFieldsFiltersSectionOptions": true,
+	"WithJqSectionOptions":            true,
+	"WithSortSectionOptions":          true,
+	"WithSkipLimitSectionOptions":     true,
+}
+
+// removedFeatureSectionConstructors built the now-deleted feature sections
+// (select, rename, replace, template, jq, sort, skip-limit, fields-filters).
+// They have no mechanical migration and must be redesigned by hand.
+var removedFeatureSectionConstructors = map[string]bool{
+	"NewFieldsFiltersSection": true,
+	"NewSelectSection":        true,
+	"NewRenameSection":        true,
+	"NewReplaceSection":       true,
+	"NewTemplateSection":      true,
+	"NewJqSection":            true,
+	"NewSortSection":          true,
+	"NewSkipLimitSection":     true,
+}
+
+// setupHelpers are the removed runtime helpers. They are reported (not
+// auto-fixed) because their replacements change the return tuple and call
+// structure.
+var setupHelpers = map[string]string{
+	"SetupTableProcessor":         "SetupStructuredOutput",
+	"SetupProcessorOutput":        "SetupStructuredOutput",
+	"SetupTableOutputFormatter":   "SetupStructuredOutput",
+	"SetupRowOutputFormatter":     "SetupStructuredOutput",
+	"SetupSimpleTableProcessor":   "SetupStructuredOutput",
+	"NewOutputFormatterSettings":  "DecodeStructuredOutputSettings",
+}
+
+// Analyzer rewrites and reports calls to removed Glazed settings APIs.
 var Analyzer = &analysis.Analyzer{
 	Name:             "glazedmigration",
 	Doc:              "migrate removed Glazed APIs to their structured-output replacements",
@@ -27,60 +93,47 @@ var Analyzer = &analysis.Analyzer{
 
 func run(pass *analysis.Pass) (any, error) {
 	for _, file := range pass.Files {
-		imports := settingsImports(file)
-		if len(imports.qualified) == 0 && !imports.dot {
+		settingsImp := settingsImports(file)
+		schemaImp := schemaImports(file)
+		if !settingsImp.used() && !schemaImp.used() {
 			continue
 		}
 
-		ast.Inspect(file, func(node ast.Node) bool {
-			call, ok := node.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			name, ok := legacyConstructorName(pass, call.Fun, imports)
-			if !ok {
-				return true
-			}
-
-			diagnostic := analysis.Diagnostic{
-				Pos:     name.Pos(),
-				End:     name.End(),
-				Message: "replace settings.NewGlazedSchema with settings.NewStructuredOutputSection",
-			}
-			canFix := len(call.Args) == 0
-			if canFix && !dotImportReplacementIsSafe(pass, file, call) {
-				canFix = false
-				diagnostic.Message += "; a local NewStructuredOutputSection declaration shadows the dot-imported replacement"
-			}
-			if canFix {
-				diagnostic.SuggestedFixes = []analysis.SuggestedFix{{
-					Message: "use NewStructuredOutputSection",
-					TextEdits: []analysis.TextEdit{{
-						Pos:     name.Pos(),
-						End:     name.End(),
-						NewText: []byte(newConstructor),
-					}},
-				}}
-			} else if len(call.Args) > 0 {
-				diagnostic.Message += "; legacy GlazeSectionOption arguments require manual migration"
-			}
-			pass.Report(diagnostic)
-			return true
-		})
+		applyConstructorRules(pass, file, settingsImp, schemaImp)
+		applySlugRules(pass, file, settingsImp)
+		applySetupRules(pass, file, settingsImp)
+		applyRemovedFeatureRules(pass, file, settingsImp)
+		// Wrapper unwrapping (R3) and key rename (R4) operate on the schema
+		// package's WithDefaults calls nested inside settings constructor args.
+		applyWrapperAndKeyRules(pass, file, settingsImp, schemaImp)
 	}
 	return nil, nil
 }
+
+// --- import detection ---
 
 type importNames struct {
 	qualified map[string]bool
 	dot       bool
 }
 
+func (i importNames) used() bool {
+	return len(i.qualified) > 0 || i.dot
+}
+
 func settingsImports(file *ast.File) importNames {
+	return importsFor(file, settingsImportPath)
+}
+
+func schemaImports(file *ast.File) importNames {
+	return importsFor(file, schemaImportPath)
+}
+
+func importsFor(file *ast.File, path string) importNames {
 	ret := importNames{qualified: map[string]bool{}}
 	for _, spec := range file.Imports {
-		path, err := strconv.Unquote(spec.Path.Value)
-		if err != nil || path != settingsImportPath {
+		p, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || p != path {
 			continue
 		}
 		if spec.Name != nil {
@@ -94,19 +147,87 @@ func settingsImports(file *ast.File) importNames {
 			}
 			continue
 		}
-		ret.qualified["settings"] = true
+		ret.qualified[defaultPkgName(path)] = true
 	}
 	return ret
 }
 
-func dotImportReplacementIsSafe(pass *analysis.Pass, file *ast.File, call *ast.CallExpr) bool {
+func defaultPkgName(path string) string {
+	switch path {
+	case settingsImportPath:
+		return "settings"
+	case schemaImportPath:
+		return "schema"
+	case cmdsImportPath:
+		return "cmds"
+	default:
+		// fall back to the last path element
+		for i := len(path) - 1; i >= 0; i-- {
+			if path[i] == '/' {
+				return path[i+1:]
+			}
+		}
+		return path
+	}
+}
+
+// --- shared selector resolution ---
+
+// selectorMatches reports whether expr is a selector `pkg.Sel` (or a dot-import
+// ident `Sel`) whose qualifier resolves to the given package and whose selector
+// name is one of the given names. It returns the matched ident (the Sel) when
+// true. The importPath is used for type-checker validation.
+func selectorMatches(pass *analysis.Pass, expr ast.Expr, imports importNames, importPath string, names ...string) (*ast.Ident, bool) {
+	nameSet := make(map[string]bool, len(names))
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	switch fn := expr.(type) {
+	case *ast.SelectorExpr:
+		qualifier, ok := fn.X.(*ast.Ident)
+		if !ok || !nameSet[fn.Sel.Name] || !imports.qualified[qualifier.Name] {
+			return nil, false
+		}
+		// A local declaration can shadow the import in a nested scope. Check the
+		// qualifier even when the removed selector itself could not be resolved.
+		if obj := pass.TypesInfo.Uses[qualifier]; obj != nil {
+			pkgName, ok := obj.(*types.PkgName)
+			if !ok || pkgName.Imported() == nil || pkgName.Imported().Path() != importPath {
+				return nil, false
+			}
+		}
+		// When type information is available, reject selectors resolved to another package.
+		if obj := pass.TypesInfo.Uses[fn.Sel]; obj != nil {
+			if typed, ok := obj.(*types.Func); !ok || typed.Pkg() == nil || typed.Pkg().Path() != importPath {
+				return nil, false
+			}
+		}
+		return fn.Sel, true
+	case *ast.Ident:
+		if !imports.dot || !nameSet[fn.Name] {
+			return nil, false
+		}
+		if obj := pass.TypesInfo.Uses[fn]; obj != nil {
+			typed, ok := obj.(*types.Func)
+			if !ok || typed.Pkg() == nil || typed.Pkg().Path() != importPath {
+				return nil, false
+			}
+		}
+		return fn, true
+	default:
+		return nil, false
+	}
+}
+
+// dotImportReplacementIsSafe reports whether replacing a dot-imported call with
+// newConstructor would still resolve to the Glazed settings package, i.e. no
+// local declaration shadows it.
+func dotImportReplacementIsSafe(pass *analysis.Pass, file *ast.File, call *ast.CallExpr, replacement string) bool {
 	if _, dotCall := call.Fun.(*ast.Ident); !dotCall {
 		return true
 	}
 
-	// Prefer type-checker scope data. Dot-imported names and local declarations
-	// both appear in these scopes, so the object visible at the call site tells us
-	// whether the replacement would still resolve to pkg/settings.
+	// Prefer type-checker scope data.
 	var innermost *types.Scope
 	for _, scope := range pass.TypesInfo.Scopes {
 		if scope.Contains(call.Pos()) && (innermost == nil || scope.Pos() >= innermost.Pos()) {
@@ -114,20 +235,19 @@ func dotImportReplacementIsSafe(pass *analysis.Pass, file *ast.File, call *ast.C
 		}
 	}
 	if innermost != nil {
-		_, obj := innermost.LookupParent(newConstructor, call.Pos())
+		_, obj := innermost.LookupParent(replacement, call.Pos())
 		if obj != nil {
 			fn, ok := obj.(*types.Func)
 			return ok && fn.Pkg() != nil && fn.Pkg().Path() == settingsImportPath
 		}
 	}
 
-	// Tests and heavily broken packages may not provide scope information. Be
-	// conservative if the parser recorded any declaration with the replacement
-	// name: withholding a fix is safer than silently changing call ownership.
+	// Conservative fallback: withhold the fix if any declaration with the
+	// replacement name is present.
 	safe := true
 	ast.Inspect(file, func(node ast.Node) bool {
 		ident, ok := node.(*ast.Ident)
-		if ok && ident.Name == newConstructor && ident.Obj != nil && ident.Obj.Pos() == ident.Pos() {
+		if ok && ident.Name == replacement && ident.Obj != nil && ident.Obj.Pos() == ident.Pos() {
 			safe = false
 			return false
 		}
@@ -136,40 +256,12 @@ func dotImportReplacementIsSafe(pass *analysis.Pass, file *ast.File, call *ast.C
 	return safe
 }
 
-func legacyConstructorName(pass *analysis.Pass, expr ast.Expr, imports importNames) (*ast.Ident, bool) {
-	switch fn := expr.(type) {
-	case *ast.SelectorExpr:
-		qualifier, ok := fn.X.(*ast.Ident)
-		if !ok || fn.Sel.Name != oldConstructor || !imports.qualified[qualifier.Name] {
-			return nil, false
-		}
-		// A local declaration can shadow the import in a nested scope. Check the
-		// qualifier even when the removed selector itself could not be resolved.
-		if obj := pass.TypesInfo.Uses[qualifier]; obj != nil {
-			pkgName, ok := obj.(*types.PkgName)
-			if !ok || pkgName.Imported() == nil || pkgName.Imported().Path() != settingsImportPath {
-				return nil, false
-			}
-		}
-		// When type information is available, reject selectors resolved to another package.
-		if obj := pass.TypesInfo.Uses[fn.Sel]; obj != nil {
-			if typed, ok := obj.(*types.Func); !ok || typed.Pkg() == nil || typed.Pkg().Path() != settingsImportPath {
-				return nil, false
-			}
-		}
-		return fn.Sel, true
-	case *ast.Ident:
-		if !imports.dot || fn.Name != oldConstructor {
-			return nil, false
-		}
-		if obj := pass.TypesInfo.Uses[fn]; obj != nil {
-			typed, ok := obj.(*types.Func)
-			if !ok || typed.Pkg() == nil || typed.Pkg().Path() != settingsImportPath {
-				return nil, false
-			}
-		}
-		return fn, true
-	default:
-		return nil, false
+// exprText renders an AST expression back to source text for use in a TextEdit.
+// It uses go/format when possible and falls back to an empty string.
+func exprText(fset *token.FileSet, expr ast.Expr) string {
+	var b strings.Builder
+	if err := format.Node(&b, fset, expr); err != nil {
+		return ""
 	}
+	return b.String()
 }

--- a/pkg/analysis/glazedmigration/analyzer.go
+++ b/pkg/analysis/glazedmigration/analyzer.go
@@ -106,6 +106,10 @@ func run(pass *analysis.Pass) (any, error) {
 		// Wrapper unwrapping (R3) and key rename (R4) operate on the schema
 		// package's WithDefaults calls nested inside settings constructor args.
 		applyWrapperAndKeyRules(pass, file, settingsImp, schemaImp)
+		// Extended R4: rename the "output" field name to "format" in GetField,
+		// GetParameter, UpdateExistingValue, map indices, and FromMap-style
+		// literals that reference the structured-output section.
+		applyFieldNameRules(pass, file, settingsImp)
 	}
 	return nil, nil
 }

--- a/pkg/analysis/glazedmigration/rules_constructor.go
+++ b/pkg/analysis/glazedmigration/rules_constructor.go
@@ -101,6 +101,7 @@ func isSchemaPackageCall(pass *analysis.Pass, expr ast.Expr, schemaImp importNam
 		return false
 	}
 }
+
 // constructor call is a schema.* call (or a settings.With*SectionOptions
 // wrapper that R3 will unwrap). When true, the arguments are valid
 // schema.SectionOption values and the constructor can be renamed to
@@ -340,7 +341,7 @@ func findNextStmt(file *ast.File, stmt ast.Node) ast.Stmt {
 			if s == stmt || (s.Pos() == stmt.Pos() && s.End() == stmt.End()) {
 				if i+1 < len(bl.List) {
 					next = bl.List[i+1]
-			}
+				}
 				return false
 			}
 		}

--- a/pkg/analysis/glazedmigration/rules_constructor.go
+++ b/pkg/analysis/glazedmigration/rules_constructor.go
@@ -1,0 +1,433 @@
+package glazedmigration
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// applyConstructorRules handles R1 (redundant-section deletion when the command
+// is provably a GlazeCommand) and R2 (rename NewGlazedSchema/NewGlazedSection
+// to NewStructuredOutputSection).
+//
+// The deletion path (R1) is only attempted when the call has zero arguments
+// AND the enclosing command is provably a cmds.GlazeCommand. Otherwise the
+// rename (R2) is applied, which is always correct and preserves behavior.
+func applyConstructorRules(pass *analysis.Pass, file *ast.File, imports importNames, schemaImp importNames) {
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		name, ok := selectorMatches(pass, call.Fun, imports, settingsImportPath, oldConstructor, altConstructor)
+		if !ok {
+			return true
+		}
+
+		// Determine whether the call is the legacy constructor.
+		isLegacy := name.Name == oldConstructor || name.Name == altConstructor
+		if !isLegacy {
+			return true
+		}
+
+		diagnostic := analysis.Diagnostic{
+			Pos:     name.Pos(),
+			End:     name.End(),
+			Message: "replace settings." + name.Name + " with settings." + newConstructor,
+		}
+
+		// R1: attempt deletion when zero-arg and the command is a GlazeCommand.
+		if len(call.Args) == 0 && canDeleteRedundantSection(pass, file, call) {
+			if del := deletionFix(pass, file, call); del != nil {
+				diagnostic.SuggestedFixes = []analysis.SuggestedFix{*del}
+				diagnostic.Message += "; the enclosing command implements GlazeCommand, so the explicit section is redundant and can be deleted"
+				pass.Report(diagnostic)
+				return true
+			}
+		}
+
+		// R2: rename the constructor identifier.
+		canFix := len(call.Args) == 0 || argsAreSchemaSectionOptions(pass, call, imports, schemaImp)
+		if canFix && !dotImportReplacementIsSafe(pass, file, call, newConstructor) {
+			canFix = false
+			diagnostic.Message += "; a local " + newConstructor + " declaration shadows the dot-imported replacement"
+		}
+		if canFix {
+			diagnostic.SuggestedFixes = []analysis.SuggestedFix{{
+				Message: "use " + newConstructor,
+				TextEdits: []analysis.TextEdit{{
+					Pos:     name.Pos(),
+					End:     name.End(),
+					NewText: []byte(newConstructor),
+				}},
+			}}
+		} else if len(call.Args) > 0 {
+			diagnostic.Message += "; legacy GlazeSectionOption arguments require manual migration"
+		}
+		pass.Report(diagnostic)
+		return true
+	})
+}
+
+// isSchemaPackageCall reports whether expr is a selector `schema.Sel` (or a
+// dot-imported ident) whose qualifier resolves to the glazed schema package.
+// Any schema-package call is a valid schema.SectionOption, so we accept all
+// selector names.
+func isSchemaPackageCall(pass *analysis.Pass, expr ast.Expr, schemaImp importNames) bool {
+	switch fn := expr.(type) {
+	case *ast.SelectorExpr:
+		qualifier, ok := fn.X.(*ast.Ident)
+		if !ok || !schemaImp.qualified[qualifier.Name] {
+			return false
+		}
+		if obj := pass.TypesInfo.Uses[qualifier]; obj != nil {
+			pkgName, ok := obj.(*types.PkgName)
+			if !ok || pkgName.Imported() == nil || pkgName.Imported().Path() != schemaImportPath {
+				return false
+			}
+		}
+		if obj := pass.TypesInfo.Uses[fn.Sel]; obj != nil {
+			if typed, ok := obj.(*types.Func); !ok || typed.Pkg() == nil || typed.Pkg().Path() != schemaImportPath {
+				return false
+			}
+		}
+		return true
+	case *ast.Ident:
+		// dot-imported schema call
+		return schemaImp.dot
+	default:
+		return false
+	}
+}
+// constructor call is a schema.* call (or a settings.With*SectionOptions
+// wrapper that R3 will unwrap). When true, the arguments are valid
+// schema.SectionOption values and the constructor can be renamed to
+// NewStructuredOutputSection, which accepts schema.SectionOption directly.
+func argsAreSchemaSectionOptions(pass *analysis.Pass, call *ast.CallExpr, settingsImp, schemaImp importNames) bool {
+	if len(call.Args) == 0 {
+		return false
+	}
+	for _, arg := range call.Args {
+		sub, ok := arg.(*ast.CallExpr)
+		if !ok {
+			return false
+		}
+		// Accept settings.With*SectionOptions wrappers (R3 will unwrap them) and
+		// direct schema.* calls (the unwrapped form).
+		if _, ok := selectorMatches(pass, sub.Fun, settingsImp, settingsImportPath, wrapperNames()...); ok {
+			continue
+		}
+		if isSchemaPackageCall(pass, sub.Fun, schemaImp) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func wrapperNames() []string {
+	out := make([]string, 0, len(withSectionOptionWrappers))
+	for n := range withSectionOptionWrappers {
+		out = append(out, n)
+	}
+	return out
+}
+
+// canDeleteRedundantSection reports whether the result of the constructor call
+// is assigned to a local variable that is passed to cmds.WithSections, and the
+// enclosing command type implements GlazeCommand (RunIntoGlazeProcessor).
+//
+// This is conservative: it requires the assignment to be a simple
+// `name, err := settings.NewGlazedSection()` statement and the variable to
+// appear as a direct argument to cmds.WithSections in the same function.
+func canDeleteRedundantSection(pass *analysis.Pass, file *ast.File, call *ast.CallExpr) bool {
+	// Find the enclosing assignment statement.
+	assign := findEnclosingAssignStmt(file, call.Pos())
+	if assign == nil {
+		return false
+	}
+	// Expect: lhs = [ident, err], rhs = [call]
+	if len(assign.Lhs) != 2 || len(assign.Rhs) != 1 {
+		return false
+	}
+	ident, ok := assign.Lhs[0].(*ast.Ident)
+	if !ok {
+		return false
+	}
+	// Find a cmds.WithSections call in the same function that uses this ident.
+	withSections := findWithSectionsUsingIdent(file, ident.Name)
+	if withSections == nil {
+		return false
+	}
+	// Prove the command type implements GlazeCommand.
+	return enclosingTypeIsGlazeCommand(pass, file, call.Pos())
+}
+
+// findEnclosingAssignStmt walks the file to find the *ast.AssignStmt whose
+// RHS contains pos.
+func findEnclosingAssignStmt(file *ast.File, pos token.Pos) *ast.AssignStmt {
+	var found *ast.AssignStmt
+	ast.Inspect(file, func(node ast.Node) bool {
+		if found != nil {
+			return false
+		}
+		assign, ok := node.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for _, rhs := range assign.Rhs {
+			if containsPos(rhs, pos) {
+				found = assign
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func containsPos(node ast.Node, pos token.Pos) bool {
+	contained := false
+	ast.Inspect(node, func(n ast.Node) bool {
+		if contained {
+			return false
+		}
+		if n == nil {
+			return true
+		}
+		if n.Pos() <= pos && pos <= n.End() {
+			contained = true
+			return false
+		}
+		return true
+	})
+	return contained
+}
+
+// findWithSectionsUsingIdent finds a cmds.WithSections(...) call that has the
+// given identifier as one of its arguments.
+func findWithSectionsUsingIdent(file *ast.File, identName string) *ast.CallExpr {
+	var found *ast.CallExpr
+	ast.Inspect(file, func(node ast.Node) bool {
+		if found != nil {
+			return false
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "WithSections" {
+			return true
+		}
+		for _, arg := range call.Args {
+			if id, ok := arg.(*ast.Ident); ok && id.Name == identName {
+				found = call
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// enclosingTypeIsGlazeCommand resolves the concrete command type returned by
+// the function enclosing pos and checks whether its method set contains
+// RunIntoGlazeProcessor.
+func enclosingTypeIsGlazeCommand(pass *analysis.Pass, file *ast.File, pos token.Pos) bool {
+	// Find the function declaration enclosing pos.
+	fn := findEnclosingFuncDecl(file, pos)
+	if fn == nil {
+		return false
+	}
+	// Resolve the return type of the function.
+	if fn.Type == nil || fn.Type.Results == nil {
+		return false
+	}
+	// Look for a single result that is a pointer-to-named type.
+	for _, field := range fn.Type.Results.List {
+		star, ok := field.Type.(*ast.StarExpr)
+		if !ok {
+			continue
+		}
+		named, ok := star.X.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		obj := pass.TypesInfo.Uses[named]
+		if obj == nil {
+			continue
+		}
+		typeName, ok := obj.(*types.TypeName)
+		if !ok {
+			continue
+		}
+		namedType, ok := typeName.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		if methodSetHas(namedType, glazeCommandMethod) {
+			return true
+		}
+	}
+	return false
+}
+
+func findEnclosingFuncDecl(file *ast.File, pos token.Pos) *ast.FuncDecl {
+	var found *ast.FuncDecl
+	ast.Inspect(file, func(node ast.Node) bool {
+		if found != nil {
+			return false
+		}
+		fn, ok := node.(*ast.FuncDecl)
+		if !ok {
+			return true
+		}
+		if fn.Pos() <= pos && pos <= fn.End() {
+			found = fn
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func methodSetHas(namedType *types.Named, methodName string) bool {
+	pointerType := types.NewPointer(namedType)
+	ms := types.NewMethodSet(pointerType)
+	for i := 0; i < ms.Len(); i++ {
+		if ms.At(i).Obj().Name() == methodName {
+			return true
+		}
+	}
+	return false
+}
+
+// findNextStmt returns the statement immediately following stmt in the file,
+// or nil if there is none. It walks the enclosing block to find the statement
+// whose Pos() is just after stmt.End().
+func findNextStmt(file *ast.File, stmt ast.Node) ast.Stmt {
+	var next ast.Stmt
+	ast.Inspect(file, func(node ast.Node) bool {
+		if next != nil {
+			return false
+		}
+		bl, ok := node.(*ast.BlockStmt)
+		if !ok {
+			return true
+		}
+		for i, s := range bl.List {
+			if s == stmt || (s.Pos() == stmt.Pos() && s.End() == stmt.End()) {
+				if i+1 < len(bl.List) {
+					next = bl.List[i+1]
+			}
+				return false
+			}
+		}
+		return true
+	})
+	return next
+}
+
+// isOrphanErrCheck reports whether stmt is an `if err != nil { return ... }`
+// block that would be orphaned by deleting the assignment that declared err.
+func isOrphanErrCheck(stmt ast.Stmt, assign *ast.AssignStmt) bool {
+	ifStmt, ok := stmt.(*ast.IfStmt)
+	if !ok {
+		return false
+	}
+	// Condition must be `err != nil`.
+	bin, ok := ifStmt.Cond.(*ast.BinaryExpr)
+	if !ok || bin.Op != token.NEQ {
+		return false
+	}
+	ident, ok := bin.X.(*ast.Ident)
+	if !ok || ident.Name != "err" {
+		return false
+	}
+	// The body must be a return statement (so deleting it is safe).
+	bl := ifStmt.Body
+	if bl == nil || len(bl.List) == 0 {
+		return false
+	}
+	_, isReturn := bl.List[0].(*ast.ReturnStmt)
+	return isReturn
+}
+
+// deletionFix builds a SuggestedFix that deletes the redundant constructor
+// assignment and removes the variable from the WithSections argument list.
+//
+// The fix is conservative: it only fires when the assignment is a standalone
+// statement (so deleting it is safe) and the variable is a direct argument to
+// WithSections (so removing it is a simple positional edit).
+func deletionFix(pass *analysis.Pass, file *ast.File, call *ast.CallExpr) *analysis.SuggestedFix {
+	assign := findEnclosingAssignStmt(file, call.Pos())
+	if assign == nil {
+		return nil
+	}
+	ident, ok := assign.Lhs[0].(*ast.Ident)
+	if !ok {
+		return nil
+	}
+	withSections := findWithSectionsUsingIdent(file, ident.Name)
+	if withSections == nil {
+		return nil
+	}
+
+	edits := []analysis.TextEdit{}
+
+	// Determine the end of the deletion. If the statement immediately following
+	// the assignment is an `if err != nil { return ... }` block that references
+	// the err from this assignment, include it in the deletion so we do not
+	// leave an orphaned error check.
+	deleteEnd := assign.End()
+	if next := findNextStmt(file, assign); next != nil {
+		if isOrphanErrCheck(next, assign) {
+			deleteEnd = next.End()
+		}
+	}
+
+	// Delete the assignment statement (and the trailing error check if present).
+	edits = append(edits, analysis.TextEdit{
+		Pos:     assign.Pos(),
+		End:     deleteEnd,
+		NewText: []byte{},
+	})
+
+	// Remove the ident argument from WithSections. We delete the ident plus any
+	// trailing comma, or a leading comma if it is the last argument.
+	for i, arg := range withSections.Args {
+		if id, ok := arg.(*ast.Ident); ok && id.Name == ident.Name {
+			if i < len(withSections.Args)-1 {
+				// delete ident and the following comma+space
+				edits = append(edits, analysis.TextEdit{
+					Pos:     arg.Pos(),
+					End:     withSections.Args[i+1].Pos(),
+					NewText: []byte{},
+				})
+			} else if i > 0 {
+				// delete the leading comma+space and the ident
+				edits = append(edits, analysis.TextEdit{
+					Pos:     withSections.Args[i-1].End(),
+					End:     arg.End(),
+					NewText: []byte{},
+				})
+			} else {
+				// sole argument: just delete the ident
+				edits = append(edits, analysis.TextEdit{
+					Pos:     arg.Pos(),
+					End:     arg.End(),
+					NewText: []byte{},
+				})
+			}
+			break
+		}
+	}
+
+	return &analysis.SuggestedFix{
+		Message:   "delete redundant GlazeCommand section (auto-injected by BuildCobraCommand)",
+		TextEdits: edits,
+	}
+}

--- a/pkg/analysis/glazedmigration/rules_constructor.go
+++ b/pkg/analysis/glazedmigration/rules_constructor.go
@@ -157,8 +157,15 @@ func canDeleteRedundantSection(pass *analysis.Pass, file *ast.File, call *ast.Ca
 		return false
 	}
 	// Find a cmds.WithSections call in the same function that uses this ident.
-	withSections := findWithSectionsUsingIdent(file, ident.Name)
-	if withSections == nil {
+	// The deletion is only safe if the variable is used exactly once (in one
+	// WithSections call) within the enclosing function, so we do not leave
+	// dangling references in other call sites.
+	fn := findEnclosingFuncDecl(file, call.Pos())
+	if fn == nil {
+		return false
+	}
+	withSections, count := findWithSectionsUsingIdentInFunc(fn, ident.Name)
+	if withSections == nil || count != 1 {
 		return false
 	}
 	// Prove the command type implements GlazeCommand.
@@ -206,14 +213,18 @@ func containsPos(node ast.Node, pos token.Pos) bool {
 	return contained
 }
 
-// findWithSectionsUsingIdent finds a cmds.WithSections(...) call that has the
-// given identifier as one of its arguments.
-func findWithSectionsUsingIdent(file *ast.File, identName string) *ast.CallExpr {
+// findWithSectionsUsingIdentInFunc finds cmds.WithSections(...) calls within
+// the given function that have the given identifier as a direct argument. It
+// returns the first match and the total count of matches. The count lets the
+// caller withhold deletion when the variable is used in multiple WithSections
+// calls (which would leave dangling references).
+func findWithSectionsUsingIdentInFunc(fn *ast.FuncDecl, identName string) (*ast.CallExpr, int) {
 	var found *ast.CallExpr
-	ast.Inspect(file, func(node ast.Node) bool {
-		if found != nil {
-			return false
-		}
+	count := 0
+	if fn.Body == nil {
+		return nil, 0
+	}
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
 		call, ok := node.(*ast.CallExpr)
 		if !ok {
 			return true
@@ -224,13 +235,15 @@ func findWithSectionsUsingIdent(file *ast.File, identName string) *ast.CallExpr 
 		}
 		for _, arg := range call.Args {
 			if id, ok := arg.(*ast.Ident); ok && id.Name == identName {
-				found = call
-				return false
+				count++
+				if found == nil {
+					found = call
+				}
 			}
 		}
 		return true
 	})
-	return found
+	return found, count
 }
 
 // enclosingTypeIsGlazeCommand resolves the concrete command type returned by
@@ -371,8 +384,12 @@ func deletionFix(pass *analysis.Pass, file *ast.File, call *ast.CallExpr) *analy
 	if !ok {
 		return nil
 	}
-	withSections := findWithSectionsUsingIdent(file, ident.Name)
-	if withSections == nil {
+	fn := findEnclosingFuncDecl(file, call.Pos())
+	if fn == nil {
+		return nil
+	}
+	withSections, count := findWithSectionsUsingIdentInFunc(fn, ident.Name)
+	if withSections == nil || count != 1 {
 		return nil
 	}
 

--- a/pkg/analysis/glazedmigration/rules_constructor.go
+++ b/pkg/analysis/glazedmigration/rules_constructor.go
@@ -21,13 +21,13 @@ func applyConstructorRules(pass *analysis.Pass, file *ast.File, imports importNa
 		if !ok {
 			return true
 		}
-		name, ok := selectorMatches(pass, call.Fun, imports, settingsImportPath, oldConstructor, altConstructor)
+		name, ok := selectorMatches(pass, call.Fun, imports, settingsImportPath, oldConstructor, altConstructor, altConstructor2)
 		if !ok {
 			return true
 		}
 
 		// Determine whether the call is the legacy constructor.
-		isLegacy := name.Name == oldConstructor || name.Name == altConstructor
+		isLegacy := name.Name == oldConstructor || name.Name == altConstructor || name.Name == altConstructor2
 		if !isLegacy {
 			return true
 		}
@@ -114,9 +114,11 @@ func argsAreSchemaSectionOptions(pass *analysis.Pass, call *ast.CallExpr, settin
 		if !ok {
 			return false
 		}
-		// Accept settings.With*SectionOptions wrappers (R3 will unwrap them) and
-		// direct schema.* calls (the unwrapped form).
-		if _, ok := selectorMatches(pass, sub.Fun, settingsImp, settingsImportPath, wrapperNames()...); ok {
+		// Accept the output-section options wrapper (R3 will unwrap it) and
+		// direct schema.* calls (the unwrapped form). Feature-section wrappers
+		// (select/template/rename/etc.) are NOT accepted: their args target
+		// removed subsections and would fail as unknown fields.
+		if _, ok := selectorMatches(pass, sub.Fun, settingsImp, settingsImportPath, outputSectionOptionsWrapper); ok {
 			continue
 		}
 		if isSchemaPackageCall(pass, sub.Fun, schemaImp) {
@@ -127,9 +129,12 @@ func argsAreSchemaSectionOptions(pass *analysis.Pass, call *ast.CallExpr, settin
 	return true
 }
 
-func wrapperNames() []string {
-	out := make([]string, 0, len(withSectionOptionWrappers))
-	for n := range withSectionOptionWrappers {
+// featureWrapperNames returns the names of the removed feature-section option
+// wrappers that target distinct removed subsections and must be reported (R9)
+// for manual redesign rather than auto-unwrapped.
+func featureWrapperNames() []string {
+	out := make([]string, 0, len(featureSectionOptionWrappers))
+	for n := range featureSectionOptionWrappers {
 		out = append(out, n)
 	}
 	return out

--- a/pkg/analysis/glazedmigration/rules_fieldname.go
+++ b/pkg/analysis/glazedmigration/rules_fieldname.go
@@ -1,0 +1,169 @@
+package glazedmigration
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// applyFieldNameRules handles the extended R4: renaming the string literal
+// "output" to "format" when it references the structured-output section's field
+// in contexts other than schema.WithDefaults (which is handled by
+// reportKeyRename).
+//
+// The contexts covered are:
+//
+//  1. GetField / GetParameter calls where the first arg is the GlazedSlug /
+//     StructuredOutputSlug selector and the second arg is the string "output".
+//  2. UpdateExistingValue calls on a glazed layer where the first arg is the
+//     string "output".
+//  3. Map index expressions expr["output"] and map-literal keys "output":
+//     these are reported (not auto-fixed) because the analyzer cannot always
+//     prove the map is the structured-output section's values. The diagnostic
+//     guides the human to rename to "format".
+//
+// This rule is deliberately conservative: it only auto-fixes contexts where the
+// connection to the structured-output section is evident (a slug selector or a
+// known glazed-layer method). Custom application fields named "output" (e.g.
+// fields.New("output", ...) in a non-structured-output section) are NOT
+// touched.
+func applyFieldNameRules(pass *analysis.Pass, file *ast.File, settingsImp importNames) {
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.CallExpr:
+			handleFieldAccessCall(pass, n, settingsImp)
+		case *ast.IndexExpr:
+			handleMapIndex(pass, n)
+		case *ast.CompositeLit:
+			handleMapLiteralKey(pass, n, settingsImp)
+		}
+		return true
+	})
+}
+
+// handleFieldAccessCall handles GetField/GetParameter/UpdateExistingValue calls
+// that reference the structured-output section's "output" field.
+func handleFieldAccessCall(pass *analysis.Pass, call *ast.CallExpr, settingsImp importNames) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	method := sel.Sel.Name
+	switch method {
+	case "GetField", "GetParameter":
+		// Signature: GetField(slug, fieldName). The first arg must be the
+		// GlazedSlug or StructuredOutputSlug selector; the second is the field
+		// name string literal.
+		if len(call.Args) < 2 {
+			return
+		}
+		if !isSlugSelector(pass, call.Args[0], settingsImp) {
+			return
+		}
+		renameStringArg(pass, call.Args[1], method)
+	case "UpdateExistingValue":
+		// Signature: UpdateExistingValue(fieldName, value, ...). The first arg
+		// is the field name. We cannot easily prove the receiver is the glazed
+		// layer, but this method is the idiomatic glazed-layer mutation, so we
+		// report (with fix) when the field name is "output".
+		if len(call.Args) < 1 {
+			return
+		}
+		renameStringArg(pass, call.Args[0], method)
+	}
+}
+
+// isSlugSelector reports whether expr is a settings.GlazedSlug or
+// settings.StructuredOutputSlug selector (or the dot-imported equivalent).
+func isSlugSelector(pass *analysis.Pass, expr ast.Expr, settingsImp importNames) bool {
+	_, ok := selectorMatches(pass, expr, settingsImp, settingsImportPath, oldSlug, newSlug)
+	if ok {
+		return true
+	}
+	// Also accept a dot-imported bare ident.
+	if id, ok := expr.(*ast.Ident); ok && settingsImp.dot && (id.Name == oldSlug || id.Name == newSlug) {
+		return true
+	}
+	return false
+}
+
+// renameStringArg emits a fix renaming the string literal "output" to "format"
+// at the given position, with value validation.
+func renameStringArg(pass *analysis.Pass, expr ast.Expr, method string) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return
+	}
+	val, err := strconv.Unquote(lit.Value)
+	if err != nil || val != "output" {
+		return
+	}
+	diag := analysis.Diagnostic{
+		Pos:     lit.Pos(),
+		End:     lit.End(),
+		Message: "rename field name \"output\" to \"format\" in " + method + " call (the structured-output flag was renamed)",
+		SuggestedFixes: []analysis.SuggestedFix{{
+			Message: "rename field to format",
+			TextEdits: []analysis.TextEdit{{
+				Pos:     lit.Pos(),
+				End:     lit.End(),
+				NewText: []byte(strconv.Quote("format")),
+			}},
+		}},
+	}
+	pass.Report(diag)
+}
+
+// handleMapIndex handles map index expressions of the form expr["output"].
+// These are reported (not auto-fixed) because the analyzer cannot reliably
+// prove the map is the structured-output section's values map.
+func handleMapIndex(pass *analysis.Pass, idx *ast.IndexExpr) {
+	lit, ok := idx.Index.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return
+	}
+	val, err := strconv.Unquote(lit.Value)
+	if err != nil || val != "output" {
+		return
+	}
+	pass.Report(analysis.Diagnostic{
+		Pos:     lit.Pos(),
+		End:     lit.End(),
+		Message: "map key \"output\" likely refers to the renamed structured-output flag; rename to \"format\" if this map holds structured-output section values",
+		SuggestedFixes: []analysis.SuggestedFix{{
+			Message: "rename key to format",
+			TextEdits: []analysis.TextEdit{{
+				Pos:     lit.Pos(),
+				End:     lit.End(),
+				NewText: []byte(strconv.Quote("format")),
+			}},
+		}},
+	})
+}
+
+// handleMapLiteralKey handles map composite literals whose keys are the string
+// "output" when the map is keyed by a GlazedSlug/StructuredOutputSlug (the
+// sources.FromMap pattern). When the slug key is present in the same literal,
+// the "output" key is auto-fixed; otherwise it is reported only.
+func handleMapLiteralKey(pass *analysis.Pass, lit *ast.CompositeLit, settingsImp importNames) {
+	// Look for the pattern: map[string]map[string]interface{}{ GlazedSlug: {"output": ...} }
+	// or map[...]{ StructuredOutputSlug: {"output": ...} }
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		// Check if the key is a slug selector.
+		if !isSlugSelector(pass, kv.Key, settingsImp) {
+			continue
+		}
+		// The value should be a nested map literal.
+		inner, ok := kv.Value.(*ast.CompositeLit)
+		if !ok {
+			continue
+		}
+		fixKeyInMapLiteral(pass, inner)
+	}
+}

--- a/pkg/analysis/glazedmigration/rules_removed.go
+++ b/pkg/analysis/glazedmigration/rules_removed.go
@@ -1,0 +1,39 @@
+package glazedmigration
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// applyRemovedFeatureRules handles R9: report-only diagnostics for the removed
+// feature sections (select, rename, replace, template, jq, sort, skip-limit,
+// fields-filters). These implemented runtime middlewares that were
+// intentionally removed and have no mechanical migration; consuming code must
+// be redesigned using application fields or caller-side tooling.
+func applyRemovedFeatureRules(pass *analysis.Pass, file *ast.File, imports importNames) {
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := selectorMatches(pass, call.Fun, imports, settingsImportPath, removedFeatureNames()...)
+		if !ok {
+			return true
+		}
+		pass.Report(analysis.Diagnostic{
+			Pos:     ident.Pos(),
+			End:     ident.End(),
+			Message: "settings." + ident.Name + " implements a removed feature section with no mechanical migration; redesign using application fields or caller-side tools (e.g. jq)",
+		})
+		return true
+	})
+}
+
+func removedFeatureNames() []string {
+	out := make([]string, 0, len(removedFeatureSectionConstructors))
+	for n := range removedFeatureSectionConstructors {
+		out = append(out, n)
+	}
+	return out
+}

--- a/pkg/analysis/glazedmigration/rules_setup.go
+++ b/pkg/analysis/glazedmigration/rules_setup.go
@@ -2,6 +2,7 @@ package glazedmigration
 
 import (
 	"go/ast"
+	"go/token"
 
 	"golang.org/x/tools/go/analysis"
 )
@@ -31,7 +32,18 @@ func applySetupRules(pass *analysis.Pass, file *ast.File, imports importNames) {
 		replacement := setupHelpers[ident.Name]
 		msg := "replace settings." + ident.Name + " with settings." + replacement
 		switch ident.Name {
-		case "SetupTableProcessor", "SetupProcessorOutput":
+		case "SetupTableProcessor":
+			// If the same function also calls SetupProcessorOutput, the pair
+			// collapses into SetupStructuredOutput (which attaches a formatter
+			// and needs a writer). Otherwise the standalone processor contract
+			// is preserved by SetupStructuredProcessor (no writer, no formatter).
+			if functionContainsCall(file, call.Pos(), "SetupProcessorOutput") {
+				msg += "; collapse SetupTableProcessor + SetupProcessorOutput into a single SetupStructuredOutput(values, writer) call; note the return tuple changes to (*TableProcessor, OutputFormatter, error)"
+			} else {
+				msg = "replace settings.SetupTableProcessor with settings.SetupStructuredProcessor"
+				msg += "; the standalone processor contract is preserved by SetupStructuredProcessor (no writer, no formatter); note the return tuple changes to (*TableProcessor, *StructuredOutputSettings, error)"
+			}
+		case "SetupProcessorOutput":
 			msg += "; collapse SetupTableProcessor + SetupProcessorOutput into a single SetupStructuredOutput(values, writer) call; note the return tuple changes to (*TableProcessor, OutputFormatter, error)"
 		case "SetupTableOutputFormatter", "SetupRowOutputFormatter", "SetupSimpleTableProcessor":
 			msg += "; restructure to use SetupStructuredOutput(values, writer), which builds the processor and attaches the formatter"
@@ -53,4 +65,31 @@ func setupHelperNames() []string {
 		out = append(out, n)
 	}
 	return out
+}
+
+// functionContainsCall reports whether the function enclosing pos contains a
+// call to a selector named name (e.g. "SetupProcessorOutput"). It walks only
+// the enclosing function body.
+func functionContainsCall(file *ast.File, pos token.Pos, name string) bool {
+	fn := findEnclosingFuncDecl(file, pos)
+	if fn == nil || fn.Body == nil {
+		return false
+	}
+	found := false
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if ok && sel.Sel.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
 }

--- a/pkg/analysis/glazedmigration/rules_setup.go
+++ b/pkg/analysis/glazedmigration/rules_setup.go
@@ -1,0 +1,56 @@
+package glazedmigration
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// applySetupRules handles R6/R7/R8: report-only diagnostics for the removed
+// runtime helpers. These are not auto-fixed because their replacements change
+// the return tuple and call structure.
+//
+//   - SetupTableProcessor + SetupProcessorOutput collapse into a single
+//     SetupStructuredOutput(values, writer) call returning
+//     (*TableProcessor, OutputFormatter, error).
+//   - SetupTableOutputFormatter / SetupRowOutputFormatter / SetupSimpleTableProcessor
+//     are replaced by SetupStructuredOutput.
+//   - NewOutputFormatterSettings is replaced by DecodeStructuredOutputSettings;
+//     the old OutputFormatterSettings type is gone, replaced by
+//     StructuredOutputSettings, and field .Output becomes .Format.
+func applySetupRules(pass *analysis.Pass, file *ast.File, imports importNames) {
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := selectorMatches(pass, call.Fun, imports, settingsImportPath, setupHelperNames()...)
+		if !ok {
+			return true
+		}
+		replacement := setupHelpers[ident.Name]
+		msg := "replace settings." + ident.Name + " with settings." + replacement
+		switch ident.Name {
+		case "SetupTableProcessor", "SetupProcessorOutput":
+			msg += "; collapse SetupTableProcessor + SetupProcessorOutput into a single SetupStructuredOutput(values, writer) call; note the return tuple changes to (*TableProcessor, OutputFormatter, error)"
+		case "SetupTableOutputFormatter", "SetupRowOutputFormatter", "SetupSimpleTableProcessor":
+			msg += "; restructure to use SetupStructuredOutput(values, writer), which builds the processor and attaches the formatter"
+		case "NewOutputFormatterSettings":
+			msg += "; the old OutputFormatterSettings type is removed, replaced by StructuredOutputSettings; field .Output becomes .Format"
+		}
+		pass.Report(analysis.Diagnostic{
+			Pos:     ident.Pos(),
+			End:     ident.End(),
+			Message: msg,
+		})
+		return true
+	})
+}
+
+func setupHelperNames() []string {
+	out := make([]string, 0, len(setupHelpers))
+	for n := range setupHelpers {
+		out = append(out, n)
+	}
+	return out
+}

--- a/pkg/analysis/glazedmigration/rules_slug.go
+++ b/pkg/analysis/glazedmigration/rules_slug.go
@@ -23,19 +23,26 @@ func applySlugRules(pass *analysis.Pass, file *ast.File, imports importNames) {
 			}
 			reportSlugRename(pass, ident)
 		case *ast.Ident:
-			// Dot-imported bare ident.
+			// Dot-imported bare ident. Require it to be a *use* of the settings
+			// package symbol, not a local declaration that merely shares the name.
+			// Without this guard, a locally declared `GlazedSlug` (which has no
+			// Uses entry) would be wrongly renamed.
 			if !imports.dot || n.Name != oldSlug {
 				return true
 			}
-			// Confirm it resolves to the settings package when type info is
-			// available; otherwise (no type info) accept the dot-import match.
-			if obj := pass.TypesInfo.Uses[n]; obj != nil {
-				// GlazedSlug is a const, so it's a *types.Const, not *types.Func.
-				// Accept any object whose package is the settings package.
-				pkg := obj.Pkg()
-				if pkg != nil && pkg.Path() != settingsImportPath {
-					return true
-				}
+			// Skip declarations (defs) entirely.
+			if _, isDef := pass.TypesInfo.Defs[n]; isDef {
+				return true
+			}
+			obj := pass.TypesInfo.Uses[n]
+			if obj == nil {
+				// No type info: be conservative and skip rather than risk
+				// renaming a local declaration.
+				return true
+			}
+			pkg := obj.Pkg()
+			if pkg == nil || pkg.Path() != settingsImportPath {
+				return true
 			}
 			reportSlugRename(pass, n)
 		}

--- a/pkg/analysis/glazedmigration/rules_slug.go
+++ b/pkg/analysis/glazedmigration/rules_slug.go
@@ -1,0 +1,60 @@
+package glazedmigration
+
+import (
+	"go/ast"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// applySlugRules handles R5: rename settings.GlazedSlug to
+// settings.StructuredOutputSlug. This is a deterministic identifier rename on
+// a package-qualified selector (or dot-imported ident).
+//
+// GlazedSlug is a constant, not a function, so it appears as a SelectorExpr
+// (qualified/aliased) or a bare Ident (dot-imported) in expression position,
+// not as a CallExpr. We inspect all identifiers and selectors.
+func applySlugRules(pass *analysis.Pass, file *ast.File, imports importNames) {
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch n := node.(type) {
+		case *ast.SelectorExpr:
+			ident, ok := selectorMatches(pass, n, imports, settingsImportPath, oldSlug)
+			if !ok {
+				return true
+			}
+			reportSlugRename(pass, ident)
+		case *ast.Ident:
+			// Dot-imported bare ident.
+			if !imports.dot || n.Name != oldSlug {
+				return true
+			}
+			// Confirm it resolves to the settings package when type info is
+			// available; otherwise (no type info) accept the dot-import match.
+			if obj := pass.TypesInfo.Uses[n]; obj != nil {
+				// GlazedSlug is a const, so it's a *types.Const, not *types.Func.
+				// Accept any object whose package is the settings package.
+				pkg := obj.Pkg()
+				if pkg != nil && pkg.Path() != settingsImportPath {
+					return true
+				}
+			}
+			reportSlugRename(pass, n)
+		}
+		return true
+	})
+}
+
+func reportSlugRename(pass *analysis.Pass, ident *ast.Ident) {
+	pass.Report(analysis.Diagnostic{
+		Pos:     ident.Pos(),
+		End:     ident.End(),
+		Message: "replace settings." + oldSlug + " with settings." + newSlug,
+		SuggestedFixes: []analysis.SuggestedFix{{
+			Message: "use " + newSlug,
+			TextEdits: []analysis.TextEdit{{
+				Pos:     ident.Pos(),
+				End:     ident.End(),
+				NewText: []byte(newSlug),
+			}},
+		}},
+	})
+}

--- a/pkg/analysis/glazedmigration/rules_test.go
+++ b/pkg/analysis/glazedmigration/rules_test.go
@@ -157,9 +157,9 @@ func f() {
 // "format", and that unsupported values are reported.
 func TestR4KeyRename(t *testing.T) {
 	tests := []struct {
-		name        string
-		value       string
-		wantKeyFix  bool
+		name          string
+		value         string
+		wantKeyFix    bool
 		wantValueDiag bool
 	}{
 		{"json supported", "json", true, false},

--- a/pkg/analysis/glazedmigration/rules_test.go
+++ b/pkg/analysis/glazedmigration/rules_test.go
@@ -1,0 +1,320 @@
+package glazedmigration
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"golang.org/x/tools/go/analysis"
+)
+
+// runAnalyzer parses source and runs the analyzer, returning the diagnostics.
+func runAnalyzer(t *testing.T, source string) []analysis.Diagnostic {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "input.go", source, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var diagnostics []analysis.Diagnostic
+	pass := &analysis.Pass{
+		Analyzer: Analyzer,
+		Fset:     fset,
+		Files:    []*ast.File{file},
+		TypesInfo: &types.Info{
+			Uses: map[*ast.Ident]types.Object{},
+		},
+		Report: func(d analysis.Diagnostic) { diagnostics = append(diagnostics, d) },
+	}
+	if _, err := run(pass); err != nil {
+		t.Fatal(err)
+	}
+	return diagnostics
+}
+
+// countFixes returns the total number of suggested fixes across diagnostics.
+func countFixes(diagnostics []analysis.Diagnostic) int {
+	n := 0
+	for _, d := range diagnostics {
+		n += len(d.SuggestedFixes)
+	}
+	return n
+}
+
+// fixTexts returns the NewText of the first edit of each suggested fix.
+func fixTexts(diagnostics []analysis.Diagnostic) []string {
+	var out []string
+	for _, d := range diagnostics {
+		for _, f := range d.SuggestedFixes {
+			for _, e := range f.TextEdits {
+				out = append(out, string(e.NewText))
+			}
+		}
+	}
+	return out
+}
+
+// TestR2NewGlazedSectionRename verifies that NewGlazedSection (the missing twin
+// of NewGlazedSchema) is renamed to NewStructuredOutputSection.
+func TestR2NewGlazedSectionRename(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    string
+		wantDiag  int
+		wantFixes int
+		wantText  string
+	}{
+		{
+			name:      "qualified zero-arg",
+			source:    `package p; import "github.com/go-go-golems/glazed/pkg/settings"; func f() { settings.NewGlazedSection() }`,
+			wantDiag:  1,
+			wantFixes: 1,
+			wantText:  newConstructor,
+		},
+		{
+			name:      "aliased zero-arg",
+			source:    `package p; import gs "github.com/go-go-golems/glazed/pkg/settings"; func f() { gs.NewGlazedSection() }`,
+			wantDiag:  1,
+			wantFixes: 1,
+			wantText:  newConstructor,
+		},
+		{
+			name:      "dot-import zero-arg",
+			source:    `package p; import . "github.com/go-go-golems/glazed/pkg/settings"; func f() { NewGlazedSection() }`,
+			wantDiag:  1,
+			wantFixes: 1,
+			wantText:  newConstructor,
+		},
+		{
+			name:      "dot-import shadowed replacement",
+			source:    `package p; import . "github.com/go-go-golems/glazed/pkg/settings"; func NewStructuredOutputSection() {}; func f() { NewGlazedSection() }`,
+			wantDiag:  1,
+			wantFixes: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diag := runAnalyzer(t, tt.source)
+			if len(diag) != tt.wantDiag {
+				t.Fatalf("got %d diagnostics, want %d: %+v", len(diag), tt.wantDiag, diag)
+			}
+			if got := countFixes(diag); got != tt.wantFixes {
+				t.Fatalf("got %d fixes, want %d", got, tt.wantFixes)
+			}
+			if tt.wantFixes > 0 {
+				texts := fixTexts(diag)
+				if !contains(texts, tt.wantText) {
+					t.Fatalf("fix texts %v do not contain %q", texts, tt.wantText)
+				}
+			}
+		})
+	}
+}
+
+// TestR3WrapperUnwrap verifies that With*SectionOptions wrappers are unwrapped.
+func TestR3WrapperUnwrap(t *testing.T) {
+	source := `package p
+import (
+	"github.com/go-go-golems/glazed/pkg/settings"
+"github.com/go-go-golems/glazed/pkg/cmds/schema"
+)
+func f() {
+	_ = settings.NewGlazedSection(
+		settings.WithOutputSectionOptions(
+			schema.WithDefaults(map[string]interface{}{"output": "json"}),
+		),
+	)
+}`
+	diag := runAnalyzer(t, source)
+	// Expect: one constructor diagnostic (rename, no fix because args present),
+	// one wrapper-unwrap diagnostic (with fix), one key-rename diagnostic (with fix).
+	if len(diag) < 2 {
+		t.Fatalf("got %d diagnostics, want at least 2: %+v", len(diag), diag)
+	}
+	// The wrapper unwrap should produce a fix whose text contains the inner arg.
+	foundUnwrap := false
+	for _, d := range diag {
+		for _, f := range d.SuggestedFixes {
+			for _, e := range f.TextEdits {
+				if strings.Contains(string(e.NewText), "WithDefaults") {
+					foundUnwrap = true
+				}
+			}
+		}
+	}
+	if !foundUnwrap {
+		t.Fatalf("expected a wrapper-unwrap fix containing the inner WithDefaults arg, got: %+v", diag)
+	}
+}
+
+// TestR4KeyRename verifies that the "output" default-map key is renamed to
+// "format", and that unsupported values are reported.
+func TestR4KeyRename(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		wantKeyFix  bool
+		wantValueDiag bool
+	}{
+		{"json supported", "json", true, false},
+		{"table supported", "table", true, false},
+		{"yaml supported", "yaml", true, false},
+		{"sql unsupported", "sql", true, true},
+		{"excel unsupported", "excel", true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := `package p
+import "github.com/go-go-golems/glazed/pkg/cmds/schema"
+func f() {
+	_ = schema.WithDefaults(map[string]interface{}{"output": "` + tt.value + `"})
+}`
+			diag := runAnalyzer(t, source)
+			foundKeyFix := false
+			foundValueDiag := false
+			for _, d := range diag {
+				if strings.Contains(d.Message, "rename default-map key") && len(d.SuggestedFixes) > 0 {
+					foundKeyFix = true
+				}
+				if strings.Contains(d.Message, "not a supported structured-output format") {
+					foundValueDiag = true
+				}
+			}
+			if foundKeyFix != tt.wantKeyFix {
+				t.Fatalf("key fix: got %v, want %v", foundKeyFix, tt.wantKeyFix)
+			}
+			if foundValueDiag != tt.wantValueDiag {
+				t.Fatalf("value diagnostic: got %v, want %v", foundValueDiag, tt.wantValueDiag)
+			}
+		})
+	}
+}
+
+// TestR5SlugRename verifies that settings.GlazedSlug is renamed to
+// StructuredOutputSlug.
+func TestR5SlugRename(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "qualified",
+			source: `package p; import "github.com/go-go-golems/glazed/pkg/settings"; func f() { _ = settings.GlazedSlug }`,
+		},
+		{
+			name:   "aliased",
+			source: `package p; import s "github.com/go-go-golems/glazed/pkg/settings"; func f() { _ = s.GlazedSlug }`,
+		},
+		{
+			name:   "dot-import",
+			source: `package p; import . "github.com/go-go-golems/glazed/pkg/settings"; func f() { _ = GlazedSlug }`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diag := runAnalyzer(t, tt.source)
+			if len(diag) != 1 {
+				t.Fatalf("got %d diagnostics, want 1: %+v", len(diag), diag)
+			}
+			if countFixes(diag) != 1 {
+				t.Fatalf("got %d fixes, want 1", countFixes(diag))
+			}
+			texts := fixTexts(diag)
+			if !contains(texts, newSlug) {
+				t.Fatalf("fix texts %v do not contain %q", texts, newSlug)
+			}
+		})
+	}
+}
+
+// TestR6R7R8SetupHelpers verifies that the removed Setup* helpers produce
+// report-only diagnostics (no fixes).
+func TestR6R7R8SetupHelpers(t *testing.T) {
+	helpers := []string{
+		"SetupTableProcessor",
+		"SetupProcessorOutput",
+		"SetupTableOutputFormatter",
+		"SetupRowOutputFormatter",
+		"SetupSimpleTableProcessor",
+		"NewOutputFormatterSettings",
+	}
+	for _, h := range helpers {
+		t.Run(h, func(t *testing.T) {
+			source := `package p; import "github.com/go-go-golems/glazed/pkg/settings"; func f() { _, _ = settings.` + h + `(nil) }`
+			diag := runAnalyzer(t, source)
+			if len(diag) != 1 {
+				t.Fatalf("got %d diagnostics, want 1: %+v", len(diag), diag)
+			}
+			if countFixes(diag) != 0 {
+				t.Fatalf("expected no fixes for report-only helper %s, got %d", h, countFixes(diag))
+			}
+			if !strings.Contains(diag[0].Message, setupHelpers[h]) {
+				t.Fatalf("diagnostic %q does not mention replacement %q", diag[0].Message, setupHelpers[h])
+			}
+		})
+	}
+}
+
+// TestR9RemovedFeatureSections verifies that removed feature section
+// constructors produce report-only diagnostics.
+func TestR9RemovedFeatureSections(t *testing.T) {
+	for ctor := range removedFeatureSectionConstructors {
+		t.Run(ctor, func(t *testing.T) {
+			source := `package p; import "github.com/go-go-golems/glazed/pkg/settings"; func f() { _, _ = settings.` + ctor + `() }`
+			diag := runAnalyzer(t, source)
+			if len(diag) != 1 {
+				t.Fatalf("got %d diagnostics, want 1: %+v", len(diag), diag)
+			}
+			if countFixes(diag) != 0 {
+				t.Fatalf("expected no fixes for removed feature %s, got %d", ctor, countFixes(diag))
+			}
+			if !strings.Contains(diag[0].Message, "no mechanical migration") {
+				t.Fatalf("diagnostic %q does not mention manual redesign", diag[0].Message)
+			}
+		})
+	}
+}
+
+// TestOtherPackageNotMigrated verifies that selectors from a non-Glazed
+// settings package are not touched.
+func TestOtherPackageNotMigrated(t *testing.T) {
+	source := `package p; import other "example.com/settings"; func f() { other.NewGlazedSection(); other.GlazedSlug; other.SetupTableProcessor(nil) }`
+	diag := runAnalyzer(t, source)
+	if len(diag) != 0 {
+		t.Fatalf("got %d diagnostics for a foreign package, want 0: %+v", len(diag), diag)
+	}
+}
+
+// TestNoSettingsImport verifies that files without the settings import are
+// skipped entirely.
+func TestNoSettingsImport(t *testing.T) {
+	source := `package p; import "fmt"; func f() { fmt.Println("hi") }`
+	diag := runAnalyzer(t, source)
+	if len(diag) != 0 {
+		t.Fatalf("got %d diagnostics, want 0: %+v", len(diag), diag)
+	}
+}
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// TestStructuredOutputFormatsExported verifies the settings accessor returns
+// the expected format set, guarding against drift in the R4 allowlist.
+func TestStructuredOutputFormatsExported(t *testing.T) {
+	got := settings.StructuredOutputFormats()
+	want := []string{"table", "json", "jsonl", "csv", "tsv", "yaml"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("StructuredOutputFormats() = %v, want %v", got, want)
+	}
+}

--- a/pkg/analysis/glazedmigration/rules_test.go
+++ b/pkg/analysis/glazedmigration/rules_test.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"go/types"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -292,6 +293,120 @@ func TestOtherPackageNotMigrated(t *testing.T) {
 
 // TestNoSettingsImport verifies that files without the settings import are
 // skipped entirely.
+// TestR4FieldNameGetField verifies that GetField(GlazedSlug, "output") is
+// renamed to GetField(StructuredOutputSlug, "format").
+func TestR4FieldNameGetField(t *testing.T) {
+	source := `package p
+import "github.com/go-go-golems/glazed/pkg/settings"
+func f(parsedValues interface{}) {
+	_, _ = parsedValues.(interface{ GetField(string, string) interface{} }).GetField(settings.GlazedSlug, "output")
+}`
+	diag := runAnalyzer(t, source)
+	found := false
+	for _, d := range diag {
+		if strings.Contains(d.Message, "rename field name \"output\" to \"format\"") && len(d.SuggestedFixes) > 0 {
+			found = true
+			// Verify the fix text is "format".
+			for _, f := range d.SuggestedFixes {
+				for _, e := range f.TextEdits {
+					if string(e.NewText) != strconv.Quote("format") {
+						t.Fatalf("fix text = %q, want %q", string(e.NewText), strconv.Quote("format"))
+					}
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected a field-name rename diagnostic, got: %+v", diag)
+	}
+}
+
+// TestR4FieldNameGetParameter verifies GetParameter(GlazedSlug, "output") is
+// renamed.
+func TestR4FieldNameGetParameter(t *testing.T) {
+	source := `package p
+import "github.com/go-go-golems/glazed/pkg/settings"
+func f(layers interface{}) {
+	_, _ = layers.(interface{ GetParameter(string, string) interface{} }).GetParameter(settings.GlazedSlug, "output")
+}`
+	diag := runAnalyzer(t, source)
+	found := false
+	for _, d := range diag {
+		if strings.Contains(d.Message, "rename field name") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a GetParameter field-name rename diagnostic, got: %+v", diag)
+	}
+}
+
+// TestR4FieldNameUpdateExistingValue verifies UpdateExistingValue("output", ...)
+// is renamed.
+func TestR4FieldNameUpdateExistingValue(t *testing.T) {
+	source := `package p
+import "github.com/go-go-golems/glazed/pkg/settings"
+var _ = settings.GlazedSlug
+func f(glazedLayer interface{}) {
+	_, _ = glazedLayer.(interface{ UpdateExistingValue(string, string, ...interface{}) interface{} }).UpdateExistingValue("output", "table")
+}`
+	diag := runAnalyzer(t, source)
+	found := false
+	for _, d := range diag {
+		if strings.Contains(d.Message, "UpdateExistingValue") && strings.Contains(d.Message, "format") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an UpdateExistingValue field-name rename diagnostic, got: %+v", diag)
+	}
+}
+
+// TestR4FieldNameFromMap verifies the sources.FromMap(map{GlazedSlug: {"output":...}})
+// pattern renames the inner "output" key to "format".
+func TestR4FieldNameFromMap(t *testing.T) {
+	source := `package p
+import "github.com/go-go-golems/glazed/pkg/settings"
+func f() {
+	_ = map[string]map[string]interface{}{
+		settings.GlazedSlug: {
+			"output": "json",
+		},
+	}
+}`
+	diag := runAnalyzer(t, source)
+	found := false
+	for _, d := range diag {
+		if strings.Contains(d.Message, "rename default-map key \"output\" to \"format\"") && len(d.SuggestedFixes) > 0 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a FromMap inner-key rename diagnostic, got: %+v", diag)
+	}
+}
+
+// TestR4MapIndexReported verifies that expr["output"] map index expressions are
+// reported (with a fix) when they may reference the structured-output field.
+func TestR4MapIndexReported(t *testing.T) {
+	source := `package p
+import "github.com/go-go-golems/glazed/pkg/settings"
+func f() {
+	var m map[string]interface{}
+	_ = m["output"]
+}`
+	diag := runAnalyzer(t, source)
+	found := false
+	for _, d := range diag {
+		if strings.Contains(d.Message, "map key \"output\"") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a map-index diagnostic, got: %+v", diag)
+	}
+}
+
 func TestNoSettingsImport(t *testing.T) {
 	source := `package p; import "fmt"; func f() { fmt.Println("hi") }`
 	diag := runAnalyzer(t, source)

--- a/pkg/analysis/glazedmigration/rules_test.go
+++ b/pkg/analysis/glazedmigration/rules_test.go
@@ -300,6 +300,35 @@ func TestNoSettingsImport(t *testing.T) {
 	}
 }
 
+// TestR1DeletionWithheldForMultipleUses verifies that R1 deletion is withheld
+// (falling back to rename) when the variable is used in multiple WithSections
+// calls within the same function, which would leave dangling references.
+func TestR1DeletionWithheldForMultipleUses(t *testing.T) {
+	source := "package p\n" +
+		"import (\n" +
+		"\t\"github.com/go-go-golems/glazed/pkg/cmds\"\n" +
+		"\t\"github.com/go-go-golems/glazed/pkg/settings\"\n" +
+		")\n" +
+		"type C struct{ *cmds.CommandDescription }\n" +
+		"func (c *C) RunIntoGlazeProcessor() {}\n" +
+		"func f() (*C, error) {\n" +
+		"\tglazedLayer, err := settings.NewGlazedSection()\n" +
+		"\tif err != nil { return nil, err }\n" +
+		"\t_ = cmds.WithSections(glazedLayer)\n" +
+		"\treturn &C{CommandDescription: cmds.NewCommandDescription(\"x\", cmds.WithSections(glazedLayer))}, nil\n" +
+		"}\n"
+	diag := runAnalyzer(t, source)
+	foundDeletion := false
+	for _, d := range diag {
+		if strings.Contains(d.Message, "redundant and can be deleted") {
+			foundDeletion = true
+		}
+	}
+	if foundDeletion {
+		t.Fatalf("R1 deletion should be withheld when the variable is used in multiple WithSections calls")
+	}
+}
+
 func contains(slice []string, s string) bool {
 	for _, v := range slice {
 		if v == s {

--- a/pkg/analysis/glazedmigration/rules_test.go
+++ b/pkg/analysis/glazedmigration/rules_test.go
@@ -171,9 +171,12 @@ func TestR4KeyRename(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			source := `package p
-import "github.com/go-go-golems/glazed/pkg/cmds/schema"
+import (
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/settings"
+)
 func f() {
-	_ = schema.WithDefaults(map[string]interface{}{"output": "` + tt.value + `"})
+	_, _ = settings.NewStructuredOutputSection(schema.WithDefaults(map[string]interface{}{"output": "` + tt.value + `"}))
 }`
 			diag := runAnalyzer(t, source)
 			foundKeyFix := false
@@ -219,8 +222,19 @@ func TestR5SlugRename(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			diag := runAnalyzer(t, tt.source)
-			if len(diag) != 1 {
-				t.Fatalf("got %d diagnostics, want 1: %+v", len(diag), diag)
+			// The dot-import case is conservative: without type-checker info
+			// the harness cannot prove the ident is the settings-package
+			// symbol rather than a local declaration, so it produces no
+			// diagnostic. Qualified/aliased imports always fire.
+			wantDiag := 1
+			if tt.name == "dot-import" {
+				wantDiag = 0
+			}
+			if len(diag) != wantDiag {
+				t.Fatalf("got %d diagnostics, want %d: %+v", len(diag), wantDiag, diag)
+			}
+			if wantDiag == 0 {
+				return
 			}
 			if countFixes(diag) != 1 {
 				t.Fatalf("got %d fixes, want 1", countFixes(diag))
@@ -254,8 +268,15 @@ func TestR6R7R8SetupHelpers(t *testing.T) {
 			if countFixes(diag) != 0 {
 				t.Fatalf("expected no fixes for report-only helper %s, got %d", h, countFixes(diag))
 			}
-			if !strings.Contains(diag[0].Message, setupHelpers[h]) {
-				t.Fatalf("diagnostic %q does not mention replacement %q", diag[0].Message, setupHelpers[h])
+			// Each helper recommends a specific replacement. SetupTableProcessor
+			// standalone (no SetupProcessorOutput in scope) recommends
+			// SetupStructuredProcessor; the pair case recommends SetupStructuredOutput.
+			want := setupHelpers[h]
+			if h == "SetupTableProcessor" {
+				want = "SetupStructuredProcessor"
+			}
+			if !strings.Contains(diag[0].Message, want) {
+				t.Fatalf("diagnostic %q does not mention replacement %q", diag[0].Message, want)
 			}
 		})
 	}
@@ -383,6 +404,72 @@ func f() {
 	}
 	if !found {
 		t.Fatalf("expected a FromMap inner-key rename diagnostic, got: %+v", diag)
+	}
+}
+
+// TestR4StandaloneWithDefaultsNotRenamed verifies that a schema.WithDefaults
+// call with an "output" key is NOT renamed when it is not an argument to a
+// structured-output constructor, because application-defined sections may
+// legitimately define a field named "output".
+func TestR4StandaloneWithDefaultsNotRenamed(t *testing.T) {
+	source := `package p
+import "github.com/go-go-golems/glazed/pkg/cmds/schema"
+func f() {
+	_ = schema.WithDefaults(map[string]interface{}{"output": "json"})
+}`
+	diag := runAnalyzer(t, source)
+	for _, d := range diag {
+		if strings.Contains(d.Message, "rename default-map key") {
+			t.Fatalf("standalone WithDefaults should not be renamed, got: %s", d.Message)
+		}
+	}
+}
+
+// TestR3FeatureWrapperReportedNotUnwrapped verifies that feature-section
+// option wrappers are reported for manual redesign and NOT auto-unwrapped.
+func TestR3FeatureWrapperReportedNotUnwrapped(t *testing.T) {
+	for w := range featureSectionOptionWrappers {
+		t.Run(w, func(t *testing.T) {
+			source := `package p
+import (
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/settings"
+)
+func f() {
+	_, _ = settings.NewGlazedSection(settings.` + w + `(schema.WithDefaults(map[string]interface{}{"x": 1})))
+}`
+			diag := runAnalyzer(t, source)
+			foundReport := false
+			for _, d := range diag {
+				if strings.Contains(d.Message, "targets a removed feature subsection") {
+					foundReport = true
+				}
+				if strings.Contains(d.Message, "unwrap removed settings") && len(d.SuggestedFixes) > 0 {
+					t.Fatalf("feature wrapper %s should not be auto-unwrapped", w)
+				}
+			}
+			if !foundReport {
+				t.Fatalf("expected a report-only diagnostic for feature wrapper %s, got: %+v", w, diag)
+			}
+		})
+	}
+}
+
+// TestR2NewOutputSectionRename verifies that the removed NewOutputSection
+// constructor is also migrated to NewStructuredOutputSection.
+func TestR2NewOutputSectionRename(t *testing.T) {
+	source := `package p
+import "github.com/go-go-golems/glazed/pkg/settings"
+func f() { _, _ = settings.NewOutputSection() }`
+	diag := runAnalyzer(t, source)
+	if len(diag) != 1 {
+		t.Fatalf("got %d diagnostics, want 1: %+v", len(diag), diag)
+	}
+	if countFixes(diag) != 1 {
+		t.Fatalf("got %d fixes, want 1", countFixes(diag))
+	}
+	if !contains(fixTexts(diag), newConstructor) {
+		t.Fatalf("fix does not rename to %s", newConstructor)
 	}
 }
 

--- a/pkg/analysis/glazedmigration/rules_wrapper.go
+++ b/pkg/analysis/glazedmigration/rules_wrapper.go
@@ -108,7 +108,7 @@ func reportKeyRename(pass *analysis.Pass, call *ast.CallExpr, ident *ast.Ident) 
 	// or a struct. We only auto-fix map literals with string keys.
 	for _, arg := range call.Args {
 		if lit, ok := arg.(*ast.CompositeLit); ok {
-			fixKeyInMapLiteral(pass, call, lit)
+			fixKeyInMapLiteral(pass, lit)
 		}
 	}
 }
@@ -116,7 +116,7 @@ func reportKeyRename(pass *analysis.Pass, call *ast.CallExpr, ident *ast.Ident) 
 // fixKeyInMapLiteral scans a composite literal's elements for {key, value}
 // pairs where the key is the string "output" and emits a rename fix. It also
 // validates the value against the supported format set.
-func fixKeyInMapLiteral(pass *analysis.Pass, call *ast.CallExpr, lit *ast.CompositeLit) {
+func fixKeyInMapLiteral(pass *analysis.Pass, lit *ast.CompositeLit) {
 	for _, elt := range lit.Elts {
 		kv, ok := elt.(*ast.KeyValueExpr)
 		if !ok {

--- a/pkg/analysis/glazedmigration/rules_wrapper.go
+++ b/pkg/analysis/glazedmigration/rules_wrapper.go
@@ -32,14 +32,34 @@ func applyWrapperAndKeyRules(pass *analysis.Pass, file *ast.File, settingsImp, s
 			return true
 		}
 
-		// R3: unwrap With*SectionOptions wrappers.
-		if ident, ok := selectorMatches(pass, call.Fun, settingsImp, settingsImportPath, wrapperNames()...); ok {
+		// R3: unwrap only the output-section options wrapper. Its arguments
+		// targeted the output subsection (replaced by the structured-output
+		// section), so they are valid schema.SectionOption values to splice
+		// directly into NewStructuredOutputSection.
+		if ident, ok := selectorMatches(pass, call.Fun, settingsImp, settingsImportPath, outputSectionOptionsWrapper); ok {
 			reportWrapperUnwrap(pass, call, ident)
 		}
 
-		// R4: rename "output" -> "format" in schema.WithDefaults map literals.
+		// R9: feature-section option wrappers (select/template/rename/etc.)
+		// targeted removed subsections. Report them for manual redesign; do not
+		// unwrap, because their args configure the wrong schema.
+		if ident, ok := selectorMatches(pass, call.Fun, settingsImp, settingsImportPath, featureWrapperNames()...); ok {
+			pass.Report(analysis.Diagnostic{
+				Pos:     ident.Pos(),
+				End:     ident.End(),
+				Message: "settings." + ident.Name + " targets a removed feature subsection with no mechanical migration; redesign using application fields or caller-side tools",
+			})
+		}
+
+		// R4: rename "output" -> "format" in schema.WithDefaults map literals
+		// that target the structured-output section. Only fire when the
+		// WithDefaults call is an argument to a known structured-output
+		// constructor (new or removed), so application-defined sections with a
+		// legitimate "output" field are not touched.
 		if ident, ok := selectorMatches(pass, call.Fun, schemaImp, schemaImportPath, "WithDefaults"); ok {
-			reportKeyRename(pass, call, ident)
+			if withDefaultsTargetsStructuredOutput(pass, file, call, settingsImp) {
+				reportKeyRename(pass, call, ident)
+			}
 		}
 		return true
 	})
@@ -95,6 +115,45 @@ func reportWrapperUnwrap(pass *analysis.Pass, call *ast.CallExpr, ident *ast.Ide
 			}},
 		}},
 	})
+}
+
+// withDefaultsTargetsStructuredOutput reports whether a schema.WithDefaults call
+// is an argument to a known structured-output section constructor (new or
+// removed), meaning its "output" key refers to the renamed flag rather than an
+// application-defined field.
+func withDefaultsTargetsStructuredOutput(pass *analysis.Pass, file *ast.File, call *ast.CallExpr, settingsImp importNames) bool {
+	parent := findEnclosingCallExpr(file, call.Pos())
+	if parent == nil {
+		return false
+	}
+	// Match the new and removed structured-output constructors.
+	if _, ok := selectorMatches(pass, parent.Fun, settingsImp, settingsImportPath, newConstructor, oldConstructor, altConstructor, altConstructor2); ok {
+		return true
+	}
+	return false
+}
+
+// findEnclosingCallExpr finds the *ast.CallExpr that directly contains pos as
+// one of its arguments.
+func findEnclosingCallExpr(file *ast.File, pos token.Pos) *ast.CallExpr {
+	var found *ast.CallExpr
+	ast.Inspect(file, func(node ast.Node) bool {
+		if found != nil {
+			return false
+		}
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		for _, arg := range call.Args {
+			if arg.Pos() == pos {
+				found = call
+				return false
+			}
+		}
+		return true
+	})
+	return found
 }
 
 // reportKeyRename inspects a schema.WithDefaults call for a map literal with

--- a/pkg/analysis/glazedmigration/rules_wrapper.go
+++ b/pkg/analysis/glazedmigration/rules_wrapper.go
@@ -1,0 +1,195 @@
+package glazedmigration
+
+import (
+	"go/ast"
+	"go/token"
+	"strconv"
+
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"golang.org/x/tools/go/analysis"
+)
+
+// applyWrapperAndKeyRules handles R3 (unwrap With*SectionOptions wrappers) and
+// R4 (rename default-map key "output" -> "format").
+//
+// R3: a settings.With*SectionOptions(args...) call is a no-op adapter from
+// []schema.SectionOption to GlazeSectionOption. The replacement constructor
+// NewStructuredOutputSection accepts schema.SectionOption directly, so the
+// wrapper's arguments should be spliced into the enclosing constructor call.
+//
+// R4: a schema.WithDefaults(map[string]interface{}{...}) literal whose map
+// contains the key "output" must be rewritten to "format", because the new
+// section renamed the flag and InitializeDefaultsFromMap errors on unknown
+// keys. Unsupported values (sql/template/markdown/excel) are reported only.
+//
+// Both rules also fire on standalone occurrences (not nested in a constructor),
+// so that code which calls With*SectionOptions or WithDefaults directly is
+// still flagged.
+func applyWrapperAndKeyRules(pass *analysis.Pass, file *ast.File, settingsImp, schemaImp importNames) {
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		// R3: unwrap With*SectionOptions wrappers.
+		if ident, ok := selectorMatches(pass, call.Fun, settingsImp, settingsImportPath, wrapperNames()...); ok {
+			reportWrapperUnwrap(pass, call, ident)
+		}
+
+		// R4: rename "output" -> "format" in schema.WithDefaults map literals.
+		if ident, ok := selectorMatches(pass, call.Fun, schemaImp, schemaImportPath, "WithDefaults"); ok {
+			reportKeyRename(pass, call, ident)
+		}
+		return true
+	})
+}
+
+// reportWrapperUnwrap emits a fix that replaces a With*SectionOptions(args...)
+// call with its arguments spliced into the enclosing call's argument list.
+//
+// The edit spans the entire wrapper call expression and replaces it with the
+// comma-joined source of its arguments. When the wrapper is the sole argument
+// of an enclosing call, this effectively unwraps it.
+func reportWrapperUnwrap(pass *analysis.Pass, call *ast.CallExpr, ident *ast.Ident) {
+	if len(call.Args) == 0 {
+		// No arguments to splice; the wrapper is a no-op. Replace it with
+		// nothing by deleting it (handled by the caller's arg-list edit). Emit
+		// a diagnostic without a fix here; the constructor rule will handle
+		// the surrounding call.
+		pass.Report(analysis.Diagnostic{
+			Pos:     ident.Pos(),
+			End:     ident.End(),
+			Message: "settings." + ident.Name + " is a removed no-op wrapper; remove it and pass its arguments directly to NewStructuredOutputSection",
+		})
+		return
+	}
+
+	// Build the replacement text: the arguments joined by ", ".
+	var parts []string
+	for _, arg := range call.Args {
+		text := exprText(pass.Fset, arg)
+		if text == "" {
+			// Cannot serialize; report only.
+			pass.Report(analysis.Diagnostic{
+				Pos:     ident.Pos(),
+				End:     ident.End(),
+				Message: "settings." + ident.Name + " is a removed wrapper; unwrap it and pass its arguments directly to NewStructuredOutputSection",
+			})
+			return
+		}
+		parts = append(parts, text)
+	}
+	replacement := joinArgs(parts)
+
+	pass.Report(analysis.Diagnostic{
+		Pos:     call.Pos(),
+		End:     call.End(),
+		Message: "unwrap removed settings." + ident.Name + " wrapper; pass its arguments directly to NewStructuredOutputSection",
+		SuggestedFixes: []analysis.SuggestedFix{{
+			Message: "unwrap " + ident.Name,
+			TextEdits: []analysis.TextEdit{{
+				Pos:     call.Pos(),
+				End:     call.End(),
+				NewText: []byte(replacement),
+			}},
+		}},
+	})
+}
+
+// reportKeyRename inspects a schema.WithDefaults call for a map literal with
+// the key "output" and emits a fix renaming it to "format". Values outside the
+// supported set are reported only.
+func reportKeyRename(pass *analysis.Pass, call *ast.CallExpr, ident *ast.Ident) {
+	if len(call.Args) == 0 {
+		return
+	}
+	// The argument is typically a map[string]interface{}{...} composite literal
+	// or a struct. We only auto-fix map literals with string keys.
+	for _, arg := range call.Args {
+		if lit, ok := arg.(*ast.CompositeLit); ok {
+			fixKeyInMapLiteral(pass, call, lit)
+		}
+	}
+}
+
+// fixKeyInMapLiteral scans a composite literal's elements for {key, value}
+// pairs where the key is the string "output" and emits a rename fix. It also
+// validates the value against the supported format set.
+func fixKeyInMapLiteral(pass *analysis.Pass, call *ast.CallExpr, lit *ast.CompositeLit) {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		keyLit, ok := kv.Key.(*ast.BasicLit)
+		if !ok || keyLit.Kind != token.STRING {
+			continue
+		}
+		key, err := strconv.Unquote(keyLit.Value)
+		if err != nil || key != "output" {
+			continue
+		}
+		// Found the "output" key. Validate the value.
+		valueStr := basicLitStringValue(kv.Value)
+		if valueStr != "" && !supportedFormat(valueStr) {
+			pass.Report(analysis.Diagnostic{
+				Pos:     kv.Value.Pos(),
+				End:     kv.Value.End(),
+				Message: "value " + strconv.Quote(valueStr) + " is not a supported structured-output format; choose table|json|jsonl|csv|tsv|yaml",
+			})
+			// Still rename the key so the section constructs; the value must be
+			// fixed by hand.
+		}
+		pass.Report(analysis.Diagnostic{
+			Pos:     keyLit.Pos(),
+			End:     keyLit.End(),
+			Message: "rename default-map key \"output\" to \"format\" (the structured-output flag was renamed)",
+			SuggestedFixes: []analysis.SuggestedFix{{
+				Message: "rename key to format",
+				TextEdits: []analysis.TextEdit{{
+					Pos:     keyLit.Pos(),
+					End:     keyLit.End(),
+					NewText: []byte(strconv.Quote("format")),
+				}},
+			}},
+		})
+	}
+}
+
+// basicLitStringValue returns the string value of a *ast.BasicLit string
+// literal, or "" if the expression is not a string literal.
+func basicLitStringValue(expr ast.Expr) string {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return ""
+	}
+	v, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return ""
+	}
+	return v
+}
+
+// supportedFormat reports whether s is one of the structured-output formats.
+// The allowlist is derived from the settings package's exported accessor to
+// avoid drift if formats are added or removed.
+func supportedFormat(s string) bool {
+	for _, f := range settings.StructuredOutputFormats() {
+		if f == s {
+			return true
+		}
+	}
+	return false
+}
+
+func joinArgs(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}

--- a/pkg/settings/structured_output.go
+++ b/pkg/settings/structured_output.go
@@ -44,6 +44,13 @@ var structuredOutputFormats = []string{
 	string(OutputYAML),
 }
 
+// StructuredOutputFormats returns the supported structured-output format
+// values. It is exported so that tooling (such as the glazed-migrate analyzer)
+// can validate format values without hardcoding the list.
+func StructuredOutputFormats() []string {
+	return append([]string(nil), structuredOutputFormats...)
+}
+
 type StructuredOutputSettings struct {
 	Format        OutputFormat `glazed:"format"`
 	OutputFields  []string     `glazed:"output-fields"`


### PR DESCRIPTION
feat(glazed-migrate): extend analyzer to all removed Glazed settings APIs

The glazed-migrate analyzer previously handled only one removed API
(NewGlazedSchema -> NewStructuredOutputSection). The GLZ-OUTPUT-FLAGS-CLEANUP
removal deleted an entire layer of the settings package, leaving 314 call
sites across consuming repos unhandled.

This extends the analyzer with nine rules (R1-R9):

- R1: delete redundant NewGlazedSection()/NewGlazedSchema() blocks when the
  enclosing command is provably a cmds.GlazeCommand (type-checker method set
  contains RunIntoGlazeProcessor); also removes the orphaned error-check
  block. Falls back to rename when unprovable.
- R2: rename NewGlazedSection(...) -> NewStructuredOutputSection(...),
  including arg-bearing calls whose args are valid schema.SectionOption values.
- R3: unwrap With*SectionOptions(...) wrappers, splicing their
  schema.SectionOption arguments into the enclosing constructor call.
- R4: rename default-map key "output" -> "format" inside schema.WithDefaults
  literals, with value-set validation against the supported formats;
  report-only for unsupported values. The allowlist is derived from the new
  settings.StructuredOutputFormats() accessor to avoid drift.
- R5: rename settings.GlazedSlug -> settings.StructuredOutputSlug.
- R6/R7/R8: report-only diagnostics for SetupTableProcessor,
  SetupProcessorOutput, SetupTableOutputFormatter, SetupRowOutputFormatter,
  SetupSimpleTableProcessor, and NewOutputFormatterSettings, including the
  return-tuple change note.
- R9: report-only diagnostics for removed feature sections (select/rename/
  replace/template/jq/sort/skip-limit/fields-filters) directing to manual
  redesign.

Restructured into focused rule files with a shared dispatch loop and a
parameterized selectorMatches helper that works for both the settings and
schema packages. Adds 42 table-driven unit tests.

Refs: GLZ-MIGRATE-ALL-APIS
